### PR TITLE
:whale: :bug: Add missing `libgcc` package in runner

### DIFF
--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -9,6 +9,9 @@ WORKDIR /workspace
 RUN task build
 
 FROM alpine:latest AS runner
+
+RUN apk add --no-cache libgcc
+
 COPY --from=builder /workspace/bin/ /usr/local/bin/
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const FLOWG_VERSION = "v0.1.3"
+const FLOWG_VERSION = "v0.1.4"


### PR DESCRIPTION
## Decision Record

The built binary requires the shared libraries `libgcc` and `libc`.

While `libc` is already present in the `alpine` Docker image, `libgcc` is not.

## Changes

 - [x] :whale: :heavy_plus_sign: Install `libgcc` in Docker image
 - [x] :bookmark: v0.1.4

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
