### PR TITLE
:lipstick: Add VRL syntax highlighting and autocompletion

### DIFF
--- a/web/components/code-editor/package-lock.json
+++ b/web/components/code-editor/package-lock.json
@@ -9,8 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@uiw/codemirror-theme-vscode": "^4.23.0",
-        "@uiw/react-codemirror": "^4.23.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -19,104 +17,6 @@
         "@types/react-dom": "^18.3.0",
         "esbuild": "^0.23.0",
         "typescript": "^5.5.4"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@codemirror/autocomplete": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.0.tgz",
-      "integrity": "sha512-5DbOvBbY4qW5l57cjDsmmpDh3/TeK1vXfTHa+BUMrRzdWdcxKZ4U4V7vQaTtOpApNU4kLS4FQ6cINtLg245LXA==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.17.0",
-        "@lezer/common": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/commands": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.6.0.tgz",
-      "integrity": "sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
-        "@codemirror/view": "^6.27.0",
-        "@lezer/common": "^1.1.0"
-      }
-    },
-    "node_modules/@codemirror/language": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
-      "integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.1.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/lint": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.1.tgz",
-      "integrity": "sha512-IZ0Y7S4/bpaunwggW2jYqwLuHj0QtESf5xcROewY6+lDNwZ/NzvR4t+vpYgg9m7V8UXLPYqG+lu3DF470E5Oxg==",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/@codemirror/search": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.6.tgz",
-      "integrity": "sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/@codemirror/state": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
-    },
-    "node_modules/@codemirror/theme-one-dark": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
-      "integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.32.0.tgz",
-      "integrity": "sha512-AgVNvED2QTsZp5e3syoHLsrWtwJFYWdx1Vr/m3f4h1ATQz0ax60CfXF3Htdmk69k2MlYZw8gXesnQdHtzyVmAw==",
-      "dependencies": {
-        "@codemirror/state": "^6.4.0",
-        "style-mod": "^4.1.0",
-        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -503,27 +403,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@lezer/common": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
-    },
-    "node_modules/@lezer/highlight": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
-      "dependencies": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/lr": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
-      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
-      "dependencies": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
@@ -572,105 +451,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.23.0.tgz",
-      "integrity": "sha512-+k5nkRpUWGaHr1JWT8jcKsVewlXw5qBgSopm9LW8fZ6KnSNZBycz8kHxh0+WSvckmXEESGptkIsb7dlkmJT/hQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": ">=6.0.0",
-        "@codemirror/commands": ">=6.0.0",
-        "@codemirror/language": ">=6.0.0",
-        "@codemirror/lint": ">=6.0.0",
-        "@codemirror/search": ">=6.0.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0"
-      }
-    },
-    "node_modules/@uiw/codemirror-theme-vscode": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.23.0.tgz",
-      "integrity": "sha512-zl1FD7U1b58tqlF216jYv2okvVkTe+FP1ztqO/DF129bcH99QjszkakshyfxQEvvF4ys3zyzqZ7vU3VYBir8tg==",
-      "dependencies": {
-        "@uiw/codemirror-themes": "4.23.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      }
-    },
-    "node_modules/@uiw/codemirror-themes": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.23.0.tgz",
-      "integrity": "sha512-9fiji9xooZyBQozR1i6iTr56YP7j/Dr/VgsNWbqf5Szv+g+4WM1iZuiDGwNXmFMWX8gbkDzp6ASE21VCPSofWw==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@codemirror/language": ">=6.0.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0"
-      }
-    },
-    "node_modules/@uiw/react-codemirror": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.0.tgz",
-      "integrity": "sha512-MnqTXfgeLA3fsUUQjqjJgemEuNyoGALgsExVm0NQAllAAi1wfj+IoKFeK+h3XXMlTFRCFYOUh4AHDv0YXJLsOg==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.23.0",
-        "codemirror": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@babel/runtime": ">=7.11.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/theme-one-dark": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0",
-        "codemirror": ">=6.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/codemirror": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
-      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -762,11 +542,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -780,11 +555,6 @@
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
-    "node_modules/style-mod": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
-    },
     "node_modules/typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
@@ -797,11 +567,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     }
   }
 }

--- a/web/components/code-editor/package-lock.json
+++ b/web/components/code-editor/package-lock.json
@@ -8,6 +8,7 @@
       "name": "code-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
         "@uiw/codemirror-theme-vscode": "^4.23.0",
         "@uiw/react-codemirror": "^4.23.0",
         "react": "^18.3.1",
@@ -523,6 +524,30 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -708,6 +733,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
+      "peer": true
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -743,6 +774,11 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/style-mod": {
       "version": "4.1.2",

--- a/web/components/code-editor/package.json
+++ b/web/components/code-editor/package.json
@@ -9,8 +9,6 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@uiw/codemirror-theme-vscode": "^4.23.0",
-    "@uiw/react-codemirror": "^4.23.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/web/components/code-editor/package.json
+++ b/web/components/code-editor/package.json
@@ -8,6 +8,7 @@
     "watch": "node build.js --watch"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@uiw/codemirror-theme-vscode": "^4.23.0",
     "@uiw/react-codemirror": "^4.23.0",
     "react": "^18.3.1",

--- a/web/components/code-editor/src/CodeEditor.tsx
+++ b/web/components/code-editor/src/CodeEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import Editor, { useMonaco } from '@monaco-editor/react'
+import { vrlLanguageDefinition, vrlThemeDefinition } from './vrl-highlighter'
 
 interface CodeEditorProps {
   code: string
@@ -20,7 +21,11 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ code, onCodeChange }) => {
 
   useEffect(
     () => {
-      // todo...
+      if (!monaco) return
+
+      monaco.languages.register({id: 'vrl'})
+      monaco.editor.defineTheme('vrl-theme', vrlThemeDefinition)
+      monaco.languages.setMonarchTokensProvider('vrl', vrlLanguageDefinition)
     },
     [monaco],
   )
@@ -37,6 +42,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ code, onCodeChange }) => {
     <div className="w-full h-full">
       <Editor
         defaultValue={value}
+        defaultLanguage='vrl'
+        theme='vrl-theme'
         width='100%'
         height='100%'
         onChange={onChange}

--- a/web/components/code-editor/src/CodeEditor.tsx
+++ b/web/components/code-editor/src/CodeEditor.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
-import CodeMirror, { ViewUpdate } from '@uiw/react-codemirror'
-import { vscodeLight } from '@uiw/codemirror-theme-vscode'
+import Editor, { useMonaco } from '@monaco-editor/react'
 
 interface CodeEditorProps {
   code: string
@@ -10,6 +9,7 @@ interface CodeEditorProps {
 
 const CodeEditor: React.FC<CodeEditorProps> = ({ code, onCodeChange }) => {
   const [value, setValue] = useState(code)
+  const monaco = useMonaco()
 
   useEffect(
     () => {
@@ -18,23 +18,29 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ code, onCodeChange }) => {
     [code],
   )
 
+  useEffect(
+    () => {
+      // todo...
+    },
+    [monaco],
+  )
+
   const onChange = useCallback(
-    (val: string, viewUpdate: ViewUpdate) => {
-      setValue(val)
-      onCodeChange(val)
+    (val?: string) => {
+      setValue(val ?? '')
+      onCodeChange(val ?? '')
     },
     [onCodeChange],
   )
 
   return (
     <div className="w-full h-full">
-      <CodeMirror
-        value={value}
+      <Editor
+        defaultValue={value}
         width='100%'
         height='100%'
-        theme={vscodeLight}
         onChange={onChange}
-        style={{ height: '100%', overflow: 'auto' }}
+        options={{minimap: {enabled: false}}}
       />
     </div>
   )

--- a/web/components/code-editor/src/vrl-highlighter.ts
+++ b/web/components/code-editor/src/vrl-highlighter.ts
@@ -1,0 +1,638 @@
+// https://github.com/vectordotdev/vector/blob/master/lib/vector-vrl/web-playground/public/vrl-highlighter.js
+
+// VRL Language Definition
+export let vrlLanguageDefinition = {
+  defaultToken: "invalid",
+  ignoreCase: true,
+  tokenPostfix: ".vrl",
+
+  brackets: [
+      { open: "{", close: "}", token: "delimiter.curly" },
+      { open: "[", close: "]", token: "delimiter.square" },
+      { open: "(", close: ")", token: "delimiter.parenthesis" },
+  ],
+
+  regEx: /\/(?!\/\/)(?:[^\/\\]|\\.)*\/[igm]*/,
+
+  keywords: [
+      "abort",
+      "as",
+      "break",
+      "continue",
+      "else",
+      "false",
+      "for",
+      "if",
+      "impl",
+      "in",
+      "let",
+      "loop",
+      "null",
+      "return",
+      "self",
+      "std",
+      "then",
+      "this",
+      "true",
+      "type",
+      "until",
+      "use",
+      "while",
+  ],
+
+  // we include these common regular expressions
+  symbols: /[=><!~?&%|+\-*\/\^\.,\:]+/,
+  escapes: /\\(?:[abfnrtv\\"'$]|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+  // The main tokenizer for our languages
+  tokenizer: {
+      root: [
+          // function invokes fallible
+          [
+              /([a-zA-Z_!]+)(\!)(\()/,
+              {
+                  cases: {
+                      $3: ['keyword', 'keyword', '']
+                  }
+                  //   log: 'in function invoke::found::\n\n$0'
+              },
+          ],
+          // function invokes
+          [
+              /([a-zA-Z_!]+)(\()/,
+              {
+                  cases: {
+                      $2: ['keyword', '']
+                  }
+                  //   log: 'in function invoke::found::\n\n$0'
+              },
+          ],
+
+          // rstrings
+          [/r'[^']+'/, { token: "regexp" /*log: 'root_r_string::\n\n$0'*/ }],
+
+          // timestamps
+          [/t'[^']+'/, { token: "regexp" /*log: 'function_arg_r_string::\n\n$0'*/ }],
+
+          // field access, eg: .foo
+          [/(\.[^\ \=]+)([\ |\=])/, {
+              cases: {
+                  $2: ["entity", ""]
+              }
+          }],
+
+          // sstrings
+          [/s'[^']+'/, { token: "string" /*log: 'root_s_string::\n\n$0'*/ }],
+
+          // identifiers and keywords
+          [/\@[a-zA-Z_]\w*/, "variable.predefined"],
+
+          [
+              /[a-zA-Z_]\w*/,
+              {
+                  cases: {
+                  this: "variable.predefined",
+                  "@keywords": { token: "keyword.$0" },
+
+                  "@default": "",
+                  },
+              },
+          ],
+
+          // whitespace
+          [/[ \t\r\n]+/, ""],
+
+          // Comments
+          [/###/, "comment", "@comment"],
+          [/#.*$/, "comment"],
+
+          // Function invokes
+
+          // regular expressions
+          ["///", { token: "regexp", next: "@hereregexp" }],
+
+          [/^(\s*)(@regEx)/, ["", "regexp"]],
+          [/(\()(\s*)(@regEx)/, ["@brackets", "", "regexp"]],
+          [/(\,)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\=)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\:)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\[)(\s*)(@regEx)/, ["@brackets", "", "regexp"]],
+          [/(\!)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\&)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\|)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\?)(\s*)(@regEx)/, ["delimiter", "", "regexp"]],
+          [/(\{)(\s*)(@regEx)/, ["@brackets", "", "regexp"]],
+          [/(\;)(\s*)(@regEx)/, ["", "", "regexp"]],
+
+          // delimiters
+          [
+              /}/,
+              {
+                  cases: {
+                  "$S2==interpolatedstring": {
+                      token: "string",
+                      next: "@pop",
+                  },
+                  "@default": "@brackets",
+                  },
+              },
+          ],
+          [/[{}()\[\]]/, "@brackets"],
+          [/@symbols/, "delimiter"],
+
+          // numbers
+          [/\d+[eE]([\-+]?\d+)?/, "number.float"],
+          [/\d+\.\d+([eE][\-+]?\d+)?/, "number.float"],
+          [/0[xX][0-9a-fA-F]+/, "number.hex"],
+          [/0[0-7]+(?!\d)/, "number.octal"],
+          [/\d+/, "number"],
+
+          // delimiter: after number because of .\d floats
+          [/[,.]/, "delimiter"],
+
+          // strings:
+          [/"""/, "string", '@herestring."""'],
+          [/'''/, "string", "@herestring.'''"],
+          [
+              /"/,
+              {
+                  cases: {
+                  "@eos": "string",
+                  "@default": { token: "string", next: '@string."' },
+                  },
+              },
+          ],
+          [
+              /'/,
+              {
+                  cases: {
+                  "@eos": "string",
+                  "@default": { token: "string", next: "@string.'" },
+                  },
+              },
+          ],
+      ],
+
+      string: [
+          [/[^"'\#\\]+/, "string"],
+          [/@escapes/, "string.escape"],
+          [/\./, "string.escape.invalid"],
+          [/\./, "string.escape.invalid"],
+
+          [
+              /#{/,
+              {
+                  cases: {
+                  '$S2=="': {
+                      token: "string",
+                      next: "root.interpolatedstring",
+                  },
+                  "@default": "string",
+                  },
+              },
+          ],
+
+          [
+              /["']/,
+              {
+                  cases: {
+                  "$#==$S2": { token: "string", next: "@pop" },
+                  "@default": "string",
+                  },
+              },
+          ],
+          [/#/, "string"],
+      ],
+
+      herestring: [
+          [
+              /("""|''')/,
+              {
+                  cases: {
+                  "$1==$S2": { token: "string", next: "@pop" },
+                  "@default": "string",
+                  },
+              },
+          ],
+          [/[^#\\'"]+/, "string"],
+          [/['"]+/, "string"],
+          [/@escapes/, "string.escape"],
+          [/\./, "string.escape.invalid"],
+
+          [/#{/, { token: "string.quote", next: "root.interpolatedstring" }],
+          [/#/, "string"],
+      ],
+
+      comment: [
+          [/[^#]+/, "comment"],
+          [/###/, "comment", "@pop"],
+          [/#/, "comment"],
+      ],
+
+      hereregexp: [
+          [/[^\\\/#]+/, "regexp"],
+          [/\\./, "regexp"],
+          [/#.*$/, "comment"],
+          ["///[igm]*", { token: "regexp", next: "@pop" }],
+          [/\//, "regexp"],
+      ],
+
+      function_arg: [
+          [
+              /([a-zA-Z_!]+)\(/,
+              { cases: { $S1: { token: "keyword", next: "@push", log: "function_arg_nested::\n\n$0" } } },
+          ],
+          // we copy the string highlighters from root and apply them to function arguments as well
+          [/"""/, "string", '@herestring."""'],
+          [/'''/, "string", "@herestring.'''"],
+          [
+              /"/,
+              {
+                  cases: {
+                  "@eos": "string",
+                  "@default": { token: "string", next: '@string."' },
+                  },
+              },
+          ],
+          [
+              /'/,
+              {
+                  cases: {
+                  "@eos": "string",
+                  "@default": { token: "string", next: "@string.'" },
+                  },
+              },
+          ],
+          // TODO: field access inside function parameters sometimes fails, eg: in a
+          // newline func(.foo)
+          // [/(\.)/, { token: "entity" }],
+          // r strings
+          [/r'[^']+'/, { token: "regexp" /*log: 'function_arg_r_string::\n\n$0'*/ }],
+          [/t'[^']+'/, { token: "regexp" /*log: 'function_arg_r_string::\n\n$0'*/ }],
+          // s strings
+          [/s'[^']+'/, { token: "string" /*log: 'root_s_string::\n\n$0'*/ }],
+          [/\)/, { token: "", /*log: 'end_off_function_arg::\n\n$0',*/ next: "@pop" }],
+          [
+          /[\.\[\]\,\\\"\%\{\}\$\:\^\w]+/,
+          { token: "" /*log: 'function_arg_anything_else::\n\n$0'*/ },
+          ],
+      ],
+  },
+};
+
+export let vrlThemeDefinition = {
+  "base": "vs",
+  "inherit": true,
+  "rules": [
+    {
+      "background": "ffffff",
+      "token": ""
+    },
+    {
+      "foreground": "d73a49",
+      "token": "vrl-function-invokes"
+    },
+    {
+      "foreground": "d73a49",
+      "token": "vrl-function-invokes-fallible"
+    },
+    {
+      "foreground": "6a737d",
+      "token": "comment"
+    },
+    {
+      "foreground": "6a737d",
+      "token": "punctuation.definition.comment"
+    },
+    {
+      "foreground": "6a737d",
+      "token": "string.comment"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "constant"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "entity.name.constant"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "variable.other.constant"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "variable.language"
+    },
+    {
+      "foreground": "6f42c1",
+      "token": "entity"
+    },
+    {
+      "foreground": "6f42c1",
+      "token": "entity.name"
+    },
+    {
+      "foreground": "24292e",
+      "token": "variable.parameter.function"
+    },
+    {
+      "foreground": "22863a",
+      "token": "entity.name.tag"
+    },
+    {
+      "foreground": "d73a49",
+      "token": "keyword"
+    },
+    {
+      "foreground": "d73a49",
+      "token": "storage"
+    },
+    {
+      "foreground": "d73a49",
+      "token": "storage.type"
+    },
+    {
+      "foreground": "24292e",
+      "token": "storage.modifier.package"
+    },
+    {
+      "foreground": "24292e",
+      "token": "storage.modifier.import"
+    },
+    {
+      "foreground": "24292e",
+      "token": "storage.type.java"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string"
+    },
+    {
+      "foreground": "032f62",
+      "token": "punctuation.definition.string"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string punctuation.section.embedded source"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "support"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "meta.property-name"
+    },
+    {
+      "foreground": "e36209",
+      "token": "variable"
+    },
+    {
+      "foreground": "24292e",
+      "token": "variable.other"
+    },
+    {
+      "foreground": "b31d28",
+      "fontStyle": "bold italic underline",
+      "token": "invalid.broken"
+    },
+    {
+      "foreground": "b31d28",
+      "fontStyle": "bold italic underline",
+      "token": "invalid.deprecated"
+    },
+    {
+      "foreground": "fafbfc",
+      "background": "b31d28",
+      "fontStyle": "italic underline",
+      "token": "invalid.illegal"
+    },
+    {
+      "foreground": "fafbfc",
+      "background": "d73a49",
+      "fontStyle": "italic underline",
+      "token": "carriage-return"
+    },
+    {
+      "foreground": "b31d28",
+      "fontStyle": "bold italic underline",
+      "token": "invalid.unimplemented"
+    },
+    {
+      "foreground": "b31d28",
+      "token": "message.error"
+    },
+    {
+      "foreground": "24292e",
+      "token": "string source"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "string variable"
+    },
+    {
+      "foreground": "032f62",
+      "token": "source.regexp"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string.regexp"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string.regexp.character-class"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string.regexp constant.character.escape"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string.regexp source.ruby.embedded"
+    },
+    {
+      "foreground": "032f62",
+      "token": "string.regexp string.regexp.arbitrary-repitition"
+    },
+    {
+      "foreground": "22863a",
+      "fontStyle": "bold",
+      "token": "string.regexp constant.character.escape"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "support.constant"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "support.variable"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "meta.module-reference"
+    },
+    {
+      "foreground": "735c0f",
+      "token": "markup.list"
+    },
+    {
+      "foreground": "005cc5",
+      "fontStyle": "bold",
+      "token": "markup.heading"
+    },
+    {
+      "foreground": "005cc5",
+      "fontStyle": "bold",
+      "token": "markup.heading entity.name"
+    },
+    {
+      "foreground": "22863a",
+      "token": "markup.quote"
+    },
+    {
+      "foreground": "24292e",
+      "fontStyle": "italic",
+      "token": "markup.italic"
+    },
+    {
+      "foreground": "24292e",
+      "fontStyle": "bold",
+      "token": "markup.bold"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "markup.raw"
+    },
+    {
+      "foreground": "b31d28",
+      "background": "ffeef0",
+      "token": "markup.deleted"
+    },
+    {
+      "foreground": "b31d28",
+      "background": "ffeef0",
+      "token": "meta.diff.header.from-file"
+    },
+    {
+      "foreground": "b31d28",
+      "background": "ffeef0",
+      "token": "punctuation.definition.deleted"
+    },
+    {
+      "foreground": "22863a",
+      "background": "f0fff4",
+      "token": "markup.inserted"
+    },
+    {
+      "foreground": "22863a",
+      "background": "f0fff4",
+      "token": "meta.diff.header.to-file"
+    },
+    {
+      "foreground": "22863a",
+      "background": "f0fff4",
+      "token": "punctuation.definition.inserted"
+    },
+    {
+      "foreground": "e36209",
+      "background": "ffebda",
+      "token": "markup.changed"
+    },
+    {
+      "foreground": "e36209",
+      "background": "ffebda",
+      "token": "punctuation.definition.changed"
+    },
+    {
+      "foreground": "f6f8fa",
+      "background": "005cc5",
+      "token": "markup.ignored"
+    },
+    {
+      "foreground": "f6f8fa",
+      "background": "005cc5",
+      "token": "markup.untracked"
+    },
+    {
+      "foreground": "6f42c1",
+      "fontStyle": "bold",
+      "token": "meta.diff.range"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "meta.diff.header"
+    },
+    {
+      "foreground": "005cc5",
+      "fontStyle": "bold",
+      "token": "meta.separator"
+    },
+    {
+      "foreground": "005cc5",
+      "token": "meta.output"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.tag"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.curly"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.round"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.square"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.angle"
+    },
+    {
+      "foreground": "586069",
+      "token": "brackethighlighter.quote"
+    },
+    {
+      "foreground": "b31d28",
+      "token": "brackethighlighter.unmatched"
+    },
+    {
+      "foreground": "b31d28",
+      "token": "sublimelinter.mark.error"
+    },
+    {
+      "foreground": "e36209",
+      "token": "sublimelinter.mark.warning"
+    },
+    {
+      "foreground": "959da5",
+      "token": "sublimelinter.gutter-mark"
+    },
+    {
+      "foreground": "032f62",
+      "fontStyle": "underline",
+      "token": "constant.other.reference.link"
+    },
+    {
+      "foreground": "032f62",
+      "fontStyle": "underline",
+      "token": "string.other.link"
+    }
+  ],
+  "colors": {
+    "editor.foreground": "#24292e",
+    "editor.background": "#ffffff",
+    "editor.selectionBackground": "#c8c8fa",
+    "editor.inactiveSelectionBackground": "#fafbfc",
+    "editor.lineHighlightBackground": "#fafbfc",
+    "editorCursor.foreground": "#24292e",
+    "editorWhitespace.foreground": "#959da5",
+    "editorIndentGuide.background": "#959da5",
+    "editorIndentGuide.activeBackground": "#24292e",
+    "editor.selectionHighlightBorder": "#fafbfc"
+  }
+};


### PR DESCRIPTION
## Decision Record

Syntax highlighting and autocompletion are always nice when editing code. The VRL Web Playground uses Monaco-Editor and provides a custom highlighter for it, so we will use it instead of CodeMirror.

**NB:** Monaco Editor is the technology behind VS Code.

## Changes

 - [x] :heavy_minus_sign: Remove CodeMirror
 - [x] :heavy_plus_sign: Add Monaco Editor
 - [x] :lipstick: Add syntax highlighting and autocompletetion for VRL

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
