### PR TITLE
:sparkles: Add `watch_logs` API operation

### DIFF
--- a/api/watch_logs.go
+++ b/api/watch_logs.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+
+	"encoding/json"
+	"fmt"
+
+	"net/http"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/internal/data/auth"
+	"link-society.com/flowg/internal/data/lognotify"
+)
+
+type WatchLogsRequest struct {
+	Stream string `path:"stream" minLength:"1"`
+}
+
+type WatchLogsResponse struct {
+	usecase.OutputWithEmbeddedWriter
+}
+
+func WatchLogsUsecase(
+	authDb *auth.Database,
+	logNotifier *lognotify.LogNotifier,
+) usecase.Interactor {
+	u := usecase.NewInteractor(
+		auth.RequireScopeApiDecorator(
+			authDb,
+			auth.SCOPE_READ_STREAMS,
+			func(
+				ctx context.Context,
+				req WatchLogsRequest,
+				resp *WatchLogsResponse,
+			) error {
+				resp.Writer.(http.ResponseWriter).Header().Set("Access-Control-Allow-Origin", "*")
+				resp.Writer.(http.ResponseWriter).Header().Set("Access-Control-Expose-Headers", "Content-Type")
+
+				resp.Writer.(http.ResponseWriter).Header().Set("Content-Type", "text/event-stream")
+				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
+				resp.Writer.(http.ResponseWriter).Header().Set("Connection", "keep-alive")
+
+				slog.InfoContext(
+					ctx,
+					"watch logs",
+					"channel", "api",
+					"stream", req.Stream,
+				)
+				defer slog.InfoContext(
+					ctx,
+					"done watching logs",
+					"channel", "api",
+					"stream", req.Stream,
+				)
+
+				logC := logNotifier.Subscribe(req.Stream, ctx.Done())
+
+				for log := range logC {
+					payload, err := json.Marshal(log.LogEntry)
+					if err != nil {
+						fmt.Fprintf(resp, "event: error\n")
+						fmt.Fprintf(resp, "data: %s\n\n", err.Error())
+						resp.Writer.(http.Flusher).Flush()
+
+						return nil
+					}
+
+					fmt.Fprintf(resp, "id: %s\n", log.LogKey)
+					fmt.Fprintf(resp, "event: log\n")
+					fmt.Fprintf(resp, "data: %s\n\n", payload)
+					resp.Writer.(http.Flusher).Flush()
+				}
+
+				return nil
+			},
+		),
+	)
+
+	u.SetName("watch_logs")
+	u.SetTitle("Watch Logs")
+	u.SetDescription("Server-Sent Events endpoint to watch logs in real time.")
+	u.SetTags("streams")
+
+	u.SetExpectedErrors(status.PermissionDenied, status.Internal)
+
+	return u
+}

--- a/internal/app/logging/middleware.go
+++ b/internal/app/logging/middleware.go
@@ -39,3 +39,9 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 	w.ResponseWriter.WriteHeader(statusCode)
 }
+
+func (w *responseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/data/lognotify/main.go
+++ b/internal/data/lognotify/main.go
@@ -1,0 +1,61 @@
+package lognotify
+
+import (
+	"context"
+
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/data/logstorage"
+)
+
+type LogNotifier struct {
+	subMbox actor.MailboxSender[SubscribeMessage]
+	logMbox actor.MailboxSender[LogMessage]
+	rootA   actor.Actor
+}
+
+func NewLogNotifier() *LogNotifier {
+	subMbox := actor.NewMailbox[SubscribeMessage]()
+	logMbox := actor.NewMailbox[LogMessage]()
+	workerA := actor.New(&worker{
+		subscribers: make(map[string]map[chan<- LogMessage]struct{}),
+		subMbox:     subMbox,
+		logMbox:     logMbox,
+	})
+
+	return &LogNotifier{
+		subMbox: subMbox,
+		logMbox: logMbox,
+		rootA:   actor.Combine(subMbox, logMbox, workerA).Build(),
+	}
+}
+
+func (n *LogNotifier) Start() {
+	n.rootA.Start()
+}
+
+func (n *LogNotifier) Stop() {
+	n.rootA.Stop()
+}
+
+func (n *LogNotifier) Subscribe(stream string, doneC <-chan struct{}) <-chan LogMessage {
+	logC := make(chan LogMessage)
+	msg := SubscribeMessage{
+		Stream:  stream,
+		SenderC: logC,
+		DoneC:   doneC,
+	}
+
+	n.subMbox.Send(context.Background(), msg)
+
+	return logC
+}
+
+func (n *LogNotifier) Notify(stream string, logKey string, logEntry logstorage.LogEntry) {
+	msg := LogMessage{
+		Stream:   stream,
+		LogKey:   logKey,
+		LogEntry: logEntry,
+	}
+	n.logMbox.Send(context.Background(), msg)
+}

--- a/internal/data/lognotify/types.go
+++ b/internal/data/lognotify/types.go
@@ -1,0 +1,15 @@
+package lognotify
+
+import "link-society.com/flowg/internal/data/logstorage"
+
+type LogMessage struct {
+	Stream   string
+	LogKey   string
+	LogEntry logstorage.LogEntry
+}
+
+type SubscribeMessage struct {
+	Stream  string
+	SenderC chan<- LogMessage
+	DoneC   <-chan struct{}
+}

--- a/internal/data/lognotify/worker.go
+++ b/internal/data/lognotify/worker.go
@@ -1,0 +1,50 @@
+package lognotify
+
+import "github.com/vladopajic/go-actor/actor"
+
+type worker struct {
+	subscribers map[string]map[chan<- LogMessage]struct{}
+	subMbox     actor.MailboxReceiver[SubscribeMessage]
+	logMbox     actor.MailboxReceiver[LogMessage]
+}
+
+func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
+	select {
+	case <-ctx.Done():
+		return actor.WorkerEnd
+
+	case msg, ok := <-w.subMbox.ReceiveC():
+		if !ok {
+			return actor.WorkerEnd
+		}
+
+		if _, exists := w.subscribers[msg.Stream]; !exists {
+			w.subscribers[msg.Stream] = make(map[chan<- LogMessage]struct{})
+		}
+
+		w.subscribers[msg.Stream][msg.SenderC] = struct{}{}
+
+		go func() {
+			<-msg.DoneC
+			delete(w.subscribers[msg.Stream], msg.SenderC)
+			close(msg.SenderC)
+		}()
+
+		return actor.WorkerContinue
+
+	case msg, ok := <-w.logMbox.ReceiveC():
+		if !ok {
+			return actor.WorkerEnd
+		}
+
+		if _, exists := w.subscribers[msg.Stream]; !exists {
+			w.subscribers[msg.Stream] = make(map[chan<- LogMessage]struct{})
+		}
+
+		for sub := range w.subscribers[msg.Stream] {
+			sub <- msg
+		}
+
+		return actor.WorkerContinue
+	}
+}

--- a/internal/data/pipelines/main.go
+++ b/internal/data/pipelines/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"link-society.com/flowg/internal/data/lognotify"
 	"link-society.com/flowg/internal/data/logstorage"
 )
 
@@ -13,10 +14,12 @@ type Manager struct {
 	pipelinesDir    string
 
 	collectorSys *logstorage.CollectorSystem
+	notifier     *lognotify.LogNotifier
 }
 
 func NewManager(
 	collectorSys *logstorage.CollectorSystem,
+	notifier *lognotify.LogNotifier,
 	configDir string,
 ) *Manager {
 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
@@ -37,6 +40,7 @@ func NewManager(
 		transformersDir: transformersDir,
 		pipelinesDir:    pipelinesDir,
 		collectorSys:    collectorSys,
+		notifier:        notifier,
 	}
 }
 

--- a/internal/data/pipelines/types.go
+++ b/internal/data/pipelines/types.go
@@ -88,6 +88,10 @@ func (n *RouterNode) Process(
 	manager *Manager,
 	entry *logstorage.LogEntry,
 ) error {
-	_, err := manager.collectorSys.Ingest(ctx, n.Stream, entry)
+	key, err := manager.collectorSys.Ingest(ctx, n.Stream, entry)
+	if err == nil {
+		manager.notifier.Notify(n.Stream, string(key), *entry)
+	}
+
 	return err
 }


### PR DESCRIPTION
## Decision Record

In order to improve inter-operability, we add a new `watch_logs` API operation which implements **Sever-Sent Events**, as a streaming response with `text/event-stream` content type.

Users are able to watch logs of a specific stream in real time:

```
$ curl -H "Authorization: Bearer <token>" http://localhost:5080/api/v1/streams/{stream}/logs/watch
id: <log key>
event: log
data: {"timestamp": "...", "fields": {...}}

...
```

## Changes

 - [x] :sparkles: Add `LogNotifier` background task
 - [x] :sparkles: Make pipelines send a message to the `LogNotifier` when ingesting a log into a stream
 - [x] :sparkles: Add `watch_logs` API operation which subscribes to a stream via the `LogNotifier`

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
