### PR TITLE
:sparkles: Add Pipeline nodes

### DIFF
--- a/internal/app/version.go
+++ b/internal/app/version.go
@@ -1,3 +1,3 @@
 package app
 
-const FLOWG_VERSION = "v0.8.0"
+const FLOWG_VERSION = "v0.9.0"

--- a/internal/data/pipelines/flow.go
+++ b/internal/data/pipelines/flow.go
@@ -70,6 +70,20 @@ func (flowGraph FlowGraph) BuildPipeline(name string) (*Pipeline, error) {
 			}
 			pipelineNodes[flowNode.ID] = pipelineNode
 
+		case "pipeline":
+			pipeline, exists := flowNode.Data["pipeline"]
+			if !exists {
+				return nil, &MissingFlowNodeDataError{
+					NodeID: flowNode.ID,
+					Key:    "pipeline",
+				}
+			}
+
+			pipelineNode := &PipelineNode{
+				Pipeline: pipeline,
+			}
+			pipelineNodes[flowNode.ID] = pipelineNode
+
 		case "router":
 			stream, exists := flowNode.Data["stream"]
 			if !exists {

--- a/internal/data/pipelines/types.go
+++ b/internal/data/pipelines/types.go
@@ -39,6 +39,10 @@ type SwitchNode struct {
 	Next      []Node
 }
 
+type PipelineNode struct {
+	Pipeline string
+}
+
 type RouterNode struct {
 	Stream string
 }
@@ -126,6 +130,19 @@ func (n *SwitchNode) Process(
 	}
 
 	return nil
+}
+
+func (n *PipelineNode) Process(
+	ctx context.Context,
+	manager *Manager,
+	entry *logstorage.LogEntry,
+) error {
+	pipeline, err := manager.GetPipeline(n.Pipeline)
+	if err != nil {
+		return err
+	}
+
+	return pipeline.Run(ctx, manager, entry)
 }
 
 func (n *RouterNode) Process(

--- a/web/components/floweditor/src/flow/FlowEditor.tsx
+++ b/web/components/floweditor/src/flow/FlowEditor.tsx
@@ -23,6 +23,7 @@ import NodeSelector from './NodeSelector'
 import SourceNode from './nodes/SourceNode'
 import TransformNode from './nodes/TransformNode'
 import SwitchNode from './nodes/SwitchNode'
+import PipelineNode from './nodes/PipelineNode'
 import RouterNode from './nodes/RouterNode'
 import { useDnD } from '../dnd/context'
 
@@ -48,6 +49,7 @@ const FlowEditor: React.FC<FlowEditorProps> = ({ flow, onFlowChange }) => {
       source: SourceNode,
       transform: TransformNode,
       switch: SwitchNode,
+      pipeline: PipelineNode,
       router: RouterNode,
     }),
     [],

--- a/web/components/floweditor/src/flow/NodeSelector.tsx
+++ b/web/components/floweditor/src/flow/NodeSelector.tsx
@@ -32,6 +32,15 @@ const NodeSelector: React.FC = () => {
           <i className="material-icons">device_hub</i>
         </button>
         <button
+          className="btn-small tooltipped yellow darken-2"
+          data-position="top"
+          data-tooltip="Pipeline Node"
+          draggable
+          onDragStart={(event) => onDragStart(event, 'pipeline')}
+        >
+          <i className="material-icons">settings</i>
+        </button>
+        <button
           className="btn-small tooltipped purple"
           data-position="top"
           data-tooltip="Router Node"

--- a/web/components/floweditor/src/flow/nodes/PipelineNode.tsx
+++ b/web/components/floweditor/src/flow/nodes/PipelineNode.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useContext, useEffect } from 'react'
+import { Handle, Position, Node, NodeProps, NodeToolbar } from '@xyflow/react'
+
+import HooksContext from '../hooks'
+
+export type PipelineNode = Node<{
+  pipeline: string
+}>
+
+const PipelineNode: React.FC<NodeProps<PipelineNode>> = ({ id, data, selected }) => {
+  const hooksCtx = useContext(HooksContext)
+
+  useEffect(
+    () => {
+      const saveBtn = document.getElementById('action_save')
+
+      if (selected) {
+        saveBtn?.classList.add('pulse', 'orange')
+      }
+      else {
+        saveBtn?.classList.remove('pulse', 'orange')
+      }
+    },
+    [selected],
+  )
+
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    (evt) => {
+      hooksCtx.setNodes((nodes) => {
+        for (const node of nodes) {
+          if (node.id === id) {
+            node.data = {pipeline: evt.target!.value}
+            break
+          }
+        }
+
+        return [...nodes]
+      })
+    },
+    [id, hooksCtx],
+  )
+
+  return (
+    <>
+      {data.pipeline
+        ? (
+          <NodeToolbar>
+            <a
+              href={`/web/pipelines/edit/${data.pipeline}/`}
+              className="btn-small waves-effect waves-light"
+            >
+              <i className="material-icons left">build</i>
+              Edit
+            </a>
+          </NodeToolbar>
+        )
+        : (
+          <></>
+        )
+      }
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={{
+          width: '12px',
+          height: '12px',
+        }}
+      />
+      <div
+        className="
+          flex flex-row items-stretch
+          z-depth-1 p-0 gap-2
+          white black-text
+          hoverable
+        "
+        style={{
+          border: '4px solid #F9A825',
+        }}
+      >
+        <div className="yellow darken-2 white-text px-3 py-1 flex flex-row items-center">
+          <i className="material-icons small">settings</i>
+        </div>
+        <div className="input-field px-3 py-1">
+          <input
+            className="nodrag"
+            id={`pipeline-${id}`}
+            type="text"
+            defaultValue={data.pipeline}
+            onChange={onChange}
+          />
+          <label htmlFor={`pipeline-${id}`} className="font-semibold">
+            Pipeline
+          </label>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default PipelineNode


### PR DESCRIPTION
## Decision Record

For reusability, it can be useful to split a flow into multiple smaller flows. This PR adds a new *Pipeline Node* which will run the log entry through another pipeline.

## Changes

 - [x] :card_file_box: Add new `PipelineNode` type
 - [x] :lipstick: Add new `PipelineNode` to flow editor
 - [x] :bookmark: v0.9.0

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
