### PR TITLE
:lock: :whale: Drop root privileges

### DIFF
--- a/cmd/flowg/main.go
+++ b/cmd/flowg/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+
 	"os"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +26,7 @@ func main() {
 		Short: "Low-Code log management solution",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logging.Discard()
+			syscall.Umask(0077)
 		},
 	}
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,17 +1,23 @@
 #!/bin/sh
 
+set -e
+
+mkdir -p /data
+chmod 0700 /data
+chown -R flowg:flowg /data
+
 case "$1" in
   serve)
     shift
-    exec /usr/local/bin/flowg serve $@
+    exec su-exec flowg /usr/local/bin/flowg serve $@
     ;;
 
   admin)
     shift
-    exec /usr/local/bin/flowg admin $@
+    exec su-exec flowg /usr/local/bin/flowg admin $@
     ;;
 
   *)
-    exec /usr/local/bin/flowg --help
+    exec su-exec flowg /usr/local/bin/flowg --help
     ;;
 esac

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -105,12 +105,15 @@ RUN go test -v ./...
 
 FROM alpine:3.20 AS runner
 
-RUN apk add --no-cache libgcc
+RUN apk add --no-cache libgcc su-exec
 
 COPY --from=builder-go /workspace/bin/ /usr/local/bin/
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+RUN chmod 0700 /docker-entrypoint.sh
+
+RUN addgroup -S flowg && adduser -S -G flowg -h /app flowg
+WORKDIR /app
 
 ENV FLOWG_BIND_ADDRESS=":5080"
 ENV FLOWG_AUTH_DIR="/data/auth"


### PR DESCRIPTION
## Decision Record

For security reasons, *FlowG* should not run as root, the database and other files created by the application should not be readable by other users.

## Changes

 - [x] :heavy_plus_sign: :whale: Add `su-exec` in Docker image
 - [x] :lock: Set "umask" to `0077` at startup
 - [x] :whale: :lock: Add `flowg:flowg` user/group in Docker image
 - [x] :whale: :lock: Assign `/data` folder to `flowg:flowg` in entrypoint
 - [x] :whale: :lock: Drop root privileges in entrypoint

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
