### PR TITLE
:sparkles: Add In-Memory mode (for testing purpose)

### DIFF
--- a/cmd/flowg/admin_role_create.go
+++ b/cmd/flowg/admin_role_create.go
@@ -38,7 +38,9 @@ func NewAdminRoleCreateCommand() *cobra.Command {
 				role.Scopes[i] = scope
 			}
 
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_role_delete.go
+++ b/cmd/flowg/admin_role_delete.go
@@ -21,7 +21,9 @@ func NewAdminRoleDeleteCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete an existing role",
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_role_list.go
+++ b/cmd/flowg/admin_role_list.go
@@ -22,7 +22,9 @@ func NewAdminRoleListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List existing roles",
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_token_create.go
+++ b/cmd/flowg/admin_token_create.go
@@ -22,7 +22,9 @@ func NewAdminTokenCreateCommand() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new Personal Access Token",
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_user_create.go
+++ b/cmd/flowg/admin_user_create.go
@@ -29,7 +29,9 @@ func NewAdminUserCreateCommand() *cobra.Command {
 				Roles: make([]string, len(args)),
 			}
 
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_user_delete.go
+++ b/cmd/flowg/admin_user_delete.go
@@ -21,7 +21,9 @@ func NewAdminUserDeleteCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete an existing user",
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/admin_user_list.go
+++ b/cmd/flowg/admin_user_list.go
@@ -22,7 +22,9 @@ func NewAdminUserListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List existing users",
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to open auth database:", err)
 				exitCode = 1

--- a/cmd/flowg/serve.go
+++ b/cmd/flowg/serve.go
@@ -108,7 +108,9 @@ func NewServeCommand() *cobra.Command {
 			logNotifier.Start()
 			defer logNotifier.Stop()
 
-			configStorage := config.NewStorage(opts.configDir)
+			configStorage := config.NewStorage(
+				config.DefaultStorageOpts().WithDir(opts.configDir),
+			)
 
 			if err := bootstrap.DefaultRolesAndUsers(authDb); err != nil {
 				slog.Error(

--- a/cmd/flowg/serve.go
+++ b/cmd/flowg/serve.go
@@ -78,7 +78,9 @@ func NewServeCommand() *cobra.Command {
 				}
 			}()
 
-			logDb, err := logstorage.NewStorage(opts.logDir)
+			logDb, err := logstorage.NewStorage(
+				logstorage.DefaultStorageOpts().WithDir(opts.logDir),
+			)
 			if err != nil {
 				slog.Error(
 					"Failed to open logs database",

--- a/cmd/flowg/serve.go
+++ b/cmd/flowg/serve.go
@@ -52,7 +52,9 @@ func NewServeCommand() *cobra.Command {
 			metrics.Setup()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			authDb, err := auth.NewDatabase(opts.authDir)
+			authDb, err := auth.NewDatabase(
+				auth.DefaultDatabaseOpts().WithDir(opts.authDir),
+			)
 			if err != nil {
 				slog.Error(
 					"Failed to open auth database",

--- a/internal/data/auth/database.go
+++ b/internal/data/auth/database.go
@@ -7,17 +7,40 @@ import (
 	"link-society.com/flowg/internal/app/logging"
 )
 
+type DatabaseOpts struct {
+	dir      string
+	inMemory bool
+}
+
+func DefaultDatabaseOpts() DatabaseOpts {
+	return DatabaseOpts{
+		dir:      "./data/auth",
+		inMemory: false,
+	}
+}
+
+func (d DatabaseOpts) WithDir(dir string) DatabaseOpts {
+	d.dir = dir
+	return d
+}
+
+func (d DatabaseOpts) WithInMemory(inMemory bool) DatabaseOpts {
+	d.inMemory = inMemory
+	return d
+}
+
 type Database struct {
 	db *badger.DB
 }
 
-func NewDatabase(dbPath string) (*Database, error) {
-	opts := badger.
-		DefaultOptions(dbPath).
+func NewDatabase(opts DatabaseOpts) (*Database, error) {
+	dbOpts := badger.
+		DefaultOptions(opts.dir).
 		WithLogger(&logging.BadgerLogger{Channel: "authdb"}).
-		WithCompression(options.ZSTD)
+		WithCompression(options.ZSTD).
+		WithInMemory(opts.inMemory)
 
-	db, err := badger.Open(opts)
+	db, err := badger.Open(dbOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/data/config/backend.go
+++ b/internal/data/config/backend.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type backend interface {
+	PathExist(dir string) bool
+	MakePath(dir string) error
+
+	ListFiles(dir string) ([]string, error)
+	OpenFile(path string) (io.ReadCloser, error)
+	WriteFile(path string, content []byte) error
+	DeleteFile(path string) error
+}
+
+type fsBackend struct {
+	baseDir string
+}
+
+func newFsBackend(baseDir string) *fsBackend {
+	return &fsBackend{baseDir: baseDir}
+}
+
+func (b *fsBackend) PathExist(dir string) bool {
+	path := filepath.Join(b.baseDir, dir)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func (b *fsBackend) MakePath(dir string) error {
+	path := filepath.Join(b.baseDir, dir)
+	return os.MkdirAll(path, os.ModePerm)
+}
+
+func (b *fsBackend) ListFiles(dir string) ([]string, error) {
+	path := filepath.Join(b.baseDir, dir)
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	items := []string{}
+
+	for _, file := range files {
+		if !file.IsDir() {
+			item := file.Name()
+			items = append(items, item)
+		}
+	}
+
+	return items, nil
+}
+
+func (b *fsBackend) OpenFile(path string) (io.ReadCloser, error) {
+	filePath := filepath.Join(b.baseDir, path)
+	return os.Open(filePath)
+}
+
+func (b *fsBackend) WriteFile(path string, content []byte) error {
+	filePath := filepath.Join(b.baseDir, path)
+	return os.WriteFile(filePath, content, os.ModePerm)
+}
+
+func (b *fsBackend) DeleteFile(path string) error {
+	filePath := filepath.Join(b.baseDir, path)
+	return os.Remove(filePath)
+}
+
+type memBackend struct {
+	files map[string][]byte
+}
+
+func newMemBackend() *memBackend {
+	return &memBackend{
+		files: make(map[string][]byte),
+	}
+}
+
+func (b *memBackend) PathExist(dir string) bool {
+	dir = filepath.Clean(dir) + string(filepath.Separator)
+
+	for path := range b.files {
+		path = filepath.Clean(path)
+		if strings.HasPrefix(path, dir) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (b *memBackend) MakePath(dir string) error {
+	return nil
+}
+
+func (b *memBackend) ListFiles(dir string) ([]string, error) {
+	dir = filepath.Clean(dir)
+
+	items := []string{}
+
+	for path := range b.files {
+		path = filepath.Clean(path)
+		if filepath.Dir(path) == dir {
+			items = append(items, path)
+		}
+	}
+
+	return items, nil
+}
+
+func (b *memBackend) OpenFile(path string) (io.ReadCloser, error) {
+	content, ok := b.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return io.NopCloser(strings.NewReader(string(content))), nil
+}
+
+func (b *memBackend) WriteFile(path string, content []byte) error {
+	b.files[path] = content
+	return nil
+}
+
+func (b *memBackend) DeleteFile(path string) error {
+	delete(b.files, path)
+	return nil
+}

--- a/internal/data/config/system_alerts.go
+++ b/internal/data/config/system_alerts.go
@@ -16,7 +16,6 @@ type AlertSystem struct {
 }
 
 func NewAlertSystem(backend *Storage) *AlertSystem {
-	backend.resolveStorageTypeDir(ALERTS_STORAGE_TYPE)
 	return &AlertSystem{backend: backend}
 }
 

--- a/internal/data/config/system_pipelines.go
+++ b/internal/data/config/system_pipelines.go
@@ -12,7 +12,6 @@ type PipelineSystem struct {
 }
 
 func NewPipelineSystem(backend *Storage) *PipelineSystem {
-	backend.resolveStorageTypeDir(PIPELINES_STORAGE_TYPE)
 	return &PipelineSystem{backend: backend}
 }
 

--- a/internal/data/config/system_transformers.go
+++ b/internal/data/config/system_transformers.go
@@ -9,7 +9,6 @@ type TransformerSystem struct {
 }
 
 func NewTransformerSystem(backend *Storage) *TransformerSystem {
-	backend.resolveStorageTypeDir(TRANSFORMERS_STORAGE_TYPE)
 	return &TransformerSystem{backend: backend}
 }
 

--- a/internal/data/logstorage/main.go
+++ b/internal/data/logstorage/main.go
@@ -9,19 +9,42 @@ import (
 	"link-society.com/flowg/internal/app/logging"
 )
 
+type StorageOpts struct {
+	dir      string
+	inMemory bool
+}
+
+func DefaultStorageOpts() StorageOpts {
+	return StorageOpts{
+		dir:      "./data/logs",
+		inMemory: false,
+	}
+}
+
+func (s StorageOpts) WithDir(dir string) StorageOpts {
+	s.dir = dir
+	return s
+}
+
+func (s StorageOpts) WithInMemory(inMemory bool) StorageOpts {
+	s.inMemory = inMemory
+	return s
+}
+
 type Storage struct {
 	db      *badger.DB
 	gc      *garbageCollector
 	indexer *indexer
 }
 
-func NewStorage(dbPath string) (*Storage, error) {
-	opts := badger.
-		DefaultOptions(dbPath).
+func NewStorage(opts StorageOpts) (*Storage, error) {
+	dbOpts := badger.
+		DefaultOptions(opts.dir).
 		WithLogger(&logging.BadgerLogger{Channel: "logstorage"}).
-		WithCompression(options.ZSTD)
+		WithCompression(options.ZSTD).
+		WithInMemory(opts.inMemory)
 
-	db, err := badger.Open(opts)
+	db, err := badger.Open(dbOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Decision Record

See: #77

In order to facilitate the implementation of unit tests, we need the ability to open databases in "In Memory" mode.

## Changes

 - [x]  :sparkles: Add "In Memory" mode to auth database, config storage, and log storage

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
