### PR TITLE
:passport_control: Add Cookie-based authentication to API

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/internal/data/auth"
+)
+
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type LoginResponse struct {
+	Success   bool   `json:"success"`
+	SessionID string `cookie:"session_id,httponly,max-age=86400,path=/"`
+}
+
+func LoginUsecase(authDb *auth.Database) usecase.Interactor {
+	userSys := auth.NewUserSystem(authDb)
+
+	u := usecase.NewInteractor(
+		func(
+			ctx context.Context,
+			req LoginRequest,
+			resp *LoginResponse,
+		) error {
+			switch valid, err := userSys.VerifyUserPassword(req.Username, req.Password); {
+			case err != nil:
+				slog.ErrorContext(
+					ctx,
+					"Failed to verify user password",
+					"channel", "api",
+					"username", req.Username,
+					"error", err.Error(),
+				)
+
+				resp.Success = false
+				return status.Wrap(err, status.Unauthenticated)
+
+			case !valid:
+				resp.Success = false
+				return status.Wrap(errors.New("invalid credentials"), status.Unauthenticated)
+
+			case valid:
+				resp.Success = true
+				resp.SessionID = req.Username
+			}
+
+			return nil
+		},
+	)
+
+	u.SetName("login")
+	u.SetTitle("Authenticate")
+	u.SetDescription("Create new Session cookie")
+	u.SetTags("auth")
+
+	u.SetExpectedErrors(status.Unauthenticated)
+
+	return u
+}

--- a/api/logout.go
+++ b/api/logout.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"context"
+
+	"github.com/swaggest/usecase"
+
+	"link-society.com/flowg/internal/data/auth"
+)
+
+type LogoutRequest struct{}
+
+type LogoutResponse struct {
+	Success   bool   `json:"success"`
+	SessionID string `cookie:"session_id,httponly,max-age=-1,path=/"`
+}
+
+func LogoutUsecase(authDb *auth.Database) usecase.Interactor {
+	u := usecase.NewInteractor(
+		func(
+			ctx context.Context,
+			req LogoutRequest,
+			resp *LogoutResponse,
+		) error {
+			resp.SessionID = ""
+			return nil
+		},
+	)
+
+	u.SetName("logout")
+	u.SetTitle("Sign out")
+	u.SetDescription("Delete Session cookie")
+	u.SetTags("auth")
+
+	return u
+}

--- a/api/main.go
+++ b/api/main.go
@@ -31,6 +31,8 @@ func NewHandler(
 	service.OpenAPISchema().SetVersion(app.FLOWG_VERSION)
 	service.Docs("/api/docs", v5emb.New)
 
+	service.Post("/api/v1/auth/login", LoginUsecase(authDb))
+
 	service.With(
 		nethttp.HTTPBearerSecurityMiddleware(
 			service.OpenAPICollector,
@@ -94,7 +96,8 @@ func NewHandler(
 		r.Put("/api/v1/users/{user}", SaveUserUsecase(authDb))
 		r.Delete("/api/v1/users/{user}", DeleteUserUsecase(authDb))
 
-		r.Get("/api/v1/whoami", WhoamiUsecase(authDb))
+		r.Post("/api/v1/auth/logout", LogoutUsecase(authDb))
+		r.Get("/api/v1/auth/whoami", WhoamiUsecase(authDb))
 
 		r.Get("/api/v1/tokens", ListTokensUsecase(authDb))
 		r.Post("/api/v1/token", CreateTokenUsecase(authDb))

--- a/api/whoami.go
+++ b/api/whoami.go
@@ -31,7 +31,7 @@ func WhoamiUsecase(authDb *auth.Database) usecase.Interactor {
 	u.SetName("whoami")
 	u.SetTitle("Fetch current profile")
 	u.SetDescription("Fetch the profile of the currently authenticated user")
-	u.SetTags("acls")
+	u.SetTags("auth")
 
 	u.SetExpectedErrors(status.PermissionDenied)
 

--- a/internal/data/auth/middleware_api.go
+++ b/internal/data/auth/middleware_api.go
@@ -15,65 +15,24 @@ import (
 
 func ApiMiddleware(db *Database) func(http.Handler) http.Handler {
 	tokenSys := NewTokenSystem(db)
+	userSys := NewUserSystem(db)
 
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			authHeader := r.Header.Get("Authorization")
-
-			if !strings.HasPrefix(authHeader, "Bearer ") {
-				code, payload := rest.Err(status.Wrap(
-					errors.New("missing token"),
-					status.Unauthenticated,
-				))
-				w.WriteHeader(code)
-				err := json.NewEncoder(w).Encode(payload)
-				if err != nil {
-					slog.ErrorContext(
-						r.Context(),
-						"Failed to encode error response",
-						"channel", "api",
-						"error", err.Error(),
-					)
-				}
-				return
-			}
-
-			token := authHeader[len("Bearer "):]
-
-			user, err := tokenSys.VerifyToken(token)
+		serveError := func(w http.ResponseWriter, r *http.Request, err error) {
+			code, payload := rest.Err(status.Wrap(err, status.Unauthenticated))
+			w.WriteHeader(code)
+			err = json.NewEncoder(w).Encode(payload)
 			if err != nil {
-				code, payload := rest.Err(status.Wrap(err, status.Unauthenticated))
-				w.WriteHeader(code)
-				err := json.NewEncoder(w).Encode(payload)
-				if err != nil {
-					slog.ErrorContext(
-						r.Context(),
-						"Failed to encode error response",
-						"channel", "api",
-						"error", err.Error(),
-					)
-				}
-				return
+				slog.ErrorContext(
+					r.Context(),
+					"Failed to encode error response",
+					"channel", "api",
+					"error", err.Error(),
+				)
 			}
+		}
 
-			if user == nil {
-				code, payload := rest.Err(status.Wrap(
-					errors.New("invalid token"),
-					status.Unauthenticated,
-				))
-				w.WriteHeader(code)
-				err := json.NewEncoder(w).Encode(payload)
-				if err != nil {
-					slog.ErrorContext(
-						r.Context(),
-						"Failed to encode error response",
-						"channel", "api",
-						"error", err.Error(),
-					)
-				}
-				return
-			}
-
+		serveNext := func(w http.ResponseWriter, r *http.Request, user *User) {
 			slog.DebugContext(
 				r.Context(),
 				"Authenticated user",
@@ -83,6 +42,63 @@ func ApiMiddleware(db *Database) func(http.Handler) http.Handler {
 
 			ctx := ContextWithUser(r.Context(), user)
 			next.ServeHTTP(w, r.WithContext(ctx))
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie, err := r.Cookie("session_id")
+			switch err {
+			case nil:
+				user, err := userSys.GetUser(cookie.Value)
+				switch {
+				case err != nil:
+					slog.WarnContext(
+						r.Context(),
+						"Failed to get user from session cookie",
+						"channel", "api",
+						"error", err.Error(),
+					)
+
+				case user != nil:
+					serveNext(w, r, user)
+					return
+				}
+
+			case http.ErrNoCookie:
+				slog.WarnContext(
+					r.Context(),
+					"Session cookie not found",
+					"channel", "api",
+				)
+
+			default:
+				slog.WarnContext(
+					r.Context(),
+					"Failed to read session cookie",
+					"channel", "api",
+					"error", err.Error(),
+				)
+			}
+
+			authHeader := r.Header.Get("Authorization")
+
+			if !strings.HasPrefix(authHeader, "Bearer ") {
+				serveError(w, r, errors.New("missing token"))
+				return
+			}
+
+			token := authHeader[len("Bearer "):]
+
+			user, err := tokenSys.VerifyToken(token)
+			switch {
+			case err != nil:
+				serveError(w, r, err)
+
+			case user == nil:
+				serveError(w, r, errors.New("invalid token"))
+
+			default:
+				serveNext(w, r, user)
+			}
 		})
 	}
 }

--- a/tests/e2e/integration/acl_tokens.hurl
+++ b/tests/e2e/integration/acl_tokens.hurl
@@ -22,7 +22,7 @@ jsonpath "$.success" == true
 jsonpath "$.token-uuids" count == 2
 jsonpath "$.token-uuids" includes "{{new_admin_token_uuid}}"
 
-GET http://localhost:5080/api/v1/whoami
+GET http://localhost:5080/api/v1/auth/whoami
 Authorization: Bearer {{new_admin_token}}
 HTTP 200
 [Asserts]
@@ -35,6 +35,6 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
-GET http://localhost:5080/api/v1/whoami
+GET http://localhost:5080/api/v1/auth/whoami
 Authorization: Bearer {{new_admin_token}}
 HTTP 401

--- a/tests/e2e/integration/auth.hurl
+++ b/tests/e2e/integration/auth.hurl
@@ -1,10 +1,29 @@
-GET http://localhost:5080/api/v1/whoami
+GET http://localhost:5080/api/v1/auth/whoami
 HTTP 401
 
-GET http://localhost:5080/api/v1/whoami
+GET http://localhost:5080/api/v1/auth/whoami
 Authorization: Bearer {{admin_token}}
 HTTP 200
 
-GET http://localhost:5080/api/v1/whoami
+GET http://localhost:5080/api/v1/auth/whoami
 Authorization: Bearer {{guest_token}}
 HTTP 200
+
+POST http://localhost:5080/api/v1/auth/login
+Content-Type: application/json
+{
+  "username": "root",
+  "password": "root"
+}
+HTTP 200
+[Captures]
+session_id: cookie "session_id"
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth/whoami
+[Cookies]
+session_id: {{session_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true


### PR DESCRIPTION
## Decision Record

In order to be able to build a client-side web application for FlowG, we need the API to support cookie-based authentication, thus avoiding the need to store a token on the client.

## Changes

 - [x] :sparkles: Add Cookie-based authentication to API
 - [x] :sparkles: Add `login` and `logout` API operations for Cookie-based authentication

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
