### PR TITLE
:recycle: Avoid blocking notifications

### DIFF
--- a/api/watch_logs.go
+++ b/api/watch_logs.go
@@ -80,9 +80,9 @@ func WatchLogsUsecase(
 					"stream", req.Stream,
 				)
 
-				logC := logNotifier.Subscribe(req.Stream, ctx.Done())
+				logM := logNotifier.Subscribe(ctx, req.Stream)
 
-				for log := range logC {
+				for log := range logM.ReceiveC() {
 					if filter == nil || filter.Evaluate(&log.LogEntry) {
 						payload, err := json.Marshal(log.LogEntry)
 						if err != nil {

--- a/internal/data/lognotify/types.go
+++ b/internal/data/lognotify/types.go
@@ -1,6 +1,10 @@
 package lognotify
 
-import "link-society.com/flowg/internal/data/logstorage"
+import (
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/data/logstorage"
+)
 
 type LogMessage struct {
 	Stream   string
@@ -10,6 +14,6 @@ type LogMessage struct {
 
 type SubscribeMessage struct {
 	Stream  string
-	SenderC chan<- LogMessage
+	SenderM actor.Mailbox[LogMessage]
 	DoneC   <-chan struct{}
 }

--- a/internal/data/pipelines/nodes.go
+++ b/internal/data/pipelines/nodes.go
@@ -174,7 +174,7 @@ func (n *RouterNode) Process(ctx context.Context, entry *logstorage.LogEntry) er
 
 	key, err := collectorSys.Ingest(ctx, n.Stream, entry)
 	if err == nil {
-		logNotifier.Notify(n.Stream, string(key), *entry)
+		logNotifier.Notify(ctx, n.Stream, string(key), *entry)
 		metrics.IncStreamLogCounter(n.Stream)
 	}
 


### PR DESCRIPTION
## Decision Record

An `actor.Mailbox` uses internally a growing queue, which avoids blocking the goroutine when sending messages.

Let's use this instead of normal Go channels for the `lognotify.Lognotifier`

## Changes

 - [x] :recycle: Use `actor.Mailbox[LogMessage]` instead of `chan LogMessage` for `lognotify.LogNotifier`

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
