### PR TITLE
:recycle: :white_check_mark: Fix Race condition in test suite

### DIFF
--- a/internal/data/lognotify/notify_test.go
+++ b/internal/data/lognotify/notify_test.go
@@ -20,12 +20,22 @@ func TestLogNotifier(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	logM := notifier.Subscribe(ctx, "test")
+	logM, err := notifier.Subscribe(ctx, "test")
+	if err != nil {
+		t.Fatalf("unexpected error while subscribing: %v", err)
+	}
 
 	logEntry := logstorage.NewLogEntry(map[string]string{})
 
-	notifier.Notify(ctx, "test", "key", *logEntry)
-	result := <-logM.ReceiveC()
+	err = notifier.Notify(ctx, "test", "key", *logEntry)
+	if err != nil {
+		t.Fatalf("unexpected error while notifying: %v", err)
+	}
+
+	result, ok := <-logM.ReceiveC()
+	if !ok {
+		t.Fatalf("unexpected closed channel")
+	}
 
 	if result.Stream != "test" {
 		t.Fatalf("unexpected stream: %s", result.Stream)

--- a/internal/data/lognotify/types.go
+++ b/internal/data/lognotify/types.go
@@ -15,5 +15,10 @@ type LogMessage struct {
 type SubscribeMessage struct {
 	Stream  string
 	SenderM actor.Mailbox[LogMessage]
+	ReadyC  chan<- ReadyResponse
 	DoneC   <-chan struct{}
+}
+
+type ReadyResponse struct {
+	Err error
 }

--- a/internal/data/pipelines/nodes.go
+++ b/internal/data/pipelines/nodes.go
@@ -174,7 +174,9 @@ func (n *RouterNode) Process(ctx context.Context, entry *logstorage.LogEntry) er
 
 	key, err := collectorSys.Ingest(ctx, n.Stream, entry)
 	if err == nil {
-		logNotifier.Notify(ctx, n.Stream, string(key), *entry)
+		err = logNotifier.Notify(ctx, n.Stream, string(key), *entry)
+	}
+	if err == nil {
 		metrics.IncStreamLogCounter(n.Stream)
 	}
 


### PR DESCRIPTION
## Decision Record

The `LogNotifier.Subscribe()` function does not block until channel is ready to consume messages. In the test suite, this leads to a race condition where the message sent in `LogNotifier.Notify()` is received first, thus lost as there is no subscriber yet. Which means the test will fail by timeout while waiting for the message.

## Changes

 - [x] :recycle: Block `LogNotifier.Subscribe()` until mailbox is ready to receive message
 - [x] :recycle: Make `LogNotifier.Subscribe()` and `LogNotifier.Notify()` return errors
 - [x] :loud_sound: Add more logs

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
