### PR TITLE
:sparkles: Add missing edit buttons for alerts and streams

### DIFF
--- a/web/app/src/components/editors/alert/dialog.tsx
+++ b/web/app/src/components/editors/alert/dialog.tsx
@@ -140,7 +140,7 @@ export const OpenAlertDialog = ({ alert }: OpenAlertDialogProps) => {
             </Button>
           </Toolbar>
         </AppBar>
-        <div className="flex-grow bg-slate-200 p-6">
+        <div className="flex-grow p-6 overflow-auto">
           <React.Suspense
             fallback={
               <div className="w-full h-full flex flex-col items-center justify-center">

--- a/web/app/src/components/editors/alert/dialog.tsx
+++ b/web/app/src/components/editors/alert/dialog.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from 'react'
+import { useApiOperation } from '@/lib/hooks/api'
+import { useNotify } from '@/lib/hooks/notify'
+
+import * as colors from '@mui/material/colors'
+
+import EditIcon from '@mui/icons-material/Edit'
+import CloseIcon from '@mui/icons-material/Close'
+import SaveIcon from '@mui/icons-material/Save'
+
+import Slide from '@mui/material/Slide'
+import Dialog from '@mui/material/Dialog'
+import AppBar from '@mui/material/AppBar'
+import Toolbar from '@mui/material/Toolbar'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import CircularProgress from '@mui/material/CircularProgress'
+
+import { TransitionProps } from '@mui/material/transitions'
+
+import { AlertEditor } from '@/components/editors/alert'
+import { AuthenticatedAwait } from '@/components/routing/await'
+
+import * as configApi from '@/lib/api/operations/config'
+import { WebhookModel } from '@/lib/models'
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: React.ReactElement },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />
+})
+
+type OpenAlertDialogProps = Readonly<{
+  alert: string
+}>
+
+export const OpenAlertDialog = ({ alert }: OpenAlertDialogProps) => {
+  const notify = useNotify()
+
+  const [open, setOpen] = useState(false)
+
+  const [webhook, setWebhook] = useState<WebhookModel>({
+    url: '',
+    headers: {},
+  })
+  const [webhookPromise, setWebhookPromise] = useState<Promise<void> | null>(null)
+
+  const [onFetch] = useApiOperation(
+    async (alert: string) => {
+      const webhook = await configApi.getAlert(alert)
+      setWebhook(webhook)
+    },
+    [alert],
+  )
+
+  useEffect(
+    () => {
+      setWebhookPromise(onFetch(alert))
+    },
+    [alert],
+  )
+
+  const [onSave, saveLoading] = useApiOperation(
+    async () => {
+      await configApi.saveAlert(alert, webhook)
+      notify.success('Alert saved')
+      setWebhookPromise(onFetch(alert))
+    },
+    [alert, webhook],
+  )
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="small"
+        color="secondary"
+        startIcon={<EditIcon />}
+        onClick={() => setOpen(true)}
+      >
+        Edit
+      </Button>
+      <Dialog
+        fullScreen
+        open={open}
+        onClose={() => setOpen(false)}
+        TransitionComponent={Transition}
+      >
+        <AppBar sx={{ position: 'relative' }}>
+          <Toolbar className="gap-3">
+            <IconButton
+              edge="start"
+              color="inherit"
+              onClick={() => setOpen(false)}
+            >
+              <CloseIcon />
+            </IconButton>
+
+            <div className="flex-grow">
+              <TextField
+                label="Alert name"
+                value={alert}
+                type="text"
+                variant="outlined"
+                size="small"
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    sx: {
+                      color: 'white',
+                      backgroundColor: colors.blue[700]
+                    },
+                  },
+                  inputLabel: {
+                    sx: {
+                      color: 'white',
+                      '&.Mui-focused': {
+                        color: 'white',
+                      },
+                    },
+                  },
+                }}
+              />
+            </div>
+
+            <Button
+              variant="contained"
+              color="secondary"
+              size="small"
+              onClick={onSave}
+              disabled={saveLoading}
+              startIcon={!saveLoading && <SaveIcon />}
+            >
+              {saveLoading
+                ? <CircularProgress size={24} />
+                : <>Save</>
+              }
+            </Button>
+          </Toolbar>
+        </AppBar>
+        <div className="flex-grow bg-slate-200 p-6">
+          <React.Suspense
+            fallback={
+              <div className="w-full h-full flex flex-col items-center justify-center">
+                <CircularProgress />
+              </div>
+            }
+          >
+            {webhookPromise !== null && (
+              <AuthenticatedAwait resolve={webhookPromise}>
+                <AlertEditor webhook={webhook} onWebhookChange={setWebhook} />
+              </AuthenticatedAwait>
+            )}
+          </React.Suspense>
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/web/app/src/components/editors/alert/index.tsx
+++ b/web/app/src/components/editors/alert/index.tsx
@@ -1,0 +1,43 @@
+import Divider from '@mui/material/Divider'
+import TextField from '@mui/material/TextField'
+import { KeyValueEditor } from '@/components/form/kv-editor'
+
+import { WebhookModel } from '@/lib/models'
+
+type AlertEditorProps = {
+  webhook: WebhookModel
+  onWebhookChange: (webhook: WebhookModel) => void
+}
+
+export const AlertEditor = ({ webhook, onWebhookChange }: AlertEditorProps) => {
+  return (
+    <div className="flex flex-col items-stretch gap-3">
+      <TextField
+        label="Webhook URL"
+        variant="outlined"
+        type="text"
+        value={webhook.url}
+        onChange={(e) => {
+          onWebhookChange({
+            ...webhook,
+            url: e.target.value,
+          })
+        }}
+      />
+
+      <Divider />
+
+      <KeyValueEditor
+        keyLabel="HTTP Header"
+        valueLabel="Value"
+        keyValues={Object.entries(webhook.headers)}
+        onChange={(pairs) => {
+          onWebhookChange({
+            ...webhook,
+            headers: Object.fromEntries(pairs),
+          })
+        }}
+      />
+    </div>
+  )
+}

--- a/web/app/src/components/editors/pipeline/nodes/alert.tsx
+++ b/web/app/src/components/editors/pipeline/nodes/alert.tsx
@@ -4,6 +4,8 @@ import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive'
 
 import TextField from '@mui/material/TextField'
 
+import { OpenAlertDialog } from '@/components/editors/alert/dialog'
+
 type AlertNodeData = Node<{
   alert: string
 }>
@@ -12,7 +14,7 @@ export const AlertNode = ({ data, selected }: NodeProps<AlertNodeData>) => (
   <>
     {selected && (
       <NodeToolbar>
-        [edit]
+        <OpenAlertDialog alert={data.alert} />
       </NodeToolbar>
     )}
 

--- a/web/app/src/components/editors/pipeline/nodes/router.tsx
+++ b/web/app/src/components/editors/pipeline/nodes/router.tsx
@@ -4,6 +4,8 @@ import StorageIcon from '@mui/icons-material/Storage'
 
 import TextField from '@mui/material/TextField'
 
+import { OpenStreamDialog } from '@/components/editors/stream/dialog'
+
 type RouterNodeData = Node<{
   stream: string
 }>
@@ -12,7 +14,7 @@ export const RouterNode = ({ data, selected }: NodeProps<RouterNodeData>) => (
   <>
     {selected && (
       <NodeToolbar>
-        [edit]
+        <OpenStreamDialog stream={data.stream} />
       </NodeToolbar>
     )}
 

--- a/web/app/src/components/editors/stream/dialog.tsx
+++ b/web/app/src/components/editors/stream/dialog.tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useState } from 'react'
+import { useApiOperation } from '@/lib/hooks/api'
+import { useNotify } from '@/lib/hooks/notify'
+
+import * as colors from '@mui/material/colors'
+
+import EditIcon from '@mui/icons-material/Edit'
+import CloseIcon from '@mui/icons-material/Close'
+import SaveIcon from '@mui/icons-material/Save'
+
+import Slide from '@mui/material/Slide'
+import Dialog from '@mui/material/Dialog'
+import AppBar from '@mui/material/AppBar'
+import Toolbar from '@mui/material/Toolbar'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import CircularProgress from '@mui/material/CircularProgress'
+
+import { TransitionProps } from '@mui/material/transitions'
+
+import { StreamEditor } from '@/components/editors/stream'
+import { AuthenticatedAwait } from '@/components/routing/await'
+
+import * as configApi from '@/lib/api/operations/config'
+import { StreamConfigModel } from '@/lib/models'
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: React.ReactElement },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />
+})
+
+type OpenStreamDialogProps = Readonly<{
+  stream: string
+}>
+
+export const OpenStreamDialog = ({ stream }: OpenStreamDialogProps) => {
+  const notify = useNotify()
+
+  const [open, setOpen] = useState(false)
+
+  const [streamConfig, setStreamConfig] = useState<StreamConfigModel>({
+    indexed_fields: [],
+    size: 0,
+    ttl: 0,
+  })
+  const [streamConfigPromise, setStreamConfigPromise] = useState<Promise<void> | null>(null)
+
+  const [onFetch] = useApiOperation(
+    async (stream: string) => {
+      const streamConfig = await configApi.getStreamConfig(stream)
+      setStreamConfig(streamConfig)
+    },
+    [stream],
+  )
+
+  useEffect(
+    () => {
+      setStreamConfigPromise(onFetch(stream))
+    },
+    [stream],
+  )
+
+  const [onSave, saveLoading] = useApiOperation(
+    async () => {
+      await configApi.configureStream(stream, streamConfig)
+      notify.success('Stream saved')
+      setStreamConfigPromise(onFetch(stream))
+    },
+    [stream, streamConfig],
+  )
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="small"
+        color="secondary"
+        startIcon={<EditIcon />}
+        onClick={() => setOpen(true)}
+      >
+        Edit
+      </Button>
+      <Dialog
+        fullScreen
+        open={open}
+        onClose={() => setOpen(false)}
+        TransitionComponent={Transition}
+      >
+        <AppBar sx={{ position: 'relative' }}>
+          <Toolbar className="gap-3">
+            <IconButton
+              edge="start"
+              color="inherit"
+              onClick={() => setOpen(false)}
+            >
+              <CloseIcon />
+            </IconButton>
+
+            <div className="flex-grow">
+              <TextField
+                label="Stream name"
+                value={stream}
+                type="text"
+                variant="outlined"
+                size="small"
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    sx: {
+                      color: 'white',
+                      backgroundColor: colors.blue[700]
+                    },
+                  },
+                  inputLabel: {
+                    sx: {
+                      color: 'white',
+                      '&.Mui-focused': {
+                        color: 'white',
+                      },
+                    },
+                  },
+                }}
+              />
+            </div>
+
+            <Button
+              variant="contained"
+              color="secondary"
+              size="small"
+              onClick={onSave}
+              disabled={saveLoading}
+              startIcon={!saveLoading && <SaveIcon />}
+            >
+              {saveLoading
+                ? <CircularProgress size={24} />
+                : <>Save</>
+              }
+            </Button>
+          </Toolbar>
+        </AppBar>
+        <div className="flex-grow bg-slate-200 p-6 overflow-auto">
+          <React.Suspense
+            fallback={
+              <div className="w-full h-full flex flex-col items-center justify-center">
+                <CircularProgress />
+              </div>
+            }
+          >
+            {streamConfigPromise !== null && (
+              <AuthenticatedAwait resolve={streamConfigPromise}>
+                <StreamEditor
+                  streamConfig={streamConfig}
+                  onStreamConfigChange={setStreamConfig}
+                />
+              </AuthenticatedAwait>
+            )}
+          </React.Suspense>
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/web/app/src/components/editors/stream/index.tsx
+++ b/web/app/src/components/editors/stream/index.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+
+import AddIcon from '@mui/icons-material/Add'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+import Divider from '@mui/material/Divider'
+import Paper from '@mui/material/Paper'
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+
+import { StreamConfigModel } from '@/lib/models'
+
+type StreamEditorProps = {
+  streamConfig: StreamConfigModel
+  onStreamConfigChange: (config: StreamConfigModel) => void
+}
+
+export const StreamEditor = ({ streamConfig, onStreamConfigChange }: StreamEditorProps) => {
+  const [newField, setNewField] = useState('')
+
+  return (
+    <div className="h-full flex flex-row items-stretch gap-3">
+      <Paper className="h-full flex-1 flex flex-col items-stretch">
+        <h1 className="p-3 bg-gray-100 text-xl text-center font-semibold">Retention</h1>
+        <Divider />
+
+        <div
+          className="
+            p-3 flex-grow flex-shrink h-0 overflow-auto
+            flex flex-col items-stretch gap-3
+          "
+        >
+          <TextField
+            label="Retention size (in MB)"
+            variant="outlined"
+            type="number"
+            value={streamConfig.size}
+            onChange={(e) => {
+              onStreamConfigChange({
+                ...streamConfig,
+                size: Number(e.target.value),
+              })
+            }}
+          />
+
+          <TextField
+            label="Retention time (in seconds)"
+            variant="outlined"
+            type="number"
+            value={streamConfig.ttl}
+            onChange={(e) => {
+              onStreamConfigChange({
+                ...streamConfig,
+                ttl: Number(e.target.value),
+              })
+            }}
+          />
+
+          <p className="italic">Use <code className="font-mono bg-gray-200 text-red-500 px-1">0</code> to disable</p>
+        </div>
+      </Paper>
+
+      <Paper className="h-full flex-1 flex flex-col items-stretch">
+        <h1 className="p-3 bg-gray-100 text-xl text-center font-semibold">Indexes</h1>
+        <Divider />
+
+        <div
+          className="
+            p-3 flex-grow flex-shrink h-0 overflow-auto
+            flex flex-col items-stretch gap-3
+          "
+        >
+          {streamConfig.indexed_fields.map((field) => (
+            <div key={field} className="flex flex-row items-stretch gap-3">
+              <TextField
+                label="Field"
+                variant="outlined"
+                type="text"
+                value={field}
+                onChange={(e) => {
+                  onStreamConfigChange({
+                    ...streamConfig,
+                    indexed_fields: streamConfig.indexed_fields.map(
+                      (f) => f === field ? e.target.value : f
+                    ),
+                  })
+                }}
+                className="flex-grow"
+              />
+
+              <Button
+                variant="contained"
+                color="error"
+                size="small"
+                onClick={() => {
+                  onStreamConfigChange({
+                    ...streamConfig,
+                    indexed_fields: streamConfig.indexed_fields.filter(
+                      (f) => f !== field
+                    ),
+                  })
+                }}
+              >
+                <DeleteIcon />
+              </Button>
+            </div>
+          ))}
+
+          <div className="flex flex-row items-stretch gap-3">
+            <TextField
+              label="Field"
+              variant="outlined"
+              type="text"
+              value={newField}
+              onChange={(e) => {
+                setNewField(e.target.value)
+              }}
+              className="flex-grow"
+            />
+
+            <Button
+              variant="contained"
+              color="primary"
+              size="small"
+              onClick={() => {
+                onStreamConfigChange({
+                  ...streamConfig,
+                  indexed_fields: [...streamConfig.indexed_fields, newField],
+                })
+                setNewField('')
+              }}
+            >
+              <AddIcon />
+            </Button>
+          </div>
+        </div>
+      </Paper>
+    </div>
+  )
+}

--- a/web/app/src/lib/api/operations/config.ts
+++ b/web/app/src/lib/api/operations/config.ts
@@ -77,6 +77,19 @@ export const listStreamFields = async (stream: string): Promise<string[]> => {
   return body.fields
 }
 
+export const getStreamConfig = async (stream: string): Promise<StreamConfigModel> => {
+  type GetStreamConfigResponse = {
+    success: boolean
+    config: StreamConfigModel
+  }
+
+  const { body } = await request.GET<GetStreamConfigResponse>({
+    path: `/api/v1/streams/${stream}`,
+  })
+
+  return body.config
+}
+
 export const configureStream = async (stream: string, config: StreamConfigModel): Promise<void> => {
   type ConfigureStreamRequest = {
     config: StreamConfigModel

--- a/web/app/src/views/app/alerts/item.tsx
+++ b/web/app/src/views/app/alerts/item.tsx
@@ -11,15 +11,13 @@ import SaveIcon from '@mui/icons-material/Save'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid2'
 import Paper from '@mui/material/Paper'
-import Divider from '@mui/material/Divider'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
-import TextField from '@mui/material/TextField'
 
-import { KeyValueEditor } from '@/components/form/kv-editor'
+import { AlertEditor } from '@/components/editors/alert'
 import { NewAlertButton } from './new-btn'
 
 import * as configApi from '@/lib/api/operations/config'
@@ -146,33 +144,8 @@ export const AlertView = () => {
           </Paper>
         </Grid>
         <Grid size={{ xs: 10 }} className="h-full">
-          <Paper className="h-full overflow-auto p-3 flex flex-col items-stretch gap-3">
-            <TextField
-              label="Webhook URL"
-              variant="outlined"
-              type="text"
-              value={webhook.url}
-              onChange={(e) => {
-                setWebhook((prev) => ({
-                  ...prev,
-                  url: e.target.value,
-                }))
-              }}
-            />
-
-            <Divider />
-
-            <KeyValueEditor
-              keyLabel="HTTP Header"
-              valueLabel="Value"
-              keyValues={Object.entries(webhook.headers)}
-              onChange={(pairs) => {
-                setWebhook((prev) => ({
-                  ...prev,
-                  headers: Object.fromEntries(pairs),
-                }))
-              }}
-            />
+          <Paper className="h-full overflow-auto p-3">
+            <AlertEditor webhook={webhook} onWebhookChange={setWebhook} />
           </Paper>
         </Grid>
       </Grid>

--- a/web/app/src/views/app/storage/item.tsx
+++ b/web/app/src/views/app/storage/item.tsx
@@ -7,19 +7,17 @@ import { useNotify } from '@/lib/hooks/notify'
 import HelpIcon from '@mui/icons-material/Help'
 import DeleteIcon from '@mui/icons-material/Delete'
 import SaveIcon from '@mui/icons-material/Save'
-import AddIcon from '@mui/icons-material/Add'
 
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid2'
-import Divider from '@mui/material/Divider'
 import Paper from '@mui/material/Paper'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
-import TextField from '@mui/material/TextField'
 
+import { StreamEditor } from '@/components/editors/stream'
 import { NewStreamButton } from './new-btn'
 
 import * as configApi from '@/lib/api/operations/config'
@@ -35,7 +33,6 @@ export const StreamView = () => {
   const streamNames = Object.keys(streams)
 
   const [streamConfig, setStreamConfig] = useState(streams[currentStream!]!)
-  const [newField, setNewField] = useState('')
 
   const onCreate = useCallback(
     (name: string) => {
@@ -148,119 +145,10 @@ export const StreamView = () => {
           </Paper>
         </Grid>
         <Grid size={{ xs: 10 }} className="h-full">
-          <div className="h-full flex flex-row items-stretch gap-3">
-            <Paper className="h-full flex-1 flex flex-col items-stretch">
-              <h1 className="p-3 bg-gray-100 text-xl text-center font-semibold">Retention</h1>
-              <Divider />
-
-              <div
-                className="
-                  p-3 flex-grow flex-shrink h-0 overflow-auto
-                  flex flex-col items-stretch gap-3
-                "
-              >
-                <TextField
-                  label="Retention size (in MB)"
-                  variant="outlined"
-                  type="number"
-                  value={streamConfig.size}
-                  onChange={(e) => {
-                    setStreamConfig((prev) => ({
-                      ...prev,
-                      size: Number(e.target.value),
-                    }))
-                  }}
-                />
-
-                <TextField
-                  label="Retention time (in seconds)"
-                  variant="outlined"
-                  type="number"
-                  value={streamConfig.ttl}
-                  onChange={(e) => {
-                    setStreamConfig((prev) => ({
-                      ...prev,
-                      ttl: Number(e.target.value),
-                    }))
-                  }}
-                />
-
-                <p className="italic">Use <code className="font-mono bg-gray-200 text-red-500 px-1">0</code> to disable</p>
-              </div>
-            </Paper>
-
-            <Paper className="h-full flex-1 flex flex-col items-stretch">
-              <h1 className="p-3 bg-gray-100 text-xl text-center font-semibold">Indexes</h1>
-              <Divider />
-
-              <div
-                className="
-                  p-3 flex-grow flex-shrink h-0 overflow-auto
-                  flex flex-col items-stretch gap-3
-                "
-              >
-                {streamConfig.indexed_fields.map((field) => (
-                  <div key={field} className="flex flex-row items-stretch gap-3">
-                    <TextField
-                      label="Field"
-                      variant="outlined"
-                      type="text"
-                      value={field}
-                      onChange={(e) => {
-                        setStreamConfig((prev) => ({
-                          ...prev,
-                          indexed_fields: prev.indexed_fields.map((f) => f === field ? e.target.value : f),
-                        }))
-                      }}
-                      className="flex-grow"
-                    />
-
-                    <Button
-                      variant="contained"
-                      color="error"
-                      size="small"
-                      onClick={() => {
-                        setStreamConfig((prev) => ({
-                          ...prev,
-                          indexed_fields: prev.indexed_fields.filter((f) => f !== field),
-                        }))
-                      }}
-                    >
-                      <DeleteIcon />
-                    </Button>
-                  </div>
-                ))}
-
-                <div className="flex flex-row items-stretch gap-3">
-                  <TextField
-                    label="Field"
-                    variant="outlined"
-                    type="text"
-                    value={newField}
-                    onChange={(e) => {
-                      setNewField(e.target.value)
-                    }}
-                    className="flex-grow"
-                  />
-
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    size="small"
-                    onClick={() => {
-                      setStreamConfig((prev) => ({
-                        ...prev,
-                        indexed_fields: [...prev.indexed_fields, newField],
-                      }))
-                      setNewField('')
-                    }}
-                  >
-                    <AddIcon />
-                  </Button>
-                </div>
-              </div>
-            </Paper>
-          </div>
+          <StreamEditor
+            streamConfig={streamConfig}
+            onStreamConfigChange={setStreamConfig}
+          />
         </Grid>
       </Grid>
     </Box>


### PR DESCRIPTION
## Decision Record

Closes #108

## Changes

 - [x] :recycle: Move Stream and Alert editor out of the Stream and Alert views
 - [x] :lipstick: Add dialogs for Stream and Alert editor
 - [x] :lipstick: Add edit buttons for Streams and Alerts in Flow editor

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
