### PR TITLE
:bug: Link `vrl` cgo library with `math.h`

### DIFF
--- a/internal/utils/ffi/vrl/ffi.go
+++ b/internal/utils/ffi/vrl/ffi.go
@@ -1,7 +1,7 @@
 package vrl
 
 /*
-#cgo LDFLAGS: -L./rust-crate/target/release -lflowg_vrl
+#cgo LDFLAGS: -L./rust-crate/target/release -lflowg_vrl -lm
 #include <stdlib.h>
 
 typedef struct {


### PR DESCRIPTION
## Decision Record

When building in WSL, I get `undefined reference to` errors related to functions provided by `math.h` when Go is trying to link with the internal `vrl` static library.

## Changes

 - [x] :bug: Add `-lm` to `LDFLAGS` when building the `vrl` cgo library

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
