### PR TITLE
:recycle: Better offline backup for configuration storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /data/
+/backup/

--- a/cmd/flowg/admin_backup.go
+++ b/cmd/flowg/admin_backup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"link-society.com/flowg/internal/storage/auth"
+	"link-society.com/flowg/internal/storage/config"
 	"link-society.com/flowg/internal/storage/log"
 )
 
@@ -27,6 +28,7 @@ func NewAdminBackupCommand() *cobra.Command {
 		Use:   "backup",
 		Short: "Backup the database and configuration",
 		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Opening auth database...")
 			authStorage := auth.NewStorage(
 				auth.OptDirectory(opts.authDir),
 				auth.OptReadOnly(true),
@@ -40,6 +42,7 @@ func NewAdminBackupCommand() *cobra.Command {
 			}
 
 			defer func() {
+				fmt.Println("Closing auth database...")
 				authStorage.Stop()
 				err := authStorage.WaitStopped()
 				if err != nil {
@@ -48,6 +51,7 @@ func NewAdminBackupCommand() *cobra.Command {
 				}
 			}()
 
+			fmt.Println("Opening log database...")
 			logStorage := log.NewStorage(
 				log.OptDirectory(opts.logDir),
 				log.OptReadOnly(true),
@@ -61,6 +65,7 @@ func NewAdminBackupCommand() *cobra.Command {
 			}
 
 			defer func() {
+				fmt.Println("Closing log database...")
 				logStorage.Stop()
 				err := logStorage.WaitStopped()
 				if err != nil {
@@ -69,6 +74,29 @@ func NewAdminBackupCommand() *cobra.Command {
 				}
 			}()
 
+			fmt.Println("Opening config database...")
+			configStorage := config.NewStorage(
+				config.OptDirectory(opts.configDir),
+			)
+			configStorage.Start()
+			err = configStorage.WaitStarted()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "ERROR: Failed to open config database:", err)
+				exitCode = 1
+				return
+			}
+
+			defer func() {
+				fmt.Println("Closing config database...")
+				configStorage.Stop()
+				err := configStorage.WaitStopped()
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "ERROR: Failed to close config database:", err)
+					exitCode = 1
+				}
+			}()
+
+			fmt.Println("Preparing backup directory...")
 			err = os.MkdirAll(opts.backupDir, 0700)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "ERROR: Failed to create backup directory:", err)
@@ -76,6 +104,7 @@ func NewAdminBackupCommand() *cobra.Command {
 				return
 			}
 
+			fmt.Println("Backuping auth database...")
 			authBackupPath := filepath.Join(opts.backupDir, "auth.db")
 			authBackupOut, err := os.Create(authBackupPath)
 			if err != nil {
@@ -99,6 +128,7 @@ func NewAdminBackupCommand() *cobra.Command {
 				return
 			}
 
+			fmt.Println("Backuping log database...")
 			logBackupPath := filepath.Join(opts.backupDir, "log.db")
 			logBackupOut, err := os.Create(logBackupPath)
 			if err != nil {
@@ -122,15 +152,31 @@ func NewAdminBackupCommand() *cobra.Command {
 				return
 			}
 
-			err = os.CopyFS(
-				filepath.Join(opts.backupDir, "config"),
-				os.DirFS(opts.configDir),
-			)
+			fmt.Println("Backuping config database...")
+			configBackupPath := filepath.Join(opts.backupDir, "config.db")
+			configBackupOut, err := os.Create(configBackupPath)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "ERROR: Failed to backup config directory:", err)
+				fmt.Fprintln(os.Stderr, "ERROR: Failed to create backup file:", err)
 				exitCode = 1
 				return
 			}
+
+			defer func() {
+				err := configBackupOut.Close()
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "ERROR: Failed to close backup file:", err)
+					exitCode = 1
+				}
+			}()
+
+			err = configStorage.Backup(context.Background(), configBackupOut)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "ERROR: Failed to backup config database:", err)
+				exitCode = 1
+				return
+			}
+
+			fmt.Println("Backup complete.")
 		},
 	}
 

--- a/website/docs/guides/backup.md
+++ b/website/docs/guides/backup.md
@@ -21,7 +21,7 @@ This command will create the following files and directories:
 
  - `./backup/auth.db`: containing the full snapshot of the authentication database
  - `./backup/log.db`: containing the full snapshot of the logs database
- - `./backup/config/`: containing a copy of the configuration folder
+ - `./backup/config.db`: containing the full snapshot of the config database
 
 No write is ever done on the original databases.
 
@@ -35,11 +35,11 @@ flowg admin restore \
   --backup-dir ./backup
 ```
 
-This command will expect the following files and directories to exist:
+This command will expect the following files to exist:
 
  - `./backup/auth.db`: containing the full snapshot of the authentication database
  - `./backup/log.db`: containing the full snapshot of the logs database
- - `./backup/config/`: containing a copy of the configuration folder
+ - `./backup/config.db`: containing the full snapshot of the config database
 
 The content of the `auth.db` file will be inserted in the authentication database,
 overwriting pre-existing keys, but not deleting new ones.
@@ -47,8 +47,8 @@ overwriting pre-existing keys, but not deleting new ones.
 The content of the `log.db` file will be inserted in the logs database,
 overwriting pre-existing keys, but not deleting new ones.
 
-The content of the `config/` folder will be copied in the configuration folder,
-pre-existing files will be overwritten, but new ones won't be deleted.
+The content of the `config.db` file will be inserted in the config database,
+overwriting pre-existing items, but not deleting new ones.
 
 If you want a *destructive* restore (aka: remove new items that were not backed
 up), you need to remove the old database first:

--- a/website/docs/guides/backup.md
+++ b/website/docs/guides/backup.md
@@ -28,7 +28,7 @@ No write is ever done on the original databases.
 ## Performing an offline restore
 
 ```bash
-flow admin restore \
+flowg admin restore \
   --auth-dir ./data/auth \
   --config-dir ./data/config \
   --log-dir ./data/logs \
@@ -55,7 +55,7 @@ up), you need to remove the old database first:
 
 ```bash
 rm -rf ./data
-flow admin restore \
+flowg admin restore \
   --auth-dir ./data/auth \
   --config-dir ./data/config \
   --log-dir ./data/logs \


### PR DESCRIPTION
## Decision Record

Instead of copying the configuration folder into the backup directory, and then copying back the files one by one in the configuration storage during the restore; let's add `Backup()` and `Restore()` methods to the configuration storage so that:

 - its interface is the same as the auth storage and log storage interfaces
 - the CLI commands source code is easier to read
 - in the future, plugging in other `io.Writer` / `io.Reader` would allow backuping/restoring using other methods than the filesystem (like over a socket, or via the HTTP API)

## Changes

 - [x] :sparkles: `filestorage.Storage` interface now exposes a `StatFile()` method
 - [x] :sparkles: `config.Storage` interface now exposes a `Backup()` and `Restore()` method
 - [x] :recycle: Configuration backup/restore is done to/from a `tar.gz` archive
 - [x] :recycle: `flowg admin backup` and `flowg admin restore` commands use the new `config.Storage` `Backup()` and `Restore()` methods

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
