### PR TITLE
:package: Reduce executable size

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -89,7 +89,9 @@ jobs:
       - name: setup@upx
         if: ${{ matrix.goos != "darwin" }}
         run: |
-          wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}.tar.xz
+          curl -L --proto "=https" --tlsv1.2 -sSf \
+            https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-amd64_linux.tar.xz \
+            --output upx-5.0.0-amd64_linux.tar.xz \
           tar xvf upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}.tar.xz
           sudo cp upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}/upx /usr/local/bin/
 

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -86,6 +86,13 @@ jobs:
           toolchain: 1.85.0
           target: ${{ matrix.rstarget }}
 
+      - name: setup@upx
+        if: ${{ matrix.goos != "darwin" }}
+        run: |
+          wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}.tar.xz
+          tar xvf upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}.tar.xz
+          sudo cp upx-5.0.0-${{ matrix.goarch }}_${{ matrix.goos }}/upx /usr/local/bin/
+
       - name: frontend@build
         working-directory: ./web/app
         run: |
@@ -106,10 +113,14 @@ jobs:
         run: |
           go get ./...
           go generate ./...
-          go build -o bin/ ./...
+          go build -ldflags="-s -w" -o bin/ ./...
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+
+      - name: compress@binary
+        if: ${{ matrix.goos != "darwin" }}
+        run: upx bin/*
 
       - name: upload@binary
         run: |

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -82,10 +82,13 @@ RUN NODE_ENV="production" npm run build
 FROM golang:1.24-alpine3.21 AS builder-go
 ARG UPX_VERSION
 
-RUN apk add --no-cache gcc musl-dev wget
+RUN apk add --no-cache gcc musl-dev curl
 
 RUN set -ex && \
-    wget https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz && \
+    curl -L --proto "=https" --tlsv1.2 -sSf \
+        https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz \
+        --output upx-${UPX_VERSION}-amd64_linux.tar.xz \
+      && \
     tar -xvf upx-${UPX_VERSION}-amd64_linux.tar.xz && \
     mv upx-${UPX_VERSION}-amd64_linux/upx /usr/local/bin/ && \
     rm -rf upx-${UPX_VERSION}-amd64_linux.tar.xz upx-${UPX_VERSION}-amd64_linux


### PR DESCRIPTION
## Decision Record

At the moment, the binary that Go produces is quite big (around 50MB). It can be reduced using the `-ldflags="-s -w"` at compile-time, to strip the binary and gain a few MBs.

The tool [UPX](https://upx.github.io) can be used to compress the executable further and decompress it at runtime.

With both of those options, the `flowg-server` binary is now around 20MB, 60% less!

This lead to a smaller Docker image, and a smaller release archive.

## Changes

 - [x] :whale: Add UPX to Docker image to reduce binary size
 - [x] :whale: Make sure to only include `flow-server` in Docker image (more binaries might be added to the codebase)
 - [x] :construction_worker: Add UPX to `release-package` workflow

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
