### PR TITLE
:green_heart: :package: Fix release build

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: report@test
         uses: mikepenz/action-junit-report@v5
-        if: ${{ github.event_name == 'pull_request' && (success() || failure()) }}
+        if: ${{ github.event_name == 'pull_request_target' && (success() || failure()) }}
         with:
           report_paths: "./tests/reports/api/junit.xml"
           include_passed: true
@@ -130,33 +130,33 @@ jobs:
 
       - name: report@test
         uses: joonvena/robotframework-reporter-action@v2.5
-        if: ${{ github.event_name == 'pull_request' && (success() || failure()) }}
+        if: ${{ github.event_name == 'pull_request_target' && (success() || failure()) }}
         with:
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
           report_path: "./tests/reports/web/"
 
       - name: report-success@status
         uses: guibranco/github-status-action-v2@v1
-        if: ${{ github.event_name == 'pull_request' && success() }}
+        if: ${{ github.event_name == 'pull_request_target' && success() }}
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: 'Web End-To-End Test Report'
           description: 'Passed'
           state: 'success'
-          sha: ${{github.event.pull_request.head.sha }}
+          sha: ${{github.event.pull_request_target.head.sha }}
 
       - name: report-failure@status
         uses: guibranco/github-status-action-v2@v1
-        if: ${{ github.event_name == 'pull_request' && failure() }}
+        if: ${{ github.event_name == 'pull_request_target' && failure() }}
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: 'Web End-To-End Test Report'
           description: 'Failure'
           state: 'failure'
-          sha: ${{github.event.pull_request.head.sha }}
+          sha: ${{github.event.pull_request_target.head.sha }}
 
       - name: upload-logs@artifact
-        if: ${{ github.event_name == 'pull_request' && failure() }}
+        if: ${{ github.event_name == 'pull_request_target' && failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: web-e2e-reports
@@ -164,7 +164,7 @@ jobs:
           retention-days: 1
 
       - name: report@fail
-        if: ${{ github.event_name == 'pull_request' && failure() }}
+        if: ${{ github.event_name == 'pull_request_target' && failure() }}
         run: exit 1
 
   test-k8s:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,8 +16,12 @@ jobs:
         include:
           - ghrunner: ubuntu-latest
             docker_image_tag_suffix: ""
+            arch: "amd64"
+            os: "linux"
           - ghrunner: ubuntu-24.04-arm
             docker_image_tag_suffix: "-linux-arm"
+            arch: "arm64"
+            os: "linux"
 
     runs-on: ${{ matrix.ghrunner }}
 
@@ -39,6 +43,9 @@ jobs:
         with:
           context: .
           file: ./docker/flowg.dockerfile
+          build-args: |
+            UPX_ARCH=${{ matrix.arch }}
+            UPX_OS=${{ matrix.os }}
           tags: |
             linksociety/flowg:latest${{ matrix.docker_image_tag_suffix }}
             linksociety/flowg:${{ github.event.release.tag_name }}${{ matrix.docker_image_tag_suffix }}

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -83,6 +83,8 @@ RUN NODE_ENV="production" npm run build
 
 FROM golang:1.24-alpine3.21 AS builder-go
 ARG UPX_VERSION
+ARG UPX_ARCH
+ARG UPX_OS
 
 RUN apk add --no-cache gcc musl-dev curl
 

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.7-labs
 
-ARG UPX_VERSION="5.0.0"
+ARG UPX_VERSION="4.2.4"
+ARG UPX_ARCH="amd64"
+ARG UPX_OS="linux"
 
 ##############################
 ## SOURCES FILES
@@ -84,14 +86,11 @@ ARG UPX_VERSION
 
 RUN apk add --no-cache gcc musl-dev curl
 
+ADD https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${UPX_ARCH}_${UPX_OS}.tar.xz /tmp/upx.tar.xz
 RUN set -ex && \
-    curl -L --proto "=https" --tlsv1.2 -sSf \
-        https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz \
-        --output upx-${UPX_VERSION}-amd64_linux.tar.xz \
-      && \
-    tar -xvf upx-${UPX_VERSION}-amd64_linux.tar.xz && \
-    mv upx-${UPX_VERSION}-amd64_linux/upx /usr/local/bin/ && \
-    rm -rf upx-${UPX_VERSION}-amd64_linux.tar.xz upx-${UPX_VERSION}-amd64_linux
+    tar -xvf /tmp/upx.tar.xz && \
+    mv upx-${UPX_VERSION}-${UPX_ARCH}_${UPX_OS}/upx /usr/local/bin/ && \
+    rm -rf /tmp/upx.tar.xz upx-${UPX_VERSION}-${UPX_ARCH}_${UPX_OS}
 
 COPY --from=sources-go /src /workspace
 COPY --from=builder-rust-filterdsl /workspace/internal/utils/ffi/filterdsl/rust-crate/target/release/libflowg_filterdsl.a /workspace/internal/utils/ffi/filterdsl/rust-crate/target/release/libflowg_filterdsl.a


### PR DESCRIPTION
## Decision Record

The Dockerfile was explicitly downloading the `amd64-linux` version of UPX (introduced in #527), which obviously does not work for the `arm64-linux` version of the Docker image that is built for each release.

## Changes

 - [x] :whale: Parametrize via build arguments the UPX architecture and OS
 - [x] :green_heart: Update `release-package` workflow to pass the correct values to those build arguments

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
