### PR TITLE
:whale: add healthcheck in dockerfile

### DIFF
--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -146,5 +146,8 @@ ENV FLOWG_AUTH_DIR="/data/auth"
 ENV FLOWG_CONFIG_DIR="/data/config"
 ENV FLOWG_LOG_DIR="/data/logs"
 
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:9113/health || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["serve"]

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -111,7 +111,7 @@ RUN upx bin/flowg-server
 
 FROM alpine:3.21 AS runner
 
-RUN apk add --no-cache libgcc su-exec
+RUN apk add --no-cache libgcc su-exec curl
 
 COPY --from=builder-go /workspace/bin/flowg-server /usr/local/bin/flowg-server
 
@@ -146,7 +146,7 @@ ENV FLOWG_AUTH_DIR="/data/auth"
 ENV FLOWG_CONFIG_DIR="/data/config"
 ENV FLOWG_LOG_DIR="/data/logs"
 
-HEALTHCHECK --interval=5m --timeout=3s CMD curl -f http://localhost:9113/health || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:9113/health | grep -q OK || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["serve"]

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -146,8 +146,7 @@ ENV FLOWG_AUTH_DIR="/data/auth"
 ENV FLOWG_CONFIG_DIR="/data/config"
 ENV FLOWG_LOG_DIR="/data/logs"
 
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:9113/health || exit 1
+HEALTHCHECK --interval=5m --timeout=3s CMD curl -f http://localhost:9113/health || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["serve"]

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -111,7 +111,7 @@ RUN upx bin/flowg-server
 
 FROM alpine:3.21 AS runner
 
-RUN apk add --no-cache libgcc su-exec curl
+RUN apk add --no-cache curl libgcc su-exec
 
 COPY --from=builder-go /workspace/bin/flowg-server /usr/local/bin/flowg-server
 
@@ -146,7 +146,7 @@ ENV FLOWG_AUTH_DIR="/data/auth"
 ENV FLOWG_CONFIG_DIR="/data/config"
 ENV FLOWG_LOG_DIR="/data/logs"
 
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:9113/health | grep -q OK || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost${FLOWG_MGMT_BIND_ADDRESS}/health | grep -q OK || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["serve"]


### PR DESCRIPTION
## Decision Record

Current docker file does not have a health check.
It will be good to have it for alerts, error handling and add depends_on field to wait for dependencies to be healthy or running.

## Changes

This change will modify the docker file and add the health check feature.

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
