### PR TITLE
:whale: Add Healthcheck to Docker image

### DIFF
--- a/cmd/flowg-health/env.go
+++ b/cmd/flowg-health/env.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+var (
+	defaultMgmtBindAddress = getEnvString("FLOWG_MGMT_BIND_ADDRESS", ":9113")
+	defaultMgmtTlsEnabled  = getEnvBool("FLOWG_MGMT_TLS_ENABLED", false)
+)
+
+func getEnvString(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	stringVal := os.Getenv(key)
+	if stringVal == "" {
+		return defaultValue
+	}
+	value, err := strconv.ParseBool(stringVal)
+	if err == nil {
+		return value
+	}
+	return false
+}

--- a/cmd/flowg-health/main.go
+++ b/cmd/flowg-health/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"net"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/prometheus/procfs"
+)
+
+type options struct {
+	pid int
+}
+
+var exitCode int = 0
+
+func main() {
+	opts := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "flowg-health",
+		Short: "Healthcheck for FlowG",
+		Run: func(cmd *cobra.Command, args []string) {
+			proc, err := procfs.NewProc(opts.pid)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not retrieve process information: %v\n", err)
+				exitCode = 1
+				return
+			}
+
+			cmdline, err := proc.CmdLine()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not retrieve process command line: %v\n", err)
+				exitCode = 1
+				return
+			}
+
+			var mgmtBindAddress string
+			var mgmtTlsEnabled bool
+
+			flags := pflag.NewFlagSet("flowg-server", pflag.ContinueOnError)
+			flags.ParseErrorsWhitelist.UnknownFlags = true
+			flags.StringVar(&mgmtBindAddress, "mgmt-bind", defaultMgmtBindAddress, "")
+			flags.BoolVar(&mgmtTlsEnabled, "mgmt-tls", defaultMgmtTlsEnabled, "")
+
+			if err := flags.Parse(cmdline); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not parse command line: %v\n", err)
+				exitCode = 1
+				return
+			}
+
+			host, port, err := net.SplitHostPort(mgmtBindAddress)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not parse host and port: %v\n", err)
+				exitCode = 1
+				return
+			}
+
+			if host == "" || host == "0.0.0.0" {
+				host = "127.0.0.1"
+			}
+
+			var scheme string
+			if mgmtTlsEnabled {
+				scheme = "https"
+			} else {
+				scheme = "http"
+			}
+
+			url := fmt.Sprintf("%s://%s:%s/health", scheme, host, port)
+
+			resp, err := http.Get(url)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not send request: %v\n", err)
+				exitCode = 1
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				fmt.Fprintf(os.Stderr, "ERROR: Healthcheck failed with status code: %d\n", resp.StatusCode)
+				exitCode = 1
+				return
+			}
+
+			fmt.Println("OK")
+		},
+	}
+
+	cmd.Flags().IntVar(
+		&opts.pid,
+		"pid",
+		0,
+		"PID of the FlowG process to check",
+	)
+
+	if err := cmd.Execute(); err != nil {
+		exitCode = 1
+	}
+
+	os.Exit(exitCode)
+}

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -102,8 +102,8 @@ WORKDIR /workspace
 
 RUN go generate ./...
 RUN go test -timeout 500ms -v ./...
-RUN go build -ldflags="-s -w" -o bin/ ./cmd/flowg-server
-RUN upx bin/flowg-server
+RUN go build -ldflags="-s -w" -o bin/ ./...
+RUN upx bin/*
 
 ##############################
 ## FINAL ARTIFACT
@@ -114,6 +114,7 @@ FROM alpine:3.21 AS runner
 RUN apk add --no-cache libgcc su-exec
 
 COPY --from=builder-go /workspace/bin/flowg-server /usr/local/bin/flowg-server
+COPY --from=builder-go /workspace/bin/flowg-health /usr/local/bin/flowg-health
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod 0700 /docker-entrypoint.sh
@@ -147,4 +148,6 @@ ENV FLOWG_CONFIG_DIR="/data/config"
 ENV FLOWG_LOG_DIR="/data/logs"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["serve"]
+CMD []
+
+HEALTHCHECK --interval=5s --timeout=1s --retries=3 CMD ["/usr/local/bin/flowg-health", "--pid", "1"]

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/memberlist v0.5.3
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/prometheus/client_golang v1.21.1
+	github.com/prometheus/procfs v0.15.1
 	github.com/spf13/cobra v1.9.1
 	github.com/swaggest/openapi-go v0.2.57
 	github.com/swaggest/rest v0.2.73
@@ -50,7 +51,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
-	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v3 v3.1.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect


### PR DESCRIPTION
## Decision Record

See #545

Since the healthcheck endpoint can be customized via the CLI options or environment variables, we needed a `flowg-health` binary, which given a PID would parse the process's command line (via `/proc/${pid}/cmdline`) to extract the information (if present), and then would perform the HTTP request.

## Changes

 - [x] :heavy_plus_sign: Add direct dependency to `procfs`
 - [x] :sparkles: Add `flowg-health` binary to perform healthcheck against a `flowg-server` process
 - [x] :whale: Add `HEALTHCHECK` directive to Docker image

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
