### PR TITLE
:bug: Ensure Node IDs are always unique

### DIFF
--- a/internal/app/bootstrap/pipelines.go
+++ b/internal/app/bootstrap/pipelines.go
@@ -18,51 +18,54 @@ func DefaultPipeline(ctx context.Context, configStorage *config.Storage) error {
 			ctx,
 			"default",
 			`{
+				"version": 2,
 				"nodes": [
 					{
 						"id": "__builtin__source_direct",
 						"type": "source",
-						"position": {"x": 210, "y": 195},
-						"deletable": false,
-						"data": {"type": "direct"},
-						"measured": {"width": 136, "height": 38},
-						"selected": true,
-						"dragging": false
+						"position": {
+							"x": -45,
+							"y": 0
+						},
+						"data": {
+							"type": "direct"
+						}
 					},
 					{
 						"id": "__builtin__source_syslog",
 						"type": "source",
-						"position": {"x": 210, "y": 250},
-						"deletable": false,
-						"data": {"type": "syslog"},
-						"measured": {"width": 136, "height": 38},
-						"selected": true,
-						"dragging": false
+						"position": {
+							"x": -45,
+							"y": 120
+						},
+						"data": {
+							"type": "syslog"
+						}
 					},
 					{
-						"id": "node-1",
+						"id": "node-37da64b3-6243-4620-b0f2-ba484a71b053",
 						"type": "router",
-						"position": {"x": 405, "y": 195},
-						"data": {"stream": "default"},
-						"measured": {"width": 241,"height": 91},
-						"selected": false,
-						"dragging": false
+						"position": {
+							"x": 345,
+							"y": 60
+						},
+						"data": {
+							"stream": "default"
+						}
 					}
 				],
 				"edges": [
 					{
-						"id": "xy-edge____builtin__source_direct-node-1",
-						"type": "smoothstep",
-						"source": "__builtin__source_direct",
-						"target": "node-1",
-						"animated": true
+						"id": "xy-edge____builtin__source_syslog-node-37da64b3-6243-4620-b0f2-ba484a71b053",
+						"source": "__builtin__source_syslog",
+						"sourceHandle": "",
+						"target": "node-37da64b3-6243-4620-b0f2-ba484a71b053"
 					},
 					{
-						"id": "xy-edge____builtin__source_syslog-node-1",
-						"type": "smoothstep",
-						"source": "__builtin__source_syslog",
-						"target": "node-1",
-						"animated": true
+						"id": "xy-edge____builtin__source_direct-node-37da64b3-6243-4620-b0f2-ba484a71b053",
+						"source": "__builtin__source_direct",
+						"sourceHandle": "",
+						"target": "node-37da64b3-6243-4620-b0f2-ba484a71b053"
 					}
 				]
 			}`,

--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -23,7 +23,8 @@
         "react": "^19.1.0",
         "react-apexcharts": "^1.7.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.4.1"
+        "react-router": "^7.4.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.23.0",
@@ -32,6 +33,7 @@
         "@types/node": "^22.13.14",
         "@types/react": "^19.0.12",
         "@types/react-dom": "^19.0.4",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.23.0",
@@ -2680,6 +2682,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.28.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
@@ -4127,6 +4136,16 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/execa": {
@@ -6603,13 +6622,16 @@
       "peer": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -25,7 +25,8 @@
     "react": "^19.1.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.4.1"
+    "react-router": "^7.4.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
@@ -34,6 +35,7 @@
     "@types/node": "^22.13.14",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",

--- a/web/app/src/components/editors/pipeline/flow-editor.tsx
+++ b/web/app/src/components/editors/pipeline/flow-editor.tsx
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid'
+
 import React, {
   DragEventHandler,
   useCallback,
@@ -147,7 +149,7 @@ export const FlowEditor: React.FC<FlowEditorProps> = ({
 
       setNodes((nds) => {
         const newNode = {
-          id: `node-${nds.length}`,
+          id: `node-${uuidv4()}`,
           type,
           position,
           data: {},


### PR DESCRIPTION
## Decision Record

When we add a node to the pipeline, we need to generate an ID that should be unique.

Until now, the generated ID was of the form `node-${nodes.length}`. This is fine if you never remove nodes. But once you start removing nodes, you end up with conflicting IDs. This results in a glitch in the editor where nodes with conflicting IDs can disappear:

![bug-flowg-node-glitch](https://github.com/user-attachments/assets/9e69c6d3-2cb4-48c2-8d77-2b15f066e14a)

To fix that, we use an UUIDv4 to ensure that nodes always have a unique ID (honestly, this should have been done from the start, I don't know what I was thinking).

> **NB:** This is a non-breaking change, existing pipelines who used the old IDs will still work.

## Changes

 - [x] :heavy_plus_sign: Add uuid
 - [x] :bug: Use UUIDv4 to generate truly unique IDs
 - [x] :wrench: Update bootstrapped pipeline

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
