### PR TITLE
:boom: :recycle: Uniformize token formats

### DIFF
--- a/internal/utils/api/middleware.go
+++ b/internal/utils/api/middleware.go
@@ -52,7 +52,7 @@ func ApiMiddleware(authStorage *auth.Storage) func(http.Handler) http.Handler {
 
 			switch {
 			case strings.HasPrefix(strings.ToLower(authHeader), "bearer pat_"):
-				token := authHeader[len("bearer pat_"):]
+				token := authHeader[len("bearer "):]
 
 				user, err := authStorage.VerifyToken(r.Context(), token)
 				switch {
@@ -67,7 +67,7 @@ func ApiMiddleware(authStorage *auth.Storage) func(http.Handler) http.Handler {
 				}
 
 			case strings.HasPrefix(strings.ToLower(authHeader), "bearer jwt_"):
-				token := authHeader[len("bearer jwt_"):]
+				token := authHeader[len("bearer "):]
 
 				username, err := authUtils.VerifyJWT(token)
 				if err != nil {

--- a/internal/utils/api/middleware.go
+++ b/internal/utils/api/middleware.go
@@ -51,8 +51,8 @@ func ApiMiddleware(authStorage *auth.Storage) func(http.Handler) http.Handler {
 			authHeader := r.Header.Get("Authorization")
 
 			switch {
-			case strings.HasPrefix(strings.ToLower(authHeader), "bearer pat:"):
-				token := authHeader[len("bearer pat:"):]
+			case strings.HasPrefix(strings.ToLower(authHeader), "bearer pat_"):
+				token := authHeader[len("bearer pat_"):]
 
 				user, err := authStorage.VerifyToken(r.Context(), token)
 				switch {
@@ -66,8 +66,8 @@ func ApiMiddleware(authStorage *auth.Storage) func(http.Handler) http.Handler {
 					serveNext(w, r, user)
 				}
 
-			case strings.HasPrefix(strings.ToLower(authHeader), "bearer jwt:"):
-				token := authHeader[len("bearer jwt:"):]
+			case strings.HasPrefix(strings.ToLower(authHeader), "bearer jwt_"):
+				token := authHeader[len("bearer jwt_"):]
 
 				username, err := authUtils.VerifyJWT(token)
 				if err != nil {

--- a/internal/utils/auth/jwt.go
+++ b/internal/utils/auth/jwt.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+
 	"os"
 	"time"
 
@@ -29,7 +30,13 @@ func NewJWT(username string) (string, error) {
 		"sub": username,
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 	})
-	return t.SignedString([]byte(JWT_SIGNING_KEY))
+
+	tok, err := t.SignedString([]byte(JWT_SIGNING_KEY))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+
+	return fmt.Sprintf("jwt_%s", tok), nil
 }
 
 func VerifyJWT(token string) (string, error) {

--- a/internal/utils/auth/jwt.go
+++ b/internal/utils/auth/jwt.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"os"
 	"time"
@@ -40,6 +41,11 @@ func NewJWT(username string) (string, error) {
 }
 
 func VerifyJWT(token string) (string, error) {
+	if !strings.HasPrefix(token, "jwt_") {
+		return "", fmt.Errorf("invalid token prefix")
+	}
+	token = token[len("jwt_"):]
+
 	t, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
 		return []byte(JWT_SIGNING_KEY), nil
 	})

--- a/tests/specs/api/acl_roles.hurl
+++ b/tests/specs/api/acl_roles.hurl
@@ -1,5 +1,5 @@
 GET http://localhost:5080/api/v1/roles
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -7,7 +7,7 @@ jsonpath "$.roles" count == 1
 jsonpath "$.roles[*].name" includes "admin"
 
 PUT http://localhost:5080/api/v1/roles/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "scopes": [
@@ -19,7 +19,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/roles
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -27,11 +27,11 @@ jsonpath "$.roles" count == 2
 jsonpath "$.roles[*].name" includes "test"
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 PUT http://localhost:5080/api/v1/users/guest
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "password": "guest",
@@ -42,11 +42,11 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 200
 
 PUT http://localhost:5080/api/v1/users/guest
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "password": "guest",
@@ -57,17 +57,17 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 DELETE http://localhost:5080/api/v1/roles/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/roles
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true

--- a/tests/specs/api/acl_tokens.hurl
+++ b/tests/specs/api/acl_tokens.hurl
@@ -1,12 +1,12 @@
 GET http://localhost:5080/api/v1/tokens
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.token_uuids" count == 1
 
 POST http://localhost:5080/api/v1/token
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Captures]
 new_admin_token: jsonpath "$.token"
@@ -15,7 +15,7 @@ new_admin_token_uuid: jsonpath "$.token_uuid"
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/tokens
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -23,18 +23,18 @@ jsonpath "$.token_uuids" count == 2
 jsonpath "$.token_uuids" includes "{{new_admin_token_uuid}}"
 
 GET http://localhost:5080/api/v1/auth/whoami
-Authorization: Bearer pat:{{new_admin_token}}
+Authorization: Bearer {{new_admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.user.name" == "root"
 
 DELETE http://localhost:5080/api/v1/tokens/{{new_admin_token_uuid}}
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/auth/whoami
-Authorization: Bearer pat:{{new_admin_token}}
+Authorization: Bearer {{new_admin_token}}
 HTTP 401

--- a/tests/specs/api/acl_users.hurl
+++ b/tests/specs/api/acl_users.hurl
@@ -1,5 +1,5 @@
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -11,7 +11,7 @@ jsonpath "$..users[?(@.name == 'root')].roles[*]" includes "admin"
 jsonpath "$.users[?(@.name == 'guest')].roles[*]" count == 0
 
 PUT http://localhost:5080/api/v1/users/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "password": "test",
@@ -22,7 +22,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -30,11 +30,11 @@ jsonpath "$.users" count == 3
 jsonpath "$.users[*].name" includes "test"
 
 DELETE http://localhost:5080/api/v1/users/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true

--- a/tests/specs/api/auth.hurl
+++ b/tests/specs/api/auth.hurl
@@ -2,14 +2,14 @@ GET http://localhost:5080/api/v1/auth/whoami
 HTTP 401
 
 GET http://localhost:5080/api/v1/auth/whoami
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.user.name" == "root"
 
 GET http://localhost:5080/api/v1/auth/whoami
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -28,14 +28,14 @@ jwt: jsonpath "$.token"
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/auth/whoami
-Authorization: Bearer jwt:{{jwt}}
+Authorization: Bearer {{jwt}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.user.name" == "root"
 
 POST http://localhost:5080/api/v1/auth/change-password
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 Content-Type: application/json
 {
   "old_password": "guest",

--- a/tests/specs/api/backup.hurl
+++ b/tests/specs/api/backup.hurl
@@ -1,35 +1,35 @@
 GET http://localhost:5080/api/v1/backup/auth
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Options]
 output: backup/auth.db
 HTTP 200
 
 GET http://localhost:5080/api/v1/backup/config
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Options]
 output: backup/config.db
 HTTP 200
 
 GET http://localhost:5080/api/v1/backup/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Options]
 output: backup/logs.db
 HTTP 200
 
 POST http://localhost:5080/api/v1/restore/auth
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Multipart]
 backup: file,backup/auth.db;
 HTTP 200
 
 POST http://localhost:5080/api/v1/restore/config
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Multipart]
 backup: file,backup/config.db;
 HTTP 200
 
 POST http://localhost:5080/api/v1/restore/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [Multipart]
 backup: file,backup/logs.db;
 HTTP 200

--- a/tests/specs/api/forwarders.hurl
+++ b/tests/specs/api/forwarders.hurl
@@ -1,16 +1,16 @@
 GET http://localhost:5080/api/v1/forwarders
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.forwarders" count == 0
 
 GET http://localhost:5080/api/v1/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404
 
 PUT http://localhost:5080/api/v1/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "forwarder": {
@@ -28,7 +28,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/forwarders
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -36,7 +36,7 @@ jsonpath "$.forwarders" count == 1
 jsonpath "$.forwarders[0]" == "httpbin"
 
 GET http://localhost:5080/api/v1/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -45,7 +45,7 @@ jsonpath "$.forwarder.config.url" == "http://httpbin.org/anything"
 jsonpath "$.forwarder.config.headers.Foo" == "Bar"
 
 POST http://localhost:5080/api/v1/test/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "record": {
@@ -57,17 +57,17 @@ HTTP 200
 jsonpath "$.success" == true
 
 DELETE http://localhost:5080/api/v1/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/forwarders/httpbin
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404
 
 PUT http://localhost:5080/api/v1/forwarders/fail
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "forwarder": {
@@ -85,7 +85,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 POST http://localhost:5080/api/v1/test/forwarders/fail
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "record": {
@@ -95,7 +95,7 @@ Content-Type: application/json
 HTTP 500
 
 DELETE http://localhost:5080/api/v1/forwarders/fail
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true

--- a/tests/specs/api/permissions.hurl
+++ b/tests/specs/api/permissions.hurl
@@ -2,64 +2,64 @@ GET http://localhost:5080/api/v1/streams
 HTTP 401
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 GET http://localhost:5080/api/v1/transformers
 HTTP 401
 
 GET http://localhost:5080/api/v1/transformers
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/transformers
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 GET http://localhost:5080/api/v1/pipelines
 HTTP 401
 
 GET http://localhost:5080/api/v1/pipelines
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/pipelines
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 GET http://localhost:5080/api/v1/forwarders
 HTTP 401
 
 GET http://localhost:5080/api/v1/forwarders
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/forwarders
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 GET http://localhost:5080/api/v1/users
 HTTP 401
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/users
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403
 
 GET http://localhost:5080/api/v1/roles
 HTTP 401
 
 GET http://localhost:5080/api/v1/roles
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 
 GET http://localhost:5080/api/v1/roles
-Authorization: Bearer pat:{{guest_token}}
+Authorization: Bearer {{guest_token}}
 HTTP 403

--- a/tests/specs/api/pipelines.hurl
+++ b/tests/specs/api/pipelines.hurl
@@ -1,5 +1,5 @@
 GET http://localhost:5080/api/v1/pipelines
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -7,18 +7,18 @@ jsonpath "$.pipelines" count == 1
 jsonpath "$.pipelines[0]" == "default"
 
 GET http://localhost:5080/api/v1/pipelines/default
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.flow" exists
 
 GET http://localhost:5080/api/v1/pipelines/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404
 
 PUT http://localhost:5080/api/v1/pipelines/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "flow": {
@@ -76,7 +76,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/pipelines
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -85,7 +85,7 @@ jsonpath "$.pipelines" includes "default"
 jsonpath "$.pipelines" includes "test"
 
 POST http://localhost:5080/api/v1/pipelines/test/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "record": {
@@ -96,7 +96,7 @@ Content-Type: application/json
 HTTP 200
 
 GET http://localhost:5080/api/v1/streams/test/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [QueryStringParams]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
@@ -109,23 +109,23 @@ jsonpath "$.records[0].fields.level" == "info"
 jsonpath "$.records[0].fields.message" == "test"
 
 DELETE http://localhost:5080/api/v1/streams/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 DELETE http://localhost:5080/api/v1/pipelines/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/pipelines/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404
 
 GET http://localhost:5080/api/v1/pipelines
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true

--- a/tests/specs/api/retention.hurl
+++ b/tests/specs/api/retention.hurl
@@ -1,5 +1,5 @@
 PUT http://localhost:5080/api/v1/streams/default
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "config": {
@@ -14,7 +14,7 @@ jsonpath "$.success" == true
 
 
 POST http://localhost:5080/api/v1/pipelines/default/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "record": {
@@ -25,7 +25,7 @@ Content-Type: application/json
 HTTP 200
 
 GET http://localhost:5080/api/v1/streams/default/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [QueryStringParams]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
@@ -38,7 +38,7 @@ jsonpath "$.records[0].fields.level" == "info"
 jsonpath "$.records[0].fields.message" == "Hello, World!"
 
 GET http://localhost:5080/api/v1/streams/default/logs
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 [QueryStringParams]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
@@ -51,5 +51,5 @@ jsonpath "$.success" == true
 jsonpath "$.records" count == 0
 
 DELETE http://localhost:5080/api/v1/streams/default
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200

--- a/tests/specs/api/streams.hurl
+++ b/tests/specs/api/streams.hurl
@@ -1,12 +1,12 @@
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.streams" isEmpty
 
 PUT http://localhost:5080/api/v1/streams/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "config": {
@@ -20,7 +20,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -31,7 +31,7 @@ jsonpath "$.streams.test.ttl" == 3600
 jsonpath "$.streams.test.size" == 1024
 
 GET http://localhost:5080/api/v1/streams/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -41,7 +41,7 @@ jsonpath "$.config.ttl" == 3600
 jsonpath "$.config.size" == 1024
 
 GET http://localhost:5080/api/v1/streams/test_getorcreate
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -50,7 +50,7 @@ jsonpath "$.config.ttl" == 0
 jsonpath "$.config.size" == 0
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -58,13 +58,13 @@ jsonpath "$.streams.test" exists
 jsonpath "$.streams.test_getorcreate" exists
 
 DELETE http://localhost:5080/api/v1/streams/test_getorcreate
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -72,13 +72,13 @@ jsonpath "$.streams.test" exists
 jsonpath "$.streams.test_getorcreate" not exists
 
 DELETE http://localhost:5080/api/v1/streams/test
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/streams
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true

--- a/tests/specs/api/transformers.hurl
+++ b/tests/specs/api/transformers.hurl
@@ -1,5 +1,5 @@
 POST http://localhost:5080/api/v1/test/transformer
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "code": ". = parse_logfmt!(.message)",
@@ -14,18 +14,18 @@ jsonpath "$.record.level" == "info"
 jsonpath "$.record.message" == "foo bar"
 
 GET http://localhost:5080/api/v1/transformers
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.transformers" count == 0
 
 GET http://localhost:5080/api/v1/transformers/logfmt
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404
 
 PUT http://localhost:5080/api/v1/transformers/logfmt
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 Content-Type: application/json
 {
   "script": ". = parse_logfmt!(.message)"
@@ -35,7 +35,7 @@ HTTP 200
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/transformers
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
@@ -43,17 +43,17 @@ jsonpath "$.transformers" count == 1
 jsonpath "$.transformers[0]" == "logfmt"
 
 GET http://localhost:5080/api/v1/transformers/logfmt
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 DELETE http://localhost:5080/api/v1/transformers/logfmt
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 
 GET http://localhost:5080/api/v1/transformers/logfmt
-Authorization: Bearer pat:{{admin_token}}
+Authorization: Bearer {{admin_token}}
 HTTP 404

--- a/tests/specs/web/account.robot
+++ b/tests/specs/web/account.robot
@@ -24,11 +24,11 @@ Create and Delete Personal Access Token
     Wait Until Page Contains       Token created  timeout=5s
     Element Should Not Be Visible  id=input:account.tokens.modal.token_uuid
     Wait Until Page Contains       ${token_uuid}  timeout=5s
-    API GET                        path=/api/v1/auth/whoami  token=pat:${token}  expected_status=200
+    API GET                        path=/api/v1/auth/whoami  token=${token}  expected_status=200
     Remove Row                     table=table:account.tokens  row=${token_uuid}
     Wait Until Page Contains       Token deleted  timeout=5s
     Row Should Not Be Visible      table=table:account.tokens  row=${token_uuid}
-    API GET                        path=/api/v1/auth/whoami  token=pat:${token}  expected_status=401
+    API GET                        path=/api/v1/auth/whoami  token=${token}  expected_status=401
     Close Browser
 
 Change Password

--- a/tests/specs/web/resources/logging.resource
+++ b/tests/specs/web/resources/logging.resource
@@ -12,7 +12,7 @@ Send log via API
     [Arguments]                      ${message}
     ${token}=    Get JSON Web Token  username=root  password=root
     ${payload}=  Evaluate            {"record": {"appname": "robotframework", "message": "${message}"}}
-    API POST                         path=/api/v1/pipelines/default/logs  token=jwt:${token}  body=${payload}  expected_status=200
+    API POST                         path=/api/v1/pipelines/default/logs  token=${token}  body=${payload}  expected_status=200
 
 Send log via Syslog (RFC 5424)
     [Arguments]              ${message}

--- a/tests/src/benchmark/conftest.py
+++ b/tests/src/benchmark/conftest.py
@@ -93,7 +93,7 @@ def flowg_config(flowg_admin_token, spec_dir):
 
             resp = requests.put(
                 f"http://localhost:5080/api/v1/pipelines/{pipeline_name}",
-                headers={"Authorization": f"Bearer pat:{flowg_admin_token}"},
+                headers={"Authorization": f"Bearer {flowg_admin_token}"},
                 json={"flow": pipeline},
             )
             resp.raise_for_status()
@@ -108,7 +108,7 @@ def flowg_config(flowg_admin_token, spec_dir):
 
             resp = requests.put(
                 f"http://localhost:5080/api/v1/transformers/{transformer_name}",
-                headers={"Authorization": f"Bearer pat:{flowg_admin_token}"},
+                headers={"Authorization": f"Bearer {flowg_admin_token}"},
                 json={"script": transformer},
             )
             resp.raise_for_status()

--- a/tests/src/benchmark/utils.py
+++ b/tests/src/benchmark/utils.py
@@ -19,7 +19,7 @@ def send_log(token, log):
         data=payload,
         headers={
             "Content-Type": "application/json",
-            "Authorization": f"Bearer pat:{token}",
+            "Authorization": f"Bearer {token}",
         },
     )
     resp.raise_for_status()

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -265,7 +265,7 @@ def flowg_admin_token(flowg_cluster):
 
     resp = requests.post(
         "http://localhost:5080/api/v1/token",
-        headers={"Authorization": f"Bearer jwt:{admin_jwt}"},
+        headers={"Authorization": f"Bearer {admin_jwt}"},
     )
     resp.raise_for_status()
     data = resp.json()
@@ -277,7 +277,7 @@ def flowg_guest_token(flowg_admin_token):
     print("Creating guest token")
     resp = requests.put(
         "http://localhost:5080/api/v1/users/guest",
-        headers={"Authorization": f"Bearer pat:{flowg_admin_token}"},
+        headers={"Authorization": f"Bearer {flowg_admin_token}"},
         json={"password": "guest", "roles": []},
     )
     resp.raise_for_status()
@@ -292,7 +292,7 @@ def flowg_guest_token(flowg_admin_token):
 
     resp = requests.post(
         "http://localhost:5080/api/v1/token",
-        headers={"Authorization": f"Bearer jwt:{guest_jwt}"},
+        headers={"Authorization": f"Bearer {guest_jwt}"},
     )
     resp.raise_for_status()
     data = resp.json()

--- a/web/app/src/lib/api/request.ts
+++ b/web/app/src/lib/api/request.ts
@@ -28,7 +28,7 @@ const request = async <B, R extends { success: boolean }>(
 
   const token = localStorage.getItem('token')
   if (token !== null) {
-    authHeader = `Bearer jwt:${token}`
+    authHeader = `Bearer ${token}`
   }
 
   const response = await fetch(`${path}?${searchParams?.toString() ?? ''}`, {
@@ -109,7 +109,7 @@ export const SSE = (options: RequestOptions<never>) => {
     {
       maxRetryCount: 0,
       headers: {
-        Authorization: `Bearer jwt:${localStorage.getItem('token')}`,
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
     }
   )

--- a/website/docs/guides/backup.md
+++ b/website/docs/guides/backup.md
@@ -12,17 +12,17 @@ Using a Personal Access Token:
 export FLOWG_TOKEN="<your token>"
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/auth \
   --output auth.db
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/config \
   --output config.db
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/logs \
   --output logs.db
 ```
@@ -40,17 +40,17 @@ export FLOWG_TOKEN=$(
 )
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/auth \
   --output auth.db
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/config \
   --output config.db
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/backup/logs \
   --output logs.db
 ```
@@ -70,17 +70,17 @@ Using a Personal Access Token:
 export FLOWG_TOKEN="<your token>"
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/auth \
   -X POST --form backup=auth.db
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/config \
   -X POST --form backup=config.db
 
 curl \
-  -H "Authorization: Bearer pat:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/logs \
   -X POST --form backup=logs.db
 ```
@@ -98,17 +98,17 @@ export FLOWG_TOKEN=$(
 )
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/auth \
   -X POST --form backup=auth.db
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/config \
   -X POST --form backup=config.db
 
 curl \
-  -H "Authorization: Bearer jwt:${FLOWG_TOKEN}" \
+  -H "Authorization: Bearer ${FLOWG_TOKEN}" \
   http://localhost:5080/api/v1/restore/logs \
   -X POST --form backup=logs.db
 ```

--- a/website/docs/usecases/uptime-kuma.mdx
+++ b/website/docs/usecases/uptime-kuma.mdx
@@ -61,7 +61,7 @@ Then, enable the additional headers and type in the following:
 ```json
 {
   "Content-Type": "application/json",
-  "Authorization": "Bearer pat:YOUR-PERSONAL-ACCESS-TOKEN"
+  "Authorization": "Bearer YOUR-PERSONAL-ACCESS-TOKEN"
 }
 ```
 


### PR DESCRIPTION
## Decision Record

Personal Access Tokens were generated with the `pat_` prefix.
JSON Web Tokens had no prefix.

In both cases, to authenticate against the API, the `Authorization` header required the prefix `Bearer pat:` or `Bearer jwt:`.

Therefore, for a Personal Access Token, you had to write:

```
Authorization: Bearer pat:pat_...
```

Which is redundant.

Instead, let's remove the `pat:` and `jwt:` prefixes from the HTTP header, and add the `jwt_` prefix to JSON Web Tokens.

## Changes

 - [x] :recycle: Remove `pat:` and `jwt:` prefixes when parsing `Authorization` header
 - [x] :recycle: Add `jwt_` prefix when generating a JSON Web Token
 - [x] :white_check_mark: Update test suite
 - [x] :memo: Update documentation

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
