### PR TITLE
:bug: Handle GZIP encoded OTLP requests

### DIFF
--- a/internal/app/logging/main.go
+++ b/internal/app/logging/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 )
 
+var VERBOSE_LOGGING = false
+
 func Setup(verbose bool) {
 	var level slog.Level
 	if verbose {
@@ -14,6 +16,7 @@ func Setup(verbose bool) {
 		level = slog.LevelInfo
 	}
 
+	VERBOSE_LOGGING = verbose
 	opts := &slog.HandlerOptions{Level: level}
 	slog.SetDefault(slog.New(newHandler(os.Stdout, opts)))
 }

--- a/internal/app/logging/middleware.go
+++ b/internal/app/logging/middleware.go
@@ -63,7 +63,10 @@ func (w *responseWriter) Header() http.Header {
 }
 
 func (w *responseWriter) Write(b []byte) (int, error) {
-	w.buf.Write(b)
+	if VERBOSE_LOGGING {
+		w.buf.Write(b)
+	}
+
 	return w.parent.Write(b)
 }
 
@@ -78,9 +81,8 @@ func (w *responseWriter) Flush() {
 		fmt.Fprintf(os.Stderr, "---begin: %s---\n", correlationId)
 		fmt.Fprintln(os.Stderr, w.buf.String())
 		fmt.Fprintf(os.Stderr, "---end: %s---\n", correlationId)
+		w.buf.Reset()
 	}
-
-	w.buf.Reset()
 
 	if f, ok := w.parent.(http.Flusher); ok {
 		f.Flush()

--- a/internal/models/logrecord.go
+++ b/internal/models/logrecord.go
@@ -2,10 +2,13 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	otlpmodels "go.opentelemetry.io/proto/otlp/logs/v1"
+
+	otlpcommonmodels "go.opentelemetry.io/proto/otlp/common/v1"
+	otlplogmodels "go.opentelemetry.io/proto/otlp/logs/v1"
 )
 
 type LogRecord struct {
@@ -20,11 +23,11 @@ func NewLogRecord(fields map[string]string) *LogRecord {
 	}
 }
 
-func NewFromOTLP(logRecord *otlpmodels.LogRecord) *LogRecord {
+func NewFromOTLP(logRecord *otlplogmodels.LogRecord) *LogRecord {
 	fields := map[string]string{
 		"severity_number":          logRecord.SeverityNumber.String(),
 		"severity_text":            logRecord.SeverityText,
-		"body":                     logRecord.Body.String(),
+		"body":                     otlpValueParser(logRecord.Body),
 		"dropped_attributes_count": fmt.Sprintf("%d", logRecord.DroppedAttributesCount),
 		"flags":                    fmt.Sprintf("%d", logRecord.Flags),
 		"trace_id":                 fmt.Sprintf("%x", logRecord.TraceId),
@@ -35,8 +38,7 @@ func NewFromOTLP(logRecord *otlpmodels.LogRecord) *LogRecord {
 	}
 	for _, attribute := range logRecord.Attributes {
 		fieldName := fmt.Sprintf("attr.%s", attribute.Key)
-		fieldValue := attribute.Value.String()
-		fields[fieldName] = fieldValue
+		fields[fieldName] = otlpValueParser(attribute.Value)
 	}
 
 	return &LogRecord{
@@ -52,4 +54,40 @@ func (e *LogRecord) NewDbKey(stream string) []byte {
 		e.Timestamp.UnixMilli(),
 		uuid.New().String(),
 	))
+}
+
+func otlpValueParser(v *otlpcommonmodels.AnyValue) string {
+	switch v.Value.(type) {
+	case *otlpcommonmodels.AnyValue_StringValue:
+		return v.GetStringValue()
+	case *otlpcommonmodels.AnyValue_BoolValue:
+		return fmt.Sprintf("%t", v.GetBoolValue())
+	case *otlpcommonmodels.AnyValue_IntValue:
+		return fmt.Sprintf("%d", v.GetIntValue())
+	case *otlpcommonmodels.AnyValue_DoubleValue:
+		return fmt.Sprintf("%f", v.GetDoubleValue())
+	case *otlpcommonmodels.AnyValue_ArrayValue:
+		items := make([]string, 0, len(v.GetArrayValue().Values))
+
+		for i, item := range v.GetArrayValue().Values {
+			items[i] = otlpValueParser(item)
+		}
+
+		return fmt.Sprintf("[%s]", strings.Join(items, " "))
+
+	case *otlpcommonmodels.AnyValue_KvlistValue:
+		items := make([]string, 0, len(v.GetKvlistValue().Values))
+
+		for i, item := range v.GetKvlistValue().Values {
+			items[i] = fmt.Sprintf("%s:%s", item.Key, otlpValueParser(item.Value))
+		}
+
+		return fmt.Sprintf("map[%s]", strings.Join(items, " "))
+
+	case *otlpcommonmodels.AnyValue_BytesValue:
+		return fmt.Sprintf("%v", v.GetBytesValue())
+
+	default:
+		return v.String()
+	}
 }


### PR DESCRIPTION
## Decision Record

Traefik sends OTLP requests with the `Content-Encoding` set to `gzip`, which we did not handle.

On top of that, the `AnyValue` model was not parsed correctly, and we were getting columns like `string_value:"hello"` instead of `hello`.

## Changes

 - [x] :loud_sound: Log HTTP response to `stderr` when status code is not successful and verbose mode is enabled
 - [x] :bug: Decode GZIP encoded requests on OpenTelemetry endpoint
 - [x] :bug: Parse correctly OTLP `AnyValue`

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
