### PR TITLE
:white_check_mark: :bug: Teardown container if healthcheck fails

### DIFF
--- a/tests/pdm.lock
+++ b/tests/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a990f6bbbfebf552dceda612b2e197e9093c44ca32c40ef6940b4af56bad1625"
+content_hash = "sha256:211be377ddd63f63417b1e9979bc23d4e48fdd583a98a860d6974de9a2add905"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"
@@ -134,13 +134,13 @@ summary = ""
 groups = ["dev"]
 dependencies = [
     "docker>=7.1.0",
+    "opentelemetry-proto>=1.32.1",
     "pytest>=8.3.5",
     "requests>=2.32.3",
     "robotframework-dependencylibrary>=4.0.1",
     "robotframework-requests>=0.9.7",
     "robotframework-seleniumlibrary>=6.3.0",
     "robotframework>=7.2.2",
-    "tenacity>=9.0.0",
     "tqdm>=4.67.1",
 ]
 
@@ -185,7 +185,7 @@ name = "opentelemetry-proto"
 version = "1.32.1"
 requires_python = ">=3.8"
 summary = "OpenTelemetry Python Proto"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "protobuf<6.0,>=5.0",
 ]
@@ -235,7 +235,7 @@ name = "protobuf"
 version = "5.29.4"
 requires_python = ">=3.8"
 summary = ""
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "protobuf-5.29.4-cp310-abi3-win32.whl", hash = "sha256:13eb236f8eb9ec34e63fc8b1d6efd2777d062fa6aaa68268fb67cf77f6839ad7"},
     {file = "protobuf-5.29.4-cp310-abi3-win_amd64.whl", hash = "sha256:bcefcdf3976233f8a502d265eb65ea740c989bacc6c30a58290ed0e519eb4b8d"},
@@ -421,17 +421,6 @@ groups = ["default", "dev"]
 files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
-]
-
-[[package]]
-name = "tenacity"
-version = "9.0.0"
-requires_python = ">=3.8"
-summary = "Retry code until it succeeds"
-groups = ["default", "dev"]
-files = [
-    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
-    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
 ]
 
 [[package]]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.0.0"
 dependencies = [
     "docker>=7.1.0",
     "requests>=2.32.3",
-    "tenacity>=9.0.0",
     "tqdm>=4.67.1",
     "robotframework>=7.2.2",
     "robotframework-dependencylibrary>=4.0.1",

--- a/tests/specs/api/acl_roles.hurl
+++ b/tests/specs/api/acl_roles.hurl
@@ -4,7 +4,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.roles" count == 1
-jsonpath "$.roles[*].name" includes "admin"
+jsonpath "$.roles[*].name" contains "admin"
 
 PUT http://localhost:5080/api/v1/roles/test
 Authorization: Bearer {{admin_token}}
@@ -24,7 +24,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.roles" count == 2
-jsonpath "$.roles[*].name" includes "test"
+jsonpath "$.roles[*].name" contains "test"
 
 GET http://localhost:5080/api/v1/users
 Authorization: Bearer {{guest_token}}
@@ -72,4 +72,4 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.roles" count == 1
-jsonpath "$.roles[*].name" not includes "test"
+jsonpath "$.roles[*].name" not contains "test"

--- a/tests/specs/api/acl_tokens.hurl
+++ b/tests/specs/api/acl_tokens.hurl
@@ -20,7 +20,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.token_uuids" count == 2
-jsonpath "$.token_uuids" includes "{{new_admin_token_uuid}}"
+jsonpath "$.token_uuids" contains "{{new_admin_token_uuid}}"
 
 GET http://localhost:5080/api/v1/auth/whoami
 Authorization: Bearer {{new_admin_token}}

--- a/tests/specs/api/acl_users.hurl
+++ b/tests/specs/api/acl_users.hurl
@@ -4,10 +4,10 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.users" count == 2
-jsonpath "$.users[*].name" includes "root"
-jsonpath "$.users[*].name" includes "guest"
+jsonpath "$.users[*].name" contains "root"
+jsonpath "$.users[*].name" contains "guest"
 jsonpath "$.users[?(@.name == 'root')].roles[*]" count == 1
-jsonpath "$..users[?(@.name == 'root')].roles[*]" includes "admin"
+jsonpath "$..users[?(@.name == 'root')].roles[*]" contains "admin"
 jsonpath "$.users[?(@.name == 'guest')].roles[*]" count == 0
 
 PUT http://localhost:5080/api/v1/users/test
@@ -27,7 +27,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.users" count == 3
-jsonpath "$.users[*].name" includes "test"
+jsonpath "$.users[*].name" contains "test"
 
 DELETE http://localhost:5080/api/v1/users/test
 Authorization: Bearer {{admin_token}}
@@ -39,4 +39,4 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.users" count == 2
-jsonpath "$.users[*].name" not includes "test"
+jsonpath "$.users[*].name" not contains "test"

--- a/tests/specs/api/pipelines.hurl
+++ b/tests/specs/api/pipelines.hurl
@@ -81,8 +81,8 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.pipelines" count == 2
-jsonpath "$.pipelines" includes "default"
-jsonpath "$.pipelines" includes "test"
+jsonpath "$.pipelines" contains "default"
+jsonpath "$.pipelines" contains "test"
 
 POST http://localhost:5080/api/v1/pipelines/test/logs/struct
 Authorization: Bearer {{admin_token}}
@@ -102,7 +102,7 @@ jsonpath "$.processed_count" == 1
 
 GET http://localhost:5080/api/v1/streams/test/logs
 Authorization: Bearer {{admin_token}}
-[QueryStringParams]
+[Query]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
 
@@ -134,4 +134,4 @@ Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
-jsonpath "$.pipelines" not includes "test"
+jsonpath "$.pipelines" not contains "test"

--- a/tests/specs/api/retention.hurl
+++ b/tests/specs/api/retention.hurl
@@ -28,7 +28,7 @@ HTTP 200
 
 GET http://localhost:5080/api/v1/streams/default/logs
 Authorization: Bearer {{admin_token}}
-[QueryStringParams]
+[Query]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
 
@@ -41,7 +41,7 @@ jsonpath "$.records[0].fields.message" == "Hello, World!"
 
 GET http://localhost:5080/api/v1/streams/default/logs
 Authorization: Bearer {{admin_token}}
-[QueryStringParams]
+[Query]
 from: {{timewindow_begin}}
 to: {{timewindow_end}}
 [Options]

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -130,12 +130,12 @@ def flowg_node0_container(
         wait_for_healthcheck(container)
 
     except RuntimeError as err:
-        teardown_container(container)
+        teardown_container(container, report_dir)
         pytest.fail(f"{err}", pytrace=False)
 
     yield
 
-    teardown_container(container)
+    teardown_container(container, report_dir)
 
 
 @pytest.fixture(scope='module')
@@ -180,12 +180,12 @@ def flowg_node1_container(
         wait_for_healthcheck(container)
 
     except RuntimeError as err:
-        teardown_container(container)
+        teardown_container(container, report_dir)
         pytest.fail(f"{err}", pytrace=False)
 
     yield
 
-    teardown_container(container)
+    teardown_container(container, report_dir)
 
 
 @pytest.fixture(scope='module')
@@ -230,12 +230,12 @@ def flowg_node2_container(
         wait_for_healthcheck(container)
 
     except RuntimeError as err:
-        teardown_container(container)
+        teardown_container(container, report_dir)
         pytest.fail(f"{err}", pytrace=False)
 
     yield
 
-    teardown_container(container)
+    teardown_container(container, report_dir)
 
 
 @pytest.fixture(scope='module')
@@ -298,15 +298,12 @@ def wait_for_healthcheck(container):
             break
 
         elif container.health == "unhealthy":
-            raise RuntimeError(
-                f"Node {container.name} was not healthy",
-                pytrace=False,
-            )
+            raise RuntimeError(f"Node {container.name} was not healthy")
 
         sleep(1)
 
 
-def teardown_container(container):
+def teardown_container(container, report_dir):
     print(f"Stopping container: {container.name}")
     container.stop()
 


### PR DESCRIPTION
## Decision Record

In the test suite, if for some reason the container's healthcheck failed, the container was not stopped, and no logs were collected. This led to the volume not being deleted either.

The PR #547 also introduced a `HEALTHCHECK` directive in the Dockerfile, which makes our custom healthcheck obsolete.

## Changes

 - [x] :white_check_mark: :recycle: Use container's builtin healthcheck
 - [x] :white_check_mark: :bug: Teardown container if healthcheck fails
 - [x] :white_check_mark: :bug: Collect container's log if healthcheck fails

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
