### PR TITLE
:sparkles: Add Replication

### DIFF
--- a/api/backup_auth.go
+++ b/api/backup_auth.go
@@ -33,7 +33,7 @@ func (ctrl *controller) BackupAuthUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=auth.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.AuthStorage.Backup(ctx, resp.Writer)
+				err := ctrl.deps.AuthStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/backup_auth.go
+++ b/api/backup_auth.go
@@ -33,7 +33,7 @@ func (ctrl *controller) BackupAuthUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=auth.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.AuthStorage.Dump(ctx, resp.Writer, 0)
+				_, err := ctrl.deps.AuthStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/backup_config.go
+++ b/api/backup_config.go
@@ -37,7 +37,7 @@ func (ctrl *controller) BackupConfigUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=config.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.ConfigStorage.Backup(ctx, resp.Writer)
+				err := ctrl.deps.ConfigStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/backup_config.go
+++ b/api/backup_config.go
@@ -37,7 +37,7 @@ func (ctrl *controller) BackupConfigUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=config.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.ConfigStorage.Dump(ctx, resp.Writer, 0)
+				_, err := ctrl.deps.ConfigStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/backup_logs.go
+++ b/api/backup_logs.go
@@ -33,7 +33,7 @@ func (ctrl *controller) BackupLogsUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=logs.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.LogStorage.Dump(ctx, resp.Writer, 0)
+				_, err := ctrl.deps.LogStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/backup_logs.go
+++ b/api/backup_logs.go
@@ -33,7 +33,7 @@ func (ctrl *controller) BackupLogsUsecase() usecase.Interactor {
 				resp.Writer.(http.ResponseWriter).Header().Set("Content-Disposition", "attachment; filename=logs.db")
 				resp.Writer.(http.ResponseWriter).Header().Set("Cache-Control", "no-cache")
 
-				err := ctrl.deps.LogStorage.Backup(ctx, resp.Writer)
+				err := ctrl.deps.LogStorage.Dump(ctx, resp.Writer, 0)
 				resp.Writer.(http.Flusher).Flush()
 				if err != nil {
 					ctrl.logger.ErrorContext(

--- a/api/restore_auth.go
+++ b/api/restore_auth.go
@@ -33,7 +33,7 @@ func (ctrl *controller) RestoreAuthUsecase() usecase.Interactor {
 			) error {
 				defer req.Backup.Close()
 
-				err := ctrl.deps.AuthStorage.Restore(ctx, req.Backup)
+				err := ctrl.deps.AuthStorage.Load(ctx, req.Backup)
 				if err != nil {
 					ctrl.logger.ErrorContext(
 						ctx,

--- a/api/restore_config.go
+++ b/api/restore_config.go
@@ -37,7 +37,7 @@ func (ctrl *controller) RestoreConfigUsecase() usecase.Interactor {
 			) error {
 				defer req.Backup.Close()
 
-				err := ctrl.deps.ConfigStorage.Restore(ctx, req.Backup)
+				err := ctrl.deps.ConfigStorage.Load(ctx, req.Backup)
 				if err != nil {
 					ctrl.logger.ErrorContext(
 						ctx,

--- a/api/restore_logs.go
+++ b/api/restore_logs.go
@@ -33,7 +33,7 @@ func (ctrl *controller) RestoreLogsUsecase() usecase.Interactor {
 			) error {
 				defer req.Backup.Close()
 
-				err := ctrl.deps.LogStorage.Restore(ctx, req.Backup)
+				err := ctrl.deps.LogStorage.Load(ctx, req.Backup)
 				if err != nil {
 					ctrl.logger.ErrorContext(
 						ctx,

--- a/cmd/flowg-server/cmd/cli.go
+++ b/cmd/flowg-server/cmd/cli.go
@@ -17,6 +17,7 @@ type options struct {
 	clusterJoinNodeID   string
 	clusterJoinEndpoint string
 	clusterCookie       string
+	clusterStateDir     string
 
 	syslogProtocol       string
 	syslogBindAddr       string
@@ -118,6 +119,13 @@ func (opts *options) defineCliOptions(cmd *cobra.Command) {
 		"cluster-cookie",
 		defaultClusterCookie,
 		"Cookie to use for cluster communication (leave empty to disable)",
+	)
+
+	cmd.Flags().StringVar(
+		&opts.clusterStateDir,
+		"cluster-state-dir",
+		defaultClusterStateDir,
+		"Path to the cluster state directory (for replication)",
 	)
 
 	cmd.Flags().StringVar(

--- a/cmd/flowg-server/cmd/config.go
+++ b/cmd/flowg-server/cmd/config.go
@@ -110,6 +110,7 @@ func newServerConfig(opts *options) (server.Options, error) {
 		ClusterJoinNodeID:   opts.clusterJoinNodeID,
 		ClusterJoinEndpoint: clusterJoinEndpointUrl,
 		ClusterCookie:       opts.clusterCookie,
+		ClusterStateDir:     opts.clusterStateDir,
 
 		SyslogTcpMode:      opts.syslogProtocol == "tcp",
 		SyslogBindAddress:  opts.syslogBindAddr,

--- a/cmd/flowg-server/cmd/env.go
+++ b/cmd/flowg-server/cmd/env.go
@@ -41,9 +41,10 @@ var (
 	defaultSyslogTlsCertKey     = getEnvString("FLOWG_SYSLOG_TLS_KEY", "")
 	defaultSyslogTlsAuthEnabled = getEnvBool("FLOWG_SYSLOG_TLS_AUTH", false)
 
-	defaultAuthDir   = getEnvString("FLOWG_AUTH_DIR", "./data/auth")
-	defaultConfigDir = getEnvString("FLOWG_CONFIG_DIR", "./data/config")
-	defaultLogDir    = getEnvString("FLOWG_LOG_DIR", "./data/logs")
+	defaultAuthDir         = getEnvString("FLOWG_AUTH_DIR", "./data/auth")
+	defaultConfigDir       = getEnvString("FLOWG_CONFIG_DIR", "./data/config")
+	defaultLogDir          = getEnvString("FLOWG_LOG_DIR", "./data/logs")
+	defaultClusterStateDir = getEnvString("FLOWG_CLUSTER_STATE_DIR", "./data/state")
 
 	defaultServiceName = getEnvString("FLOWG_SERVICE_NAME", "FlowG")
 	defaultConsulUrl   = getEnvString("CONSUL_URL", "")

--- a/internal/app/logging/badger.go
+++ b/internal/app/logging/badger.go
@@ -34,7 +34,7 @@ func (l *BadgerLogger) Infof(format string, v ...interface{}) {
 	content := fmt.Sprintf(format, v...)
 	lines := strings.FieldsFunc(content, func(c rune) bool { return c == '\n' || c == '\r' })
 	for _, line := range lines {
-		slog.Info(line, "channel", l.Channel)
+		slog.Debug(line, "channel", l.Channel)
 	}
 }
 

--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -96,6 +96,10 @@ func NewServer(opts Options) proctree.Process {
 			ClusterJoinNode: ClusterJoinNode,
 
 			AutomaticClusterFormation: isAutomaticClusterFormation,
+
+			AuthStorage:   authStorage,
+			ConfigStorage: configStorage,
+			LogStorage:    logStorage,
 		})
 		syslogServer = syslog.NewServer(&syslog.ServerOptions{
 			TcpMode:      opts.SyslogTcpMode,

--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -33,6 +33,7 @@ type Options struct {
 	ClusterJoinNodeID   string
 	ClusterJoinEndpoint *url.URL
 	ClusterCookie       string
+	ClusterStateDir     string
 
 	SyslogTcpMode      bool
 	SyslogBindAddress  string
@@ -94,6 +95,7 @@ func NewServer(opts Options) proctree.Process {
 			ClusterNodeID:   opts.ClusterNodeID,
 			ClusterCookie:   opts.ClusterCookie,
 			ClusterJoinNode: ClusterJoinNode,
+			ClusterStateDir: opts.ClusterStateDir,
 
 			AutomaticClusterFormation: isAutomaticClusterFormation,
 

--- a/internal/cluster/main.go
+++ b/internal/cluster/main.go
@@ -6,10 +6,13 @@ import (
 	"net/url"
 
 	"github.com/vladopajic/go-actor/actor"
-
 	"link-society.com/flowg/internal/utils/proctree"
 
 	"github.com/hashicorp/memberlist"
+
+	"link-society.com/flowg/internal/storage/auth"
+	"link-society.com/flowg/internal/storage/config"
+	"link-society.com/flowg/internal/storage/log"
 )
 
 type ManagerOptions struct {
@@ -21,6 +24,10 @@ type ManagerOptions struct {
 	AutomaticClusterFormation bool
 
 	LocalEndpointResolver func() (*url.URL, error)
+
+	AuthStorage   *auth.Storage
+	ConfigStorage *config.Storage
+	LogStorage    *log.Storage
 }
 
 type Manager struct {

--- a/internal/cluster/main.go
+++ b/internal/cluster/main.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/vladopajic/go-actor/actor"
+	"link-society.com/flowg/internal/utils/kvstore"
 	"link-society.com/flowg/internal/utils/proctree"
 
 	"github.com/hashicorp/memberlist"
@@ -25,9 +26,10 @@ type ManagerOptions struct {
 
 	LocalEndpointResolver func() (*url.URL, error)
 
-	AuthStorage   *auth.Storage
-	ConfigStorage *config.Storage
-	LogStorage    *log.Storage
+	AuthStorage         *auth.Storage
+	ConfigStorage       *config.Storage
+	LogStorage          *log.Storage
+	ClusterStateStorage *kvstore.Storage
 }
 
 type Manager struct {

--- a/internal/cluster/node_state.go
+++ b/internal/cluster/node_state.go
@@ -1,0 +1,98 @@
+package cluster
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+	"link-society.com/flowg/internal/utils/kvstore"
+)
+
+type nodeState struct {
+	NodeID   string                   `json:"node_id"`
+	LastSync map[string]nodeSyncState `json:"last_sync"`
+}
+
+type nodeSyncState struct {
+	Auth   uint64 `json:"auth"`
+	Config uint64 `json:"config"`
+	Log    uint64 `json:"log"`
+}
+
+func fetchLocalState(
+	ctx context.Context,
+	storage *kvstore.Storage,
+	nodeID string,
+	endpoints []string,
+) (*nodeState, error) {
+	state := &nodeState{
+		NodeID:   nodeID,
+		LastSync: map[string]nodeSyncState{},
+	}
+
+	err := storage.View(ctx, func(txn *badger.Txn) error {
+		fetchLastSync := func(dbType string, endpointName string) (uint64, error) {
+			key := fmt.Appendf(nil, "lastsync:%s:%s", dbType, endpointName)
+			item, err := txn.Get(key)
+			if err != nil {
+				if err == badger.ErrKeyNotFound {
+					return 0, nil
+				}
+
+				return 0, err
+			}
+
+			var lastSync uint64
+			item.Value(func(val []byte) error {
+				lastSync = binary.BigEndian.Uint64(val)
+				return nil
+			})
+
+			return lastSync, nil
+		}
+
+		for _, endpointName := range endpoints {
+			lastAuthSync, err := fetchLastSync("auth", endpointName)
+			if err != nil {
+				return err
+			}
+
+			lastConfigSync, err := fetchLastSync("config", endpointName)
+			if err != nil {
+				return err
+			}
+
+			lastLogSync, err := fetchLastSync("log", endpointName)
+			if err != nil {
+				return err
+			}
+
+			state.LastSync[endpointName] = nodeSyncState{
+				Auth:   lastAuthSync,
+				Config: lastConfigSync,
+				Log:    lastLogSync,
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch node state: %w", err)
+	}
+
+	return state, nil
+}
+
+func updateLocalState(
+	ctx context.Context,
+	storage *kvstore.Storage,
+	nodeID string,
+	dbType string,
+	since uint64,
+) error {
+	key := fmt.Appendf(nil, "lastsync:%s:%s", dbType, nodeID)
+	return storage.Update(ctx, func(txn *badger.Txn) error {
+		return txn.Set(key, binary.BigEndian.AppendUint64(nil, since))
+	})
+}

--- a/internal/cluster/process.go
+++ b/internal/cluster/process.go
@@ -63,6 +63,10 @@ func (p *procHandler) Init(ctx actor.Context) proctree.ProcessResult {
 
 		connM:   p.connM,
 		packetM: p.packetM,
+
+		authStorage:   p.opts.AuthStorage,
+		configStorage: p.opts.ConfigStorage,
+		logStorage:    p.opts.LogStorage,
 	}
 
 	p.mlistConfig = memberlist.DefaultLocalConfig()
@@ -71,6 +75,7 @@ func (p *procHandler) Init(ctx actor.Context) proctree.ProcessResult {
 	p.mlistConfig.Transport = transport
 	p.mlistConfig.Delegate = d
 	p.mlistConfig.Events = d
+	p.mlistConfig.PushPullInterval = time.Second
 	p.mlistConfig.Logger = newMemberlistLogger(logger)
 
 	p.mlist, err = memberlist.Create(p.mlistConfig)

--- a/internal/cluster/sync.go
+++ b/internal/cluster/sync.go
@@ -1,0 +1,206 @@
+package cluster
+
+import (
+	"log/slog"
+
+	"fmt"
+	"strconv"
+
+	"io"
+	"net/http"
+	"net/url"
+
+	"sync"
+
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/storage"
+)
+
+type syncPool struct {
+	logger *slog.Logger
+
+	nodeID string
+	cookie string
+
+	authStorage   storage.Streamable
+	configStorage storage.Streamable
+	logStorage    storage.Streamable
+
+	workers map[string]*syncActor
+}
+
+type syncActor struct {
+	actor.Actor
+	mbox actor.MailboxSender[nodeSyncState]
+}
+
+type syncWorker struct {
+	pool     *syncPool
+	nodeID   string
+	endpoint *url.URL
+	mbox     actor.MailboxReceiver[nodeSyncState]
+}
+
+var _ actor.Actor = (*syncActor)(nil)
+var _ actor.Worker = (*syncWorker)(nil)
+
+func (p *syncPool) AddWorker(nodeID string, endpoint *url.URL) {
+	if _, exists := p.workers[nodeID]; exists {
+		return
+	}
+
+	mbox := actor.NewMailbox[nodeSyncState]()
+
+	worker := &syncWorker{
+		pool:     p,
+		nodeID:   nodeID,
+		endpoint: endpoint,
+		mbox:     mbox,
+	}
+
+	syncer := &syncActor{
+		Actor: actor.Combine(mbox, actor.New(worker)).Build(),
+		mbox:  mbox,
+	}
+	syncer.Start()
+
+	p.workers[nodeID] = syncer
+}
+
+func (p *syncPool) RemoveWorker(nodeID string) {
+	if worker, exists := p.workers[nodeID]; exists {
+		worker.Stop()
+		delete(p.workers, nodeID)
+	}
+}
+
+func (p *syncPool) RemoveAll() {
+	for nodeID, worker := range p.workers {
+		worker.Stop()
+		delete(p.workers, nodeID)
+	}
+}
+
+func (w *syncWorker) DoWork(ctx actor.Context) actor.WorkerStatus {
+	select {
+	case <-ctx.Done():
+		return actor.WorkerEnd
+
+	case msg, ok := <-w.mbox.ReceiveC():
+		if !ok {
+			return actor.WorkerEnd
+		}
+
+		wg := &sync.WaitGroup{}
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+			w.syncStorage(ctx, w.pool.authStorage, msg.Auth, "auth")
+		}()
+
+		go func() {
+			defer wg.Done()
+			w.syncStorage(ctx, w.pool.configStorage, msg.Config, "config")
+		}()
+
+		go func() {
+			defer wg.Done()
+			w.syncStorage(ctx, w.pool.logStorage, msg.Log, "log")
+		}()
+
+		wg.Wait()
+
+		return actor.WorkerContinue
+	}
+}
+
+func (w *syncWorker) syncStorage(
+	ctx actor.Context,
+	s storage.Streamable,
+	lastSync uint64,
+	dbType string,
+) {
+	logger := w.pool.logger.With(
+		slog.String("cluster.remote.node", w.nodeID),
+		slog.String("cluster.remote.endpoint", w.endpoint.String()),
+		slog.String("cluster.replication.storage", dbType),
+	)
+
+	url, err := url.JoinPath(w.endpoint.String(), "/cluster/sync", dbType)
+	if err != nil {
+		logger.ErrorContext(
+			ctx,
+			"failed to build sync url",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	reader, writer := io.Pipe()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		url,
+		reader,
+	)
+	if err != nil {
+		logger.ErrorContext(
+			ctx,
+			"failed to create sync request",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	req.Header.Set(COOKIE_HEADER_NAME, w.pool.cookie)
+	req.Header.Set(NODEID_HEADER_NAME, w.pool.nodeID)
+	req.Header.Set("Transfer-Encoding", "chunked")
+	req.Header.Set("Trailer", SINCE_HEADER_NAME)
+	req.Trailer = http.Header{
+		SINCE_HEADER_NAME: nil,
+	}
+
+	go func() {
+		defer writer.Close()
+
+		newSyncTs, err := s.Dump(ctx, writer, lastSync)
+		if err != nil {
+			logger.ErrorContext(
+				ctx,
+				"failed to dump storage",
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+
+		req.Trailer.Set(SINCE_HEADER_NAME, strconv.FormatUint(newSyncTs, 10))
+	}()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.ErrorContext(
+			ctx,
+			"failed to send sync request",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, err := io.ReadAll(resp.Body)
+		if err != nil {
+			message = fmt.Appendf(nil, "%d", resp.StatusCode)
+		}
+
+		logger.ErrorContext(
+			ctx,
+			"failed to sync storage",
+			slog.String("error", string(message)),
+		)
+		return
+	}
+}

--- a/internal/cluster/transport.go
+++ b/internal/cluster/transport.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/vladopajic/go-actor/actor"
 
+	"link-society.com/flowg/internal/storage"
 	"link-society.com/flowg/internal/storage/auth"
 	"link-society.com/flowg/internal/storage/config"
 	"link-society.com/flowg/internal/storage/log"
-	"link-society.com/flowg/internal/utils/replication"
 
 	"github.com/hashicorp/memberlist"
 )
@@ -343,7 +343,7 @@ func (t *httpTransport) handleGossipPacket(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusAccepted)
 }
 
-func (t *httpTransport) handleSync(s replication.Storage) http.HandlerFunc {
+func (t *httpTransport) handleSync(s storage.Streamable) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 

--- a/internal/cluster/transport.go
+++ b/internal/cluster/transport.go
@@ -286,7 +286,7 @@ func (t *httpTransport) handleGossipStream(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	t.delegate.logger.InfoContext(
+	t.delegate.logger.DebugContext(
 		r.Context(),
 		"accepted connection",
 		slog.String("remote", conn.RemoteAddr().String()),

--- a/internal/services/mgmt/main.go
+++ b/internal/services/mgmt/main.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/go-sockaddr"
 
 	"link-society.com/flowg/internal/cluster"
+	"link-society.com/flowg/internal/storage/auth"
+	"link-society.com/flowg/internal/storage/config"
+	"link-society.com/flowg/internal/storage/log"
 
 	"link-society.com/flowg/internal/utils/proctree"
 )
@@ -25,6 +28,10 @@ type ServerOptions struct {
 	ClusterJoinNode *cluster.ClusterJoinNode
 
 	AutomaticClusterFormation bool
+
+	AuthStorage   *auth.Storage
+	ConfigStorage *config.Storage
+	LogStorage    *log.Storage
 }
 
 func NewServer(opts *ServerOptions) proctree.Process {
@@ -77,6 +84,10 @@ func NewServer(opts *ServerOptions) proctree.Process {
 
 			return localEndpoint, nil
 		},
+
+		AuthStorage:   opts.AuthStorage,
+		ConfigStorage: opts.ConfigStorage,
+		LogStorage:    opts.LogStorage,
 	})
 
 	serverH := &serverHandler{

--- a/internal/storage/auth/main.go
+++ b/internal/storage/auth/main.go
@@ -76,7 +76,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 	}
 }
 
-func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
 	return s.kvStore.Backup(ctx, w, since)
 }
 

--- a/internal/storage/auth/main.go
+++ b/internal/storage/auth/main.go
@@ -9,9 +9,11 @@ import (
 	"link-society.com/flowg/internal/models"
 
 	"link-society.com/flowg/internal/utils/kvstore"
-	"link-society.com/flowg/internal/utils/proctree"
+	"link-society.com/flowg/internal/utils/replication"
 
 	"link-society.com/flowg/internal/storage/auth/transactions"
+
+	"link-society.com/flowg/internal/utils/proctree"
 )
 
 type options struct {
@@ -45,6 +47,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
+var _ replication.Storage = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -80,6 +83,14 @@ func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
+	return s.kvStore.Restore(ctx, r)
+}
+
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+	return s.kvStore.Backup(ctx, w, since)
+}
+
+func (s *Storage) Load(ctx context.Context, r io.Reader) error {
 	return s.kvStore.Restore(ctx, r)
 }
 

--- a/internal/storage/auth/main.go
+++ b/internal/storage/auth/main.go
@@ -7,11 +7,9 @@ import (
 	"github.com/dgraph-io/badger/v4"
 
 	"link-society.com/flowg/internal/models"
-
-	"link-society.com/flowg/internal/utils/kvstore"
-	"link-society.com/flowg/internal/utils/replication"
-
+	"link-society.com/flowg/internal/storage"
 	"link-society.com/flowg/internal/storage/auth/transactions"
+	"link-society.com/flowg/internal/utils/kvstore"
 
 	"link-society.com/flowg/internal/utils/proctree"
 )
@@ -47,7 +45,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
-var _ replication.Storage = (*Storage)(nil)
+var _ storage.Streamable = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -76,14 +74,6 @@ func NewStorage(opts ...func(*options)) *Storage {
 		Process: process,
 		kvStore: kvStore,
 	}
-}
-
-func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w, 0)
-}
-
-func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
-	return s.kvStore.Restore(ctx, r)
 }
 
 func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {

--- a/internal/storage/auth/main.go
+++ b/internal/storage/auth/main.go
@@ -76,7 +76,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 }
 
 func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w)
+	return s.kvStore.Backup(ctx, w, 0)
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -11,12 +11,11 @@ import (
 	"github.com/dgraph-io/badger/v4"
 
 	"link-society.com/flowg/internal/models"
-
-	"link-society.com/flowg/internal/utils/kvstore"
-	"link-society.com/flowg/internal/utils/proctree"
-	"link-society.com/flowg/internal/utils/replication"
-
+	"link-society.com/flowg/internal/storage"
 	"link-society.com/flowg/internal/storage/config/transactions"
+	"link-society.com/flowg/internal/utils/kvstore"
+
+	"link-society.com/flowg/internal/utils/proctree"
 )
 
 const (
@@ -56,7 +55,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
-var _ replication.Storage = (*Storage)(nil)
+var _ storage.Streamable = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -90,14 +89,6 @@ func NewStorage(opts ...func(*options)) *Storage {
 
 		kvStore: kvStore,
 	}
-}
-
-func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w, 0)
-}
-
-func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
-	return s.kvStore.Restore(ctx, r)
 }
 
 func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -14,6 +14,7 @@ import (
 
 	"link-society.com/flowg/internal/utils/kvstore"
 	"link-society.com/flowg/internal/utils/proctree"
+	"link-society.com/flowg/internal/utils/replication"
 
 	"link-society.com/flowg/internal/storage/config/transactions"
 )
@@ -55,6 +56,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
+var _ replication.Storage = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -95,6 +97,14 @@ func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
+	return s.kvStore.Restore(ctx, r)
+}
+
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+	return s.kvStore.Backup(ctx, w, since)
+}
+
+func (s *Storage) Load(ctx context.Context, r io.Reader) error {
 	return s.kvStore.Restore(ctx, r)
 }
 

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -91,7 +91,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 	}
 }
 
-func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
 	return s.kvStore.Backup(ctx, w, since)
 }
 

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -91,7 +91,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 }
 
 func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w)
+	return s.kvStore.Backup(ctx, w, 0)
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {

--- a/internal/storage/log/main.go
+++ b/internal/storage/log/main.go
@@ -93,7 +93,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 }
 
 func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w)
+	return s.kvStore.Backup(ctx, w, 0)
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {

--- a/internal/storage/log/main.go
+++ b/internal/storage/log/main.go
@@ -6,18 +6,17 @@ import (
 
 	"time"
 
-	"github.com/vladopajic/go-actor/actor"
-
 	"github.com/dgraph-io/badger/v4"
 
 	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/storage"
+	"link-society.com/flowg/internal/storage/log/transactions"
+	"link-society.com/flowg/internal/utils/kvstore"
 
 	"link-society.com/flowg/internal/utils/ffi/filterdsl"
-	"link-society.com/flowg/internal/utils/kvstore"
-	"link-society.com/flowg/internal/utils/proctree"
-	"link-society.com/flowg/internal/utils/replication"
 
-	"link-society.com/flowg/internal/storage/log/transactions"
+	"github.com/vladopajic/go-actor/actor"
+	"link-society.com/flowg/internal/utils/proctree"
 )
 
 type options struct {
@@ -58,7 +57,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
-var _ replication.Storage = (*Storage)(nil)
+var _ storage.Streamable = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -92,14 +91,6 @@ func NewStorage(opts ...func(*options)) *Storage {
 		Process: process,
 		kvStore: kvStore,
 	}
-}
-
-func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
-	return s.kvStore.Backup(ctx, w, 0)
-}
-
-func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
-	return s.kvStore.Restore(ctx, r)
 }
 
 func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {

--- a/internal/storage/log/main.go
+++ b/internal/storage/log/main.go
@@ -93,7 +93,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 	}
 }
 
-func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
 	return s.kvStore.Backup(ctx, w, since)
 }
 

--- a/internal/storage/log/main.go
+++ b/internal/storage/log/main.go
@@ -15,6 +15,7 @@ import (
 	"link-society.com/flowg/internal/utils/ffi/filterdsl"
 	"link-society.com/flowg/internal/utils/kvstore"
 	"link-society.com/flowg/internal/utils/proctree"
+	"link-society.com/flowg/internal/utils/replication"
 
 	"link-society.com/flowg/internal/storage/log/transactions"
 )
@@ -57,6 +58,7 @@ type Storage struct {
 }
 
 var _ proctree.Process = (*Storage)(nil)
+var _ replication.Storage = (*Storage)(nil)
 
 func NewStorage(opts ...func(*options)) *Storage {
 	options := options{
@@ -97,6 +99,14 @@ func (s *Storage) Backup(ctx context.Context, w io.Writer) error {
 }
 
 func (s *Storage) Restore(ctx context.Context, r io.Reader) error {
+	return s.kvStore.Restore(ctx, r)
+}
+
+func (s *Storage) Dump(ctx context.Context, w io.Writer, since uint64) error {
+	return s.kvStore.Backup(ctx, w, since)
+}
+
+func (s *Storage) Load(ctx context.Context, r io.Reader) error {
 	return s.kvStore.Restore(ctx, r)
 }
 

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -6,6 +6,6 @@ import (
 )
 
 type Streamable interface {
-	Dump(context.Context, io.Writer, uint64) error
+	Dump(context.Context, io.Writer, uint64) (uint64, error)
 	Load(context.Context, io.Reader) error
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -1,11 +1,11 @@
-package replication
+package storage
 
 import (
 	"context"
 	"io"
 )
 
-type Storage interface {
+type Streamable interface {
 	Dump(context.Context, io.Writer, uint64) error
 	Load(context.Context, io.Reader) error
 }

--- a/internal/utils/kvstore/main.go
+++ b/internal/utils/kvstore/main.go
@@ -98,6 +98,7 @@ func NewStorage(opts ...func(*options)) *Storage {
 func (kv *Storage) Backup(
 	ctx context.Context,
 	w io.Writer,
+	since uint64,
 ) error {
 	replyTo := make(chan error, 1)
 
@@ -105,7 +106,7 @@ func (kv *Storage) Backup(
 		ctx,
 		message{
 			replyTo:   replyTo,
-			operation: &backupOperation{w: w},
+			operation: &backupOperation{w: w, since: since},
 		},
 	)
 	if err != nil {

--- a/internal/utils/kvstore/messages.go
+++ b/internal/utils/kvstore/messages.go
@@ -16,7 +16,8 @@ type operation interface {
 }
 
 type backupOperation struct {
-	w io.Writer
+	w     io.Writer
+	since uint64
 }
 
 type restoreOperation struct {
@@ -37,7 +38,7 @@ var _ operation = (*viewOperation)(nil)
 var _ operation = (*updateOperation)(nil)
 
 func (m *backupOperation) Handle(db *badger.DB) error {
-	_, err := db.Backup(m.w, 0)
+	_, err := db.Backup(m.w, m.since)
 	return err
 }
 

--- a/internal/utils/kvstore/messages.go
+++ b/internal/utils/kvstore/messages.go
@@ -38,7 +38,8 @@ var _ operation = (*viewOperation)(nil)
 var _ operation = (*updateOperation)(nil)
 
 func (m *backupOperation) Handle(db *badger.DB) error {
-	_, err := db.Backup(m.w, m.since)
+	var err error
+	m.since, err = db.Backup(m.w, m.since)
 	return err
 }
 

--- a/internal/utils/replication/storage.go
+++ b/internal/utils/replication/storage.go
@@ -1,0 +1,11 @@
+package replication
+
+import (
+	"context"
+	"io"
+)
+
+type Storage interface {
+	Dump(context.Context, io.Writer, uint64) error
+	Load(context.Context, io.Reader) error
+}

--- a/scripts/run.taskfile.yml
+++ b/scripts/run.taskfile.yml
@@ -11,6 +11,7 @@ tasks:
       FLOWG_AUTH_DIR: "./data/node0/auth"
       FLOWG_CONFIG_DIR: "./data/node0/config"
       FLOWG_LOG_DIR: "./data/node0/logs"
+      FLOWG_CLUSTER_STATE_DIR: "./data/node0/state"
 
   node1:
     desc: "Run the project (node1)"
@@ -27,6 +28,7 @@ tasks:
       FLOWG_AUTH_DIR: "./data/node1/auth"
       FLOWG_CONFIG_DIR: "./data/node1/config"
       FLOWG_LOG_DIR: "./data/node1/logs"
+      FLOWG_CLUSTER_STATE_DIR: "./data/node1/state"
 
   node2:
     desc: "Run the project (node2)"
@@ -43,3 +45,4 @@ tasks:
       FLOWG_AUTH_DIR: "./data/node2/auth"
       FLOWG_CONFIG_DIR: "./data/node2/config"
       FLOWG_LOG_DIR: "./data/node2/logs"
+      FLOWG_CLUSTER_STATE_DIR: "./data/node2/state"

--- a/tests/specs/api/replication.hurl
+++ b/tests/specs/api/replication.hurl
@@ -1,0 +1,110 @@
+POST http://localhost:5080/api/v1/pipelines/default/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "records": [
+    {
+      "level": "info",
+      "message": "test"
+    }
+  ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.processed_count" == 1
+
+# Node 0
+GET http://localhost:5080/api/v1/streams/default/logs
+Authorization: Bearer {{admin_token}}
+[Query]
+from: {{timewindow_begin}}
+to: {{timewindow_end}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.records" count == 1
+jsonpath "$.records[0].fields.level" == "info"
+jsonpath "$.records[0].fields.message" == "test"
+
+# Node 1
+GET http://localhost:5081/api/v1/streams/default/logs
+Authorization: Bearer {{admin_token}}
+[Query]
+from: {{timewindow_begin}}
+to: {{timewindow_end}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.records" count == 1
+jsonpath "$.records[0].fields.level" == "info"
+jsonpath "$.records[0].fields.message" == "test"
+
+# Node 2
+GET http://localhost:5082/api/v1/streams/default/logs
+Authorization: Bearer {{admin_token}}
+[Query]
+from: {{timewindow_begin}}
+to: {{timewindow_end}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.records" count == 1
+jsonpath "$.records[0].fields.level" == "info"
+jsonpath "$.records[0].fields.message" == "test"
+
+# --- Cleanup -----------------------------------------------------------------
+
+DELETE http://localhost:5080/api/v1/streams/default
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Node 0
+GET http://localhost:5080/api/v1/streams
+Authorization: Bearer {{admin_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.streams" isEmpty
+
+# Node 1
+GET http://localhost:5081/api/v1/streams
+Authorization: Bearer {{admin_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.streams" isEmpty
+
+# Node 2
+GET http://localhost:5082/api/v1/streams
+Authorization: Bearer {{admin_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.streams" isEmpty

--- a/website/docs/design/clustering/architecture.md
+++ b/website/docs/design/clustering/architecture.md
@@ -27,6 +27,7 @@ flowg-server \
   --auth-dir ./data/node0/auth \
   --log-dir ./data/node0/logs \
   --config-dir ./data/node0/config \
+  --cluster-state-dir ./data/node0/state \
   --http-bind 127.0.0.1:5080 \
   --mgmt-bind 127.0.0.1:9113 \
   --syslog-bind 127.0.0.1:5514 &
@@ -38,6 +39,7 @@ flowg-server \
   --auth-dir ./data/node1/auth \
   --log-dir ./data/node1/logs \
   --config-dir ./data/node1/config \
+  --cluster-state-dir ./data/node1/state \
   --http-bind 127.0.0.1:5081 \
   --mgmt-bind 127.0.0.1:9114 \
   --syslog-bind 127.0.0.1:5515 &
@@ -49,6 +51,7 @@ flowg-server \
   --auth-dir ./data/node2/auth \
   --log-dir ./data/node2/logs \
   --config-dir ./data/node2/config \
+  --cluster-state-dir ./data/node2/state \
   --http-bind 127.0.0.1:5082 \
   --mgmt-bind 127.0.0.1:9115 \
   --syslog-bind 127.0.0.1:5516 &
@@ -68,6 +71,7 @@ flowg-server \
   --auth-dir ./data/node0/auth \
   --log-dir ./data/node0/logs \
   --config-dir ./data/node0/config \
+  --cluster-state-dir ./data/node0/state \
   --http-bind 127.0.0.1:5080 \
   --mgmt-bind 127.0.0.1:9113 \
   --syslog-bind 127.0.0.1:5514 &
@@ -80,6 +84,7 @@ flowg-server \
   --auth-dir ./data/node1/auth \
   --log-dir ./data/node1/logs \
   --config-dir ./data/node1/config \
+  --cluster-state-dir ./data/node1/state \
   --http-bind 127.0.0.1:5081 \
   --mgmt-bind 127.0.0.1:9114 \
   --syslog-bind 127.0.0.1:5515 &
@@ -92,6 +97,7 @@ flowg-server \
   --auth-dir ./data/node2/auth \
   --log-dir ./data/node2/logs \
   --config-dir ./data/node2/config \
+  --cluster-state-dir ./data/node2/state \
   --http-bind 127.0.0.1:5082 \
   --mgmt-bind 127.0.0.1:9115 \
   --syslog-bind 127.0.0.1:5516 &
@@ -208,6 +214,81 @@ X-FlowG-ClusterKey: <optional cluster cookie>
 | 101 Switching Protocols | The connection has been accepted, and the socket will be used for bi-directional exchange |
 | 501 Not Implemented | The server does not support hijacking the socket, maybe there is a Reverse Proxy in between? |
 | 401 Unauthorized | The node requires authentification, and the `X-FlowG-ClusterKey` header was invalid |
+| 500 Internal Server Error | On failure |
+
+</fieldset>
+
+<fieldset>
+<legend>Authentication Database synchronization</legend>
+
+**Description:** Endpoint used to receive incremental backups from other nodes.
+
+```
+POST /cluster/sync/auth
+X-FlowG-ClusterKey: <optional cluster cookie>
+X-FlowG-NodeID: <remote node ID>
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup data ...
+
+X-FlowG-Since: <new version>
+```
+
+| Response | When |
+| --- | --- |
+| 401 Unauthorized | The node requires authentification, and the `X-FlowG-ClusterKey` header was invalid |
+| 400 Bad Request | Missing HTTP header `X-FlowG-NodeID` or invalid data in HTTP trailer `X-FlowG-Since` |
+| 500 Internal Server Error | On failure |
+
+</fieldset>
+
+<fieldset>
+<legend>Configuration database synchronization</legend>
+
+**Description:** Endpoint used to receive incremental backups from other nodes.
+
+```
+POST /cluster/sync/config
+X-FlowG-ClusterKey: <optional cluster cookie>
+X-FlowG-NodeID: <remote node ID>
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup data ...
+
+X-FlowG-Since: <new version>
+```
+
+| Response | When |
+| --- | --- |
+| 401 Unauthorized | The node requires authentification, and the `X-FlowG-ClusterKey` header was invalid |
+| 400 Bad Request | Missing HTTP header `X-FlowG-NodeID` or invalid data in HTTP trailer `X-FlowG-Since` |
+| 500 Internal Server Error | On failure |
+
+</fieldset>
+
+<fieldset>
+<legend>Log database synchronization</legend>
+
+**Description:** Endpoint used to receive incremental backups from other nodes.
+
+```
+POST /cluster/sync/log
+X-FlowG-ClusterKey: <optional cluster cookie>
+X-FlowG-NodeID: <remote node ID>
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup data ...
+
+X-FlowG-Since: <new version>
+```
+
+| Response | When |
+| --- | --- |
+| 401 Unauthorized | The node requires authentification, and the `X-FlowG-ClusterKey` header was invalid |
+| 400 Bad Request | Missing HTTP header `X-FlowG-NodeID` or invalid data in HTTP trailer `X-FlowG-Since` |
 | 500 Internal Server Error | On failure |
 
 </fieldset>

--- a/website/docs/design/clustering/consensus.md
+++ b/website/docs/design/clustering/consensus.md
@@ -15,9 +15,9 @@ In terms of the [CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem), *SWIM*
 is "AP", it sacrifices **strong consistency** for **availability** and
 **partitioning tolerance**.
 
-> **NB:** FlowG achieves **eventual consistency** using a
-> [CRDT](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type). For
-> more information, consult [this page](./replication).
+> **NB:** FlowG achieves **eventual consistency** by periodically streaming
+> BadgerDB key/value pairs between nodes. For more information, consult
+> [this page](./replication).
 
 ## Why not Raft?
 

--- a/website/docs/design/clustering/replication.mdx
+++ b/website/docs/design/clustering/replication.mdx
@@ -6,14 +6,149 @@ sidebar_position: 3
 
 <div style={{
   margin: 'auto',
-  padding: '3rem',
+  paddingTop: '1rem',
+  paddingLeft: '2rem',
+  paddingRight: '2rem',
   background: '#FFF3D4',
-  fontSize: '2rem',
+  boxShadow: '0 5px 5px rgba(0, 0, 0, 0.1)',
   display: 'flex',
-  flexDirection: 'row',
+  flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  boxShadow: '0 5px 5px rgba(0, 0, 0, 0.1)',
 }}>
-:construction: **Work In Progress** :construction:
+  <div style={{
+    fontSize: '2rem',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  }}>
+  :construction: **EXPERIMENTAL** :construction:
+  </div>
+
+  <div>
+    This feature is experimental and needs thorough testing before being
+    production ready.<br/>
+    Please report any issues you encounter to the
+    [GitHub issue tracker](https://github.com/link-society/flowg/issues).
+  </div>
 </div>
+
+## Introduction
+
+Every data in **FlowG** is persisted in a [BadgerDB](https://dgraph.io/docs/badger/)
+store, which internally uses a [Log-structured merge tree](https://en.wikipedia.org/wiki/Log-structured_merge-tree)
+data-structure.
+
+Every read‐write transaction in BadgerDB is assigned a unique, strictly
+increasing `uint64` "commit timestamp" when it commits. All key‐value mutations
+in that transaction—whether a set or a delete—are stamped with that timestamp as
+their version.
+
+When doing an incremental backup since some "version", BadgerDB scans the LSM
+tree and value logs for every entry whose version is superior to the given
+"version". After successfully writing the data, it returns the highest version
+observed which can then be used for the next incremental backup.
+
+As explained in [the consensus documentation](./consensus), **FlowG** relies on
+the [SWIM Protocol](https://en.wikipedia.org/wiki/SWIM_Protocol) for node
+discovery. And most importantly, on the [hashicorp/memberlist](https://github.com/hashicorp/memberlist)
+implementation.
+
+Replication between nodes is achieved during *memberlist*'s "TCP Push/Pull".
+
+## Node's local state
+
+**FlowG** has 3 replicated storages:
+
+ - one for authentication/permissions related data
+ - one for configuration (pipelines, transormers, ...)
+ - one for actual logs
+
+In a 4th, non replicated, storage, **FlowG** stores for each other node in the
+cluster the last known "version":
+
+```
+lastsync:auth:node1   = 1
+lastsync:config:node1 = 1
+lastsync:log:node1    = 2
+
+lastsync:auth:node2   = 2
+lastsync:config:node2 = 3
+lastsync:log:node2    = 7
+
+...
+```
+
+During a "TCP Push/Pull", the local state will be serialized as JSON and sent
+to all other nodes in the cluster:
+
+```json
+{
+  "node_id": "node0",
+  "last_sync": {
+    "node1": {
+      "auth": 1,
+      "config": 1,
+      "log": 2
+    },
+    "node2": {
+      "auth": 2,
+      "config": 3,
+      "log": 7
+    }
+  }
+}
+```
+
+## Merging node states
+
+When a node receive from a remote node its state (aka: a "remote state"), it
+looks up itself to determine the "version" from which the incremental backup
+will be done:
+
+```javascript
+last_sync = remote_state.last_sync[local_node_id]
+```
+
+Then, 3 HTTP requests are made to `remote_state.node_id` on its management
+interface:
+
+```
+POST http://<remote host>/cluster/sync/auth
+X-FlowG-ClusterKey: ...
+X-FlowG-NodeID: ...
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup of auth storage ...
+
+X-FlowG-Since: ...
+```
+
+```
+POST http://<remote host>/cluster/sync/config
+X-FlowG-ClusterKey: ...
+X-FlowG-NodeID: ...
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup of config storage ...
+
+X-FlowG-Since: ...
+```
+
+```
+POST http://<remote host>/cluster/sync/log
+X-FlowG-ClusterKey: ...
+X-FlowG-NodeID: ...
+Transfer-Encoding: chunked
+Trailer: X-FlowG-Since
+
+... incremental backup of log storage ...
+
+X-FlowG-Since: ...
+```
+
+Once the data has been saved, we register in the local state the new "version",
+read from the trailer HTTP header `X-FlowG-Since`.

--- a/website/docs/setup/installation.md
+++ b/website/docs/setup/installation.md
@@ -25,6 +25,7 @@ flowg-server \
   --auth-dir /var/lib/flowg/data/auth \
   --log-dir /var/lib/flowg/logs \
   --config-dir /var/lib/flowg/config \
+  --cluster-state-dir /var/lib/flowg/state \
   --http-bind 127.0.0.1:5080 \
   --mgmt-bind 127.0.0.1:9113 \
   --syslog-bind 127.0.0.1:5514


### PR DESCRIPTION
## Decision Record

See: #14

BadgerDB provides a streaming framework, which is used for backups and restores. This framework supports incremental backups.

If we keep track on each node the last known sync timestamp with other nodes, we can trigger during a SWIM TCP Push/Pull an incremental backup:

 - node 0 tells node 1 *i haven't synced with you since `t=X`*
 - node 1 performs incremental backup: `X' = db.Backup(since=X)` and streams the data to node 0
 - node 0 loads the data with `db.Load()`
 - node 0 records `t=X'` as the last sync timestamp

This is the basis for replication, and it needs further testing:

 - what about network failures during a sync?
 - what about network partitioning?
 - what about disk failure?
 - benchmarking the network usage on the management interface
 - benchmarking the disk usage on each node
 - benchmarking the log throughput for each node, and globally for the "cluster"

Those will be improved upon in other PRs. Feedback and beta-testing will be appreciated.

## Changes

 - [x] :recycle: Add support for incremental backups/restores internally
 - [x] :card_file_box: add cluster state storage to store the local node state (the last sync timestamps with other nodes)
 - [x] :mute: reduce logging by redirecting irrelevant logs to `DEBUG` level
 - [x] :sparkles: Add `/cluster/sync/...` endpoints on the management interface to receive data from other nodes
 - [x] :sparkles: Queue replication during SWIM TCP Push/Pull
 - [x] :white_check_mark: Add API E2E test scenario
 - [x] :memo: Update documentation
 - [x] :memo: Flag feature as **EXPERIMENTAL**

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
