### PR TITLE
Feat/splunk forwarder

### DIFF
--- a/internal/models/forwarder_v2.go
+++ b/internal/models/forwarder_v2.go
@@ -17,6 +17,7 @@ type ForwarderConfigV2 struct {
 	Syslog  *ForwarderSyslogV2  `json:"-"`
 	Datadog *ForwarderDatadogV2 `json:"-"`
 	Amqp    *ForwarderAmqpV2    `json:"-"`
+	Splunk  *ForwarderSplunkV2  `json:"-"`
 }
 
 func (ForwarderConfigV2) JSONSchemaOneOf() []any {
@@ -25,6 +26,7 @@ func (ForwarderConfigV2) JSONSchemaOneOf() []any {
 		ForwarderSyslogV2{},
 		ForwarderDatadogV2{},
 		ForwarderAmqpV2{},
+		ForwarderSplunkV2{},
 	}
 }
 
@@ -41,6 +43,9 @@ func (f *ForwarderV2) Call(ctx context.Context, record *LogRecord) error {
 
 	case f.Config.Amqp != nil:
 		return f.Config.Amqp.call(ctx, record)
+
+	case f.Config.Splunk != nil:
+		return f.Config.Splunk.call(ctx, record)
 
 	default:
 		return fmt.Errorf("unsupported forwarder type")
@@ -60,6 +65,9 @@ func (cfg *ForwarderConfigV2) MarshalJSON() ([]byte, error) {
 
 	case cfg.Amqp != nil:
 		return json.Marshal(&cfg.Amqp)
+
+	case cfg.Splunk != nil:
+		return json.Marshal(&cfg.Splunk)
 
 	default:
 		return nil, fmt.Errorf("unsupported forwarder type")
@@ -87,6 +95,9 @@ func (cfg *ForwarderConfigV2) UnmarshalJSON(data []byte) error {
 
 	case "amqp":
 		return json.Unmarshal(data, &cfg.Amqp)
+
+	case "splunk":  
+        return json.Unmarshal(data, &cfg.Splunk)
 
 	default:
 		return fmt.Errorf("unsupported forwarder type: %s", typeInfo.Type)

--- a/internal/models/forwarder_v2_splunk.go
+++ b/internal/models/forwarder_v2_splunk.go
@@ -1,0 +1,68 @@
+package models
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ForwarderSplunkV2 struct {
+	Type     string `json:"type" enum:"splunk"`
+	Endpoint string `json:"endpoint"`
+	Token    string `json:"token"`
+}
+
+func (f *ForwarderSplunkV2) call(ctx context.Context, record *LogRecord) error {
+	 // Convert map[string]string to map[string]interface{}
+	 eventFields := make(map[string]interface{})
+	 for k, v := range record.Fields {
+		 eventFields[k] = v
+	 }
+
+	// Create Splunk HEC payload
+	payload := struct {
+		Event      map[string]interface{} `json:"event"`
+		Sourcetype string                 `json:"sourcetype"`
+		Source     string                 `json:"source"`
+		Host       string                 `json:"host"`
+		Time       int64                  `json:"time"`
+	}{
+		Event:      eventFields,
+		Sourcetype: "json",
+		Source:     "flowg",
+		Host:       record.Fields["host"], // or get from system
+		Time:       record.Timestamp.Unix(),
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log record: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST", f.Endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add required headers
+	req.Header.Add("Authorization", "Splunk "+f.Token)
+	req.Header.Add("Content-Type", "application/json")
+
+	// Send request
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/models/forwarder_v2_splunk_test.go
+++ b/internal/models/forwarder_v2_splunk_test.go
@@ -1,0 +1,72 @@
+package models_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"context"
+	"net/http"
+
+	"link-society.com/flowg/internal/models"
+)
+
+func TestForwarderSplunk_Call(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify headers
+		auth := r.Header.Get("Authorization")
+		if auth != "Splunk test-token" {
+			t.Fatalf("unexpected auth header: %s", auth)
+		}
+
+		// Verify content type
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Fatalf("unexpected content type: %s", contentType)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Splunk: &models.ForwarderSplunkV2{
+				Endpoint: testServer.URL,
+				Token:    "test-token",
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{
+		"message": "test message",
+		"host":    "test-host",
+	})
+	err := forwarder.Call(context.Background(), record)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestForwarderSplunk_Call_Failure(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Splunk: &models.ForwarderSplunkV2{
+				Endpoint: testServer.URL,
+				Token:    "test-token",
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{})
+	err := forwarder.Call(context.Background(), record)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/tests/specs/api/forwarders_splunk.hurl
+++ b/tests/specs/api/forwarders_splunk.hurl
@@ -1,0 +1,63 @@
+GET http://localhost:5080/api/v1/forwarders
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.forwarders" count == 0
+
+PUT http://localhost:5080/api/v1/forwarders/splunk-test
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "forwarder": {
+    "version": 2,
+    "config": {
+      "type": "splunk",
+      "endpoint": "http://localhost:8088/services/collector/event",
+      "token": "test-token"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/forwarders
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.forwarders" count == 1
+jsonpath "$.forwarders[0]" == "splunk-test"
+
+GET http://localhost:5080/api/v1/forwarders/splunk-test
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.forwarder.config.type" == "splunk"
+jsonpath "$.forwarder.config.endpoint" == "http://localhost:8088/services/collector/event"
+jsonpath "$.forwarder.config.token" == "test-token"
+
+POST http://localhost:5080/api/v1/test/forwarders/splunk-test
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "record": {
+    "message": "Test log message",
+    "host": "test-host"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+DELETE http://localhost:5080/api/v1/forwarders/splunk-test
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/forwarders/splunk-test
+Authorization: Bearer {{admin_token}}
+HTTP 404 

--- a/web/app/src/components/editors/pipeline/flow-editor.tsx
+++ b/web/app/src/components/editors/pipeline/flow-editor.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useMemo,
   useState,
+  KeyboardEvent,
 } from 'react'
 
 import Chip from '@mui/material/Chip'
@@ -50,7 +51,7 @@ export const FlowEditor: React.FC<FlowEditorProps> = ({
   flow,
   onFlowChange,
 }) => {
-  const { screenToFlowPosition } = useReactFlow()
+  const { screenToFlowPosition, getNodes, getEdges, deleteElements } = useReactFlow()
 
   const nodeTypes = useMemo(
     () => ({
@@ -179,6 +180,22 @@ export const FlowEditor: React.FC<FlowEditorProps> = ({
     [screenToFlowPosition]
   )
 
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        const selectedNodes = getNodes().filter((node) => node.selected && node.deletable !== false)
+        if (selectedNodes.length > 0) {
+          const selectedNodeIds = selectedNodes.map((node) => node.id)
+          const edgesToDelete = getEdges().filter(
+            (edge) => selectedNodeIds.includes(edge.source) || selectedNodeIds.includes(edge.target)
+          )
+          deleteElements({ nodes: selectedNodes, edges: edgesToDelete })
+        }
+      }
+    },
+    [getNodes, getEdges, deleteElements]
+  )
+
   return (
     <Paper className="w-full h-full">
       <ReactFlow
@@ -190,6 +207,7 @@ export const FlowEditor: React.FC<FlowEditorProps> = ({
         onConnect={onConnect}
         onDrop={onDrop}
         onDragOver={onDragOver}
+        onKeyDown={onKeyDown}
         fitView
         snapToGrid
         defaultEdgeOptions={{ animated: true, type: 'smoothstep' }}


### PR DESCRIPTION
Decision Record

Adds Splunk HTTP Event Collector (HEC) support as a forwarder type.

Changes

- Add Splunk forwarder type with endpoint and token configuration
- Add unit tests for Splunk forwarder
- Add integration tests using HURL
- Update forwarder type validation to support Splunk