### PR TITLE
:white_check_mark: Add Mockserver

### DIFF
--- a/tests/config/mockserver-config.json
+++ b/tests/config/mockserver-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "flowg_forwarder_http_success",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/test/flowg/forwarder/http/success"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": "OK"
+    },
+    "times": {
+      "unlimited": true
+    }
+  },
+  {
+    "id": "flowg_forwarder_http_fail",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/test/flowg/forwarder/http/fail"
+    },
+    "httpResponse": {
+      "statusCode": 500,
+      "body": "Internal Server Error"
+    },
+    "times": {
+      "unlimited": true
+    }
+  }
+]

--- a/tests/specs/api/forwarder_http.hurl
+++ b/tests/specs/api/forwarder_http.hurl
@@ -1,0 +1,71 @@
+PUT http://localhost:5080/api/v1/forwarders/http-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "forwarder": {
+    "config": {
+      "type": "http",
+      "url": "http://test-flowg-mockserver:1080/test/flowg/forwarder/http/success",
+      "headers": {
+        "Foo": "Bar"
+      }
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+POST http://localhost:5080/api/v1/test/forwarders/http-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "record": {
+    "message": "Hello, World!"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+DELETE http://localhost:5080/api/v1/forwarders/http-success
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+###############################################################################
+
+PUT http://localhost:5080/api/v1/forwarders/http-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "forwarder": {
+    "config": {
+      "type": "http",
+      "url": "http://test-flowg-mockserver:1080/test/flowg/forwarder/http/fail",
+      "headers": {
+        "Foo": "Bar"
+      }
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+POST http://localhost:5080/api/v1/test/forwarders/http-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "record": {
+    "message": "Hello, World!"
+  }
+}
+HTTP 500
+
+DELETE http://localhost:5080/api/v1/forwarders/http-fail
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true

--- a/tests/specs/api/forwarders.hurl
+++ b/tests/specs/api/forwarders.hurl
@@ -44,18 +44,6 @@ jsonpath "$.forwarder.config.type" == "http"
 jsonpath "$.forwarder.config.url" == "http://httpbin.org/anything"
 jsonpath "$.forwarder.config.headers.Foo" == "Bar"
 
-POST http://localhost:5080/api/v1/test/forwarders/httpbin
-Authorization: Bearer {{admin_token}}
-Content-Type: application/json
-{
-  "record": {
-    "message": "Hello, World!"
-  }
-}
-HTTP 200
-[Asserts]
-jsonpath "$.success" == true
-
 DELETE http://localhost:5080/api/v1/forwarders/httpbin
 Authorization: Bearer {{admin_token}}
 HTTP 200
@@ -65,37 +53,3 @@ jsonpath "$.success" == true
 GET http://localhost:5080/api/v1/forwarders/httpbin
 Authorization: Bearer {{admin_token}}
 HTTP 404
-
-PUT http://localhost:5080/api/v1/forwarders/fail
-Authorization: Bearer {{admin_token}}
-Content-Type: application/json
-{
-  "forwarder": {
-    "config": {
-      "type": "http",
-      "url": "http://httpbin.org/status/500",
-      "headers": {
-        "Foo": "Bar"
-      }
-    }
-  }
-}
-HTTP 200
-[Asserts]
-jsonpath "$.success" == true
-
-POST http://localhost:5080/api/v1/test/forwarders/fail
-Authorization: Bearer {{admin_token}}
-Content-Type: application/json
-{
-  "record": {
-    "message": "Hello, World!"
-  }
-}
-HTTP 500
-
-DELETE http://localhost:5080/api/v1/forwarders/fail
-Authorization: Bearer {{admin_token}}
-HTTP 200
-[Asserts]
-jsonpath "$.success" == true

--- a/tests/src/_lib/mockserver_utils.py
+++ b/tests/src/_lib/mockserver_utils.py
@@ -1,0 +1,74 @@
+import pytest
+
+from contextlib import contextmanager
+from time import sleep
+
+import requests
+
+from . import docker_utils
+
+
+@contextmanager
+def container(
+    docker_client,
+    *,
+    name,
+    network,
+    config_dir,
+    report_dir,
+):
+    print(f"Creating container: {name}")
+    container = docker_client.containers.run(
+        image="mockserver/mockserver:latest",
+        name=name,
+        network=network.name,
+        hostname=name,
+        environment={
+            "MOCKSERVER_INITIALIZATION_JSON_PATH": "/config.json",
+        },
+        ports={
+            "1080/tcp": 1080,
+        },
+        volumes={
+            (config_dir / "mockserver-config.json").absolute().as_posix(): {
+                "bind": "/config.json",
+                "mode": "ro",
+            }
+        },
+        detach=True,
+    )
+
+    try:
+        print(f"Waiting for healthcheck: {name}")
+        wait_for_healthcheck()
+
+    except RuntimeError as err:
+        docker_utils.teardown_container(container, report_dir)
+        pytest.fail(f"{err}", pytrace=False)
+
+    yield
+
+    docker_utils.teardown_container(container, report_dir)
+
+
+def wait_for_healthcheck():
+    attempt = 0
+    max_attempts = 10
+
+    while True:
+        try:
+            response = requests.put(
+                "http://localhost:1080/mockserver/status",
+                timeout=1,
+            )
+            response.raise_for_status()
+
+        except Exception:
+            attempt += 1
+            if attempt >= max_attempts:
+                raise
+
+            sleep(1)
+
+        else:
+            break

--- a/tests/src/api/test_e2e.py
+++ b/tests/src/api/test_e2e.py
@@ -11,6 +11,7 @@ def test_hurl(
     spec_dir,
     report_dir,
     cache_dir,
+    mockserver_container,
     flowg_admin_token,
     flowg_guest_token,
     otlp_pb,

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from shutil import rmtree
 import docker
 
-from ._lib import docker_utils, flowg_utils
+from ._lib import docker_utils, flowg_utils, mockserver_utils
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -13,6 +13,12 @@ def log_separator(request):
     print("--- Running test:", request.node.path)
     yield
     print("-" * 80)
+
+
+@pytest.fixture(scope="module")
+def config_dir():
+    config_dir = Path.cwd() / "config"
+    yield config_dir
 
 
 @pytest.fixture(scope="module")
@@ -178,6 +184,23 @@ def flowg_guest_token(flowg_admin_token):
         username="guest",
         password="guest",
     )
+
+
+@pytest.fixture(scope='module')
+def mockserver_container(
+    config_dir,
+    report_dir,
+    docker_client,
+    flowg_network,
+):
+    with mockserver_utils.container(
+        docker_client,
+        name="test-flowg-mockserver",
+        network=flowg_network,
+        config_dir=config_dir,
+        report_dir=report_dir,
+    ):
+        yield
 
 
 def pytest_report_teststatus(report, config):


### PR DESCRIPTION
## Decision Record

The forwarders are making requests to third-party services. In order to test them, we need to mock the third-party services.

In the current test suite, we relied on https://httpbin.org for the HTTP Forwarder, which is fine, but not enough for other forwarders (Datadog, and upcoming Splunk HEC in #685).

Instead, with https://mock-server.com, we can define "expectations" to match HTTP requests and return responses accordingly.

## Changes

 - [x] :white_check_mark: Add MockServer container to test suite
 - [x] :white_check_mark: Add request "expectations" for HTTP forwarder
 - [x] :white_check_mark: Split forwarder test suite, one to test the actual API, one to test the HTTP forwarder
 - [x] :white_check_mark: Switch test HTTP forwarder from HttpBin to MockServer

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
