### PR TITLE
✨ add Splunk forwarder support

### DIFF
--- a/internal/models/forwarder_v2.go
+++ b/internal/models/forwarder_v2.go
@@ -17,6 +17,7 @@ type ForwarderConfigV2 struct {
 	Syslog  *ForwarderSyslogV2  `json:"-"`
 	Datadog *ForwarderDatadogV2 `json:"-"`
 	Amqp    *ForwarderAmqpV2    `json:"-"`
+	Splunk  *ForwarderSplunkV2  `json:"-"`
 }
 
 func (ForwarderConfigV2) JSONSchemaOneOf() []any {
@@ -25,23 +26,23 @@ func (ForwarderConfigV2) JSONSchemaOneOf() []any {
 		ForwarderSyslogV2{},
 		ForwarderDatadogV2{},
 		ForwarderAmqpV2{},
+		ForwarderSplunkV2{},
 	}
 }
 
+// Call sends the log record to the configured forwarder
 func (f *ForwarderV2) Call(ctx context.Context, record *LogRecord) error {
 	switch {
 	case f.Config.Http != nil:
 		return f.Config.Http.call(ctx, record)
-
+	case f.Config.Splunk != nil:
+		return f.Config.Splunk.call(ctx, record)
 	case f.Config.Syslog != nil:
 		return f.Config.Syslog.call(ctx, record)
-
 	case f.Config.Datadog != nil:
 		return f.Config.Datadog.call(ctx, record)
-
 	case f.Config.Amqp != nil:
 		return f.Config.Amqp.call(ctx, record)
-
 	default:
 		return fmt.Errorf("unsupported forwarder type")
 	}
@@ -60,6 +61,9 @@ func (cfg *ForwarderConfigV2) MarshalJSON() ([]byte, error) {
 
 	case cfg.Amqp != nil:
 		return json.Marshal(&cfg.Amqp)
+
+	case cfg.Splunk != nil:
+		return json.Marshal(&cfg.Splunk)
 
 	default:
 		return nil, fmt.Errorf("unsupported forwarder type")
@@ -87,6 +91,9 @@ func (cfg *ForwarderConfigV2) UnmarshalJSON(data []byte) error {
 
 	case "amqp":
 		return json.Unmarshal(data, &cfg.Amqp)
+
+	case "splunk":
+		return json.Unmarshal(data, &cfg.Splunk)
 
 	default:
 		return fmt.Errorf("unsupported forwarder type: %s", typeInfo.Type)

--- a/internal/models/forwarder_v2_splunk.go
+++ b/internal/models/forwarder_v2_splunk.go
@@ -1,0 +1,83 @@
+package models
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ForwarderSplunkV2 struct {
+	Type     string `json:"type" enum:"splunk"`
+	Endpoint string `json:"endpoint"`
+	Token    string `json:"token"`
+}
+
+func (f *ForwarderSplunkV2) call(ctx context.Context, record *LogRecord) error {
+	// Convert map[string]string to map[string]interface{}
+	eventFields := make(map[string]interface{})
+	for k, v := range record.Fields {
+		eventFields[k] = v
+	}
+
+	// Create Splunk HEC payload
+	payload := struct {
+		Event      map[string]interface{} `json:"event"`
+		Sourcetype string                 `json:"sourcetype"`
+		Source     string                 `json:"source"`
+		Host       string                 `json:"host"`
+		Time       int64                  `json:"time"`
+	}{
+		Event:      eventFields,
+		Sourcetype: "json",
+		Source:     "flowg",
+		Host:       getHost(record.Fields),
+		Time:       record.Timestamp.Unix(),
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log record: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST", f.Endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add required headers
+	req.Header.Add("Authorization", "Splunk "+f.Token)
+	req.Header.Add("Content-Type", "application/json")
+
+	// Send request
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code from Splunk: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Text string `json:"text"`
+		Code int    `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getHost returns the host from fields or a default value
+func getHost(fields map[string]string) string {
+	host, ok := fields["host"]
+	if !ok || host == "" {
+		return "flowg"
+	}
+	return host
+}

--- a/internal/models/forwarder_v2_splunk_test.go
+++ b/internal/models/forwarder_v2_splunk_test.go
@@ -1,0 +1,76 @@
+package models_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"context"
+	"net/http"
+
+	"link-society.com/flowg/internal/models"
+)
+
+func TestForwarderSplunk_Call(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify headers
+		auth := r.Header.Get("Authorization")
+		if auth != "Splunk test-token" {
+			t.Fatalf("unexpected auth header: %s", auth)
+		}
+
+		// Verify content type
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Fatalf("unexpected content type: %s", contentType)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"text": "Success", "code": 0}`))
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Splunk: &models.ForwarderSplunkV2{
+				Endpoint: testServer.URL,
+				Token:    "test-token",
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{
+		"message": "test message",
+		"host":    "test-host",
+	})
+	err := forwarder.Call(context.Background(), record)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestForwarderSplunk_Call_Failure(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"text": "Internal Server Error", "code": 1}`))
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Splunk: &models.ForwarderSplunkV2{
+				Endpoint: testServer.URL,
+				Token:    "test-token",
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{})
+	err := forwarder.Call(context.Background(), record)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/tests/config/mockserver-config.json
+++ b/tests/config/mockserver-config.json
@@ -26,5 +26,33 @@
     "times": {
       "unlimited": true
     }
+  },
+  {
+    "id": "flowg_forwarder_splunk_success",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/services/collector/event"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": "{\"text\":\"Success\",\"code\":0}"
+    },
+    "times": {
+      "unlimited": true
+    }
+  },
+  {
+    "id": "flowg_forwarder_splunk_fail",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/services/collector/fail"
+    },
+    "httpResponse": {
+      "statusCode": 500,
+      "body": "Internal Server Error"
+    },
+    "times": {
+      "unlimited": true
+    }
   }
 ]

--- a/tests/specs/api/forwarder_splunk.hurl
+++ b/tests/specs/api/forwarder_splunk.hurl
@@ -1,0 +1,69 @@
+PUT http://localhost:5080/api/v1/forwarders/splunk-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "forwarder": {
+    "config": {
+      "type": "splunk",
+      "endpoint": "http://test-flowg-mockserver:1080/services/collector/event",
+      "token": "12345678-1234-1234-1234-123456789012"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+POST http://localhost:5080/api/v1/test/forwarders/splunk-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "record": {
+    "message": "Splunk success test"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+DELETE http://localhost:5080/api/v1/forwarders/splunk-success
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+PUT http://localhost:5080/api/v1/forwarders/splunk-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "forwarder": {
+    "config": {
+      "type": "splunk",
+      "endpoint": "http://test-flowg-mockserver:1080/services/collector/fail",
+      "token": "12345678-1234-1234-1234-123456789012"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+POST http://localhost:5080/api/v1/test/forwarders/splunk-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "record": {
+    "message": "Splunk failure test"
+  }
+}
+HTTP 500
+
+DELETE http://localhost:5080/api/v1/forwarders/splunk-fail
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true


### PR DESCRIPTION
Decision Record:

Add Splunk HEC Forwarder

Summary
Add support for Splunk HTTP Event Collector (HEC) as a new forwarder type.

Changes
- Added `splunk` forwarder with endpoint and token config
- Implemented HTTP POST to Splunk HEC with proper payload and headers
- Added unit and integration tests (HURL)