### PR TITLE
✨ add OpenTelemetry forwarder support

### DIFF
--- a/internal/models/forwarder_v2.go
+++ b/internal/models/forwarder_v2.go
@@ -18,6 +18,7 @@ type ForwarderConfigV2 struct {
 	Datadog *ForwarderDatadogV2 `json:"-"`
 	Amqp    *ForwarderAmqpV2    `json:"-"`
 	Splunk  *ForwarderSplunkV2  `json:"-"`
+	Otlp    *ForwarderOtlpV2    `json:"-"`
 }
 
 func (ForwarderConfigV2) JSONSchemaOneOf() []any {
@@ -27,6 +28,8 @@ func (ForwarderConfigV2) JSONSchemaOneOf() []any {
 		ForwarderDatadogV2{},
 		ForwarderAmqpV2{},
 		ForwarderSplunkV2{},
+		ForwarderOtlpV2{},
+
 	}
 }
 
@@ -43,6 +46,8 @@ func (f *ForwarderV2) Call(ctx context.Context, record *LogRecord) error {
 		return f.Config.Datadog.call(ctx, record)
 	case f.Config.Amqp != nil:
 		return f.Config.Amqp.call(ctx, record)
+	case f.Config.Otlp != nil:
+		return f.Config.Otlp.call(ctx, record)
 	default:
 		return fmt.Errorf("unsupported forwarder type")
 	}
@@ -64,6 +69,9 @@ func (cfg *ForwarderConfigV2) MarshalJSON() ([]byte, error) {
 
 	case cfg.Splunk != nil:
 		return json.Marshal(&cfg.Splunk)
+
+	case cfg.Otlp != nil:
+		return json.Marshal(&cfg.Otlp)
 
 	default:
 		return nil, fmt.Errorf("unsupported forwarder type")
@@ -94,6 +102,9 @@ func (cfg *ForwarderConfigV2) UnmarshalJSON(data []byte) error {
 
 	case "splunk":
 		return json.Unmarshal(data, &cfg.Splunk)
+
+	case "otlp":
+		return json.Unmarshal(data, &cfg.Otlp)
 
 	default:
 		return fmt.Errorf("unsupported forwarder type: %s", typeInfo.Type)

--- a/internal/models/forwarder_v2_otlp.go
+++ b/internal/models/forwarder_v2_otlp.go
@@ -1,0 +1,128 @@
+package models
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
+	otlplogs "go.opentelemetry.io/proto/otlp/logs/v1"
+	proto "google.golang.org/protobuf/proto"
+)
+
+type OtlpForwarderConfig struct {
+	Endpoint string            `json:"endpoint,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+}
+
+type ForwarderOtlpV2 struct {
+	Type   string              `json:"type" enum:"otlp"`
+	Config OtlpForwarderConfig `json:"config"`
+	client *http.Client        `json:"-"`
+}
+
+// call sends a single log record
+func (f *ForwarderOtlpV2) call(ctx context.Context, record *LogRecord) error {
+	// Initialize client if nil
+	if f.client == nil {
+		f.client = &http.Client{}
+	}
+
+	// Convert single log to OTLP protobuf msg format
+	otlpLogs, err := ConvertToOtlpLogs([]*LogRecord{record})
+	if err != nil {
+		return err
+	}
+
+	// Marshal the OTLP logs to protobuf bytes
+	data, err := proto.Marshal(otlpLogs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OTLP logs: %w", err)
+	}
+
+	// Create HTTP POST request
+	req, err := http.NewRequestWithContext(ctx, "POST", f.Config.Endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set Headers
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range f.Config.Headers {
+		req.Header.Set(k, v)
+	}
+
+	// Send the request
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		errMsg := fmt.Sprintf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+		fmt.Println("OTLP forwarder error:", errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
+}
+
+// ConvertToOtlpLogs converts a slice of LogRecord to OTLP LogsData format
+func ConvertToOtlpLogs(records []*LogRecord) (*otlplogs.LogsData, error) {
+	otlpLogs := &otlplogs.LogsData{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				ScopeLogs: []*otlplogs.ScopeLogs{
+					{
+						LogRecords: []*otlplogs.LogRecord{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, r := range records {
+		lr := &otlplogs.LogRecord{
+			TimeUnixNano: uint64(r.Timestamp.UnixNano()),
+			Body: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: getBody(r.Fields),
+				},
+			},
+			Attributes: []*otlpcommon.KeyValue{},
+		}
+
+		// Convert log fields to OTLP attributes
+		for k, v := range r.Fields {
+			if k == "body" {
+				continue // Skip body as it's already set
+			}
+			attr := &otlpcommon.KeyValue{
+				Key: k,
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_StringValue{
+						StringValue: v,
+					},
+				},
+			}
+			lr.Attributes = append(lr.Attributes, attr)
+		}
+
+		otlpLogs.ResourceLogs[0].ScopeLogs[0].LogRecords = append(otlpLogs.ResourceLogs[0].ScopeLogs[0].LogRecords, lr)
+	}
+
+	return otlpLogs, nil
+}
+
+// getBody returns the body from fields or a default empty string
+func getBody(fields map[string]string) string {
+	body, ok := fields["body"]
+	if !ok || body == "" {
+		return ""
+	}
+	return body
+}

--- a/internal/models/forwarder_v2_otlp_test.go
+++ b/internal/models/forwarder_v2_otlp_test.go
@@ -1,0 +1,90 @@
+package models_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"link-society.com/flowg/internal/models"
+)
+
+func TestForwarderOtlpV2_Call_Success(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check content type header
+		if got := r.Header.Get("Content-Type"); got != "application/x-protobuf" {
+			t.Fatalf("unexpected Content-Type: %s", got)
+		}
+
+		// Check custom header
+		if got := r.Header.Get("X-Test-Header"); got != "test-value" {
+			t.Fatalf("unexpected X-Test-Header: %s", got)
+		}
+
+		// Read body (protobuf bytes)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if len(body) == 0 {
+			t.Fatalf("empty body")
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Otlp: &models.ForwarderOtlpV2{
+				Type: "otlp",
+				Config: models.OtlpForwarderConfig{
+					Endpoint: testServer.URL,
+					Headers: map[string]string{
+						"X-Test-Header": "test-value",
+					},
+				},
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{
+		"body": "test log body",
+		"foo":  "bar",
+	})
+	err := forwarder.Call(context.Background(), record)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestForwarderOtlpV2_Call_Failure(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 500 error
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Internal Server Error"))
+	}))
+	defer testServer.Close()
+
+	forwarder := &models.ForwarderV2{
+		Version: 2,
+		Config: &models.ForwarderConfigV2{
+			Otlp: &models.ForwarderOtlpV2{
+				Type: "otlp",
+				Config: models.OtlpForwarderConfig{
+					Endpoint: testServer.URL,
+				},
+			},
+		},
+	}
+
+	record := models.NewLogRecord(map[string]string{
+		"body": "test log body",
+	})
+	err := forwarder.Call(context.Background(), record)
+	if err == nil {
+		t.Fatalf("expected error on failure response, got nil")
+	}
+}

--- a/tests/config/mockserver-config.json
+++ b/tests/config/mockserver-config.json
@@ -54,5 +54,42 @@
     "times": {
       "unlimited": true
     }
+  },{
+    "id": "flowg_forwarder_otlp_success",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/v1/logs",
+      "headers": {
+        "Content-Type": ["application/x-protobuf"],
+        "X-Custom-Header": ["test-value"],
+        "X-Test-Mode": ["success"]
+      }
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": ""
+    },
+    "times": {
+      "unlimited": true
+    }
+  },
+  {
+    "id": "flowg_forwarder_otlp_fail",
+    "httpRequest": {
+      "method": "POST",
+      "path": "/v1/logs",
+      "headers": {
+        "Content-Type": ["application/x-protobuf"],
+        "X-Custom-Header": ["test-value"],
+        "X-Test-Mode": ["fail"]
+      }
+    },
+    "httpResponse": {
+      "statusCode": 500,
+      "body": "Internal Server Error"
+    },
+    "times": {
+      "unlimited": true
+    }
   }
 ]

--- a/tests/specs/api/forwarder_otlp.hurl
+++ b/tests/specs/api/forwarder_otlp.hurl
@@ -1,0 +1,122 @@
+###############################################################################
+# OTLP Forwarder - Success Scenario
+###############################################################################
+
+# Create OTLP Success Forwarder
+PUT http://localhost:5080/api/v1/forwarders/otlp-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "forwarder": {
+    "version": 2,
+    "config": {
+      "type": "otlp",
+      "config": {
+        "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
+        "headers": {
+          "X-Custom-Header": "test-value",
+          "X-Test-Mode": "success",
+          "Content-Type": "application/x-protobuf"
+        }
+      }
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Send minimal test log (should forward with above headers)
+POST http://localhost:5080/api/v1/test/forwarders/otlp-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "record": {
+    "timestamp": "1700000000000000000",
+    "body": "Minimal test log message"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Send full test log
+POST http://localhost:5080/api/v1/test/forwarders/otlp-success
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "record": {
+    "timestamp": "1700000000000000000",
+    "body": "Full test log message",
+    "severity_number": "9",
+    "severity_text": "INFO",
+    "service": "auth",
+    "environment": "production"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Delete OTLP Success Forwarder
+DELETE http://localhost:5080/api/v1/forwarders/otlp-success
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+
+###############################################################################
+# OTLP Forwarder - Failure Scenario
+###############################################################################
+
+# Create OTLP Fail Forwarder (headers specify X-Test-Mode: fail)
+PUT http://localhost:5080/api/v1/forwarders/otlp-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "forwarder": {
+    "version": 2,
+    "config": {
+      "type": "otlp",
+      "config": {
+        "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
+        "headers": {
+          "X-Custom-Header": "test-value",
+          "X-Test-Mode": "fail",
+          "Content-Type": "application/x-protobuf"
+        }
+      }
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Send test log that should fail (mockserver returns 500)
+POST http://localhost:5080/api/v1/test/forwarders/otlp-fail
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+
+{
+  "record": {
+    "timestamp": "1700000000000000000",
+    "body": "Test OTLP failure"
+  }
+}
+HTTP 500
+[Asserts]
+jsonpath "$.status" == "INTERNAL"
+jsonpath "$.error" == "internal: unexpected status code: 500, body: Internal Server Error"
+
+# Delete OTLP Fail Forwarder
+DELETE http://localhost:5080/api/v1/forwarders/otlp-fail
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true

--- a/web/app/src/components/editors/forwarder/index.tsx
+++ b/web/app/src/components/editors/forwarder/index.tsx
@@ -3,6 +3,7 @@ import { ForwarderConfigModel, ForwarderModel } from '@/lib/models/forwarder'
 import { AmqpForwarderEditor } from './amqp'
 import { DatadogForwarderEditor } from './datadog'
 import { HttpForwarderEditor } from './http'
+import { OtlpForwarderEditor } from './otlp'
 import { SplunkForwarderEditor } from './splunk'
 import { SyslogForwarderEditor } from './syslog'
 
@@ -58,6 +59,14 @@ export const ForwarderEditor = ({
     case 'amqp':
       return (
         <AmqpForwarderEditor
+          config={forwarder.config}
+          onConfigChange={onConfigChange}
+        />
+      )
+
+    case 'otlp':
+      return (
+        <OtlpForwarderEditor
           config={forwarder.config}
           onConfigChange={onConfigChange}
         />

--- a/web/app/src/components/editors/forwarder/otlp.tsx
+++ b/web/app/src/components/editors/forwarder/otlp.tsx
@@ -1,0 +1,70 @@
+import TextField from '@mui/material/TextField'
+
+import { OtlpForwarderModel } from '@/lib/models/forwarder/otlp'
+
+import { KeyValueEditor } from '@/components/form/kv-editor'
+
+type OtlpForwarderEditorProps = {
+  config: OtlpForwarderModel
+  onConfigChange: (config: OtlpForwarderModel) => void
+}
+
+export const OtlpForwarderEditor = ({
+  config,
+  onConfigChange,
+}: OtlpForwarderEditorProps) => {
+  const headerPairs = Object.entries(config.headers || {}).map(
+    ([key, value]) => [key, value] as [string, string]
+  )
+
+  const onHeadersChange = (pairs: [string, string][]) => {
+    const newHeaders = pairs.reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value,
+      }),
+      {} as Record<string, string>
+    )
+
+    // Only include headers if there are any
+    const updatedConfig = {
+      ...config,
+      endpoint: config.endpoint,
+    }
+    if (Object.keys(newHeaders).length > 0) {
+      updatedConfig.headers = newHeaders
+    } else {
+      delete updatedConfig.headers
+    }
+
+    onConfigChange(updatedConfig)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <TextField
+        id="input:forwarder.otlp.endpoint"
+        label="Endpoint"
+        value={config.endpoint}
+        onChange={(e) =>
+          onConfigChange({
+            ...config,
+            endpoint: e.target.value,
+          })
+        }
+        type="text"
+        variant="outlined"
+        required
+        className="w-full"
+      />
+
+      <KeyValueEditor
+        id="input:forwarder.otlp.headers"
+        keyLabel="Header Name"
+        valueLabel="Header Value"
+        keyValues={headerPairs}
+        onChange={onHeadersChange}
+      />
+    </div>
+  )
+}

--- a/web/app/src/lib/models/forwarder/index.ts
+++ b/web/app/src/lib/models/forwarder/index.ts
@@ -1,6 +1,7 @@
 import { AmqpForwarderModel } from '@/lib/models/forwarder/amqp'
 import { DatadogForwarderModel } from '@/lib/models/forwarder/datadog'
 import { HttpForwarderModel } from '@/lib/models/forwarder/http'
+import { OtlpForwarderModel } from '@/lib/models/forwarder/otlp'
 import { SplunkForwarderModel } from '@/lib/models/forwarder/splunk'
 import { SyslogForwarderModel } from '@/lib/models/forwarder/syslog'
 
@@ -14,6 +15,7 @@ export const ForwarderTypeValues = [
   { key: 'datadog', label: 'Datadog' },
   { key: 'splunk', label: 'Splunk' },
   { key: 'amqp', label: 'AMQP' },
+  { key: 'otlp', label: 'OpenTelemetry' },
 ] as const
 
 export const ForwarderTypeLabelMap = ForwarderTypeValues.reduce(
@@ -30,5 +32,6 @@ export type ForwarderConfigModel =
   | DatadogForwarderModel
   | SplunkForwarderModel
   | AmqpForwarderModel
+  | OtlpForwarderModel
 
 export type ForwarderTypes = ForwarderConfigModel['type']

--- a/web/app/src/lib/models/forwarder/otlp.ts
+++ b/web/app/src/lib/models/forwarder/otlp.ts
@@ -1,0 +1,5 @@
+export type OtlpForwarderModel = {
+  type: 'otlp'
+  endpoint: string
+  headers?: Record<string, string>
+}

--- a/web/app/src/views/app/forwarders/new-btn/modal.tsx
+++ b/web/app/src/views/app/forwarders/new-btn/modal.tsx
@@ -75,6 +75,15 @@ const newForwarderFactory = (type: ForwarderTypes): ForwarderModel => {
         },
       }
 
+    case 'otlp':
+      return {
+        config: {
+          type,
+          endpoint: 'http://localhost:4318',
+          headers: {},
+        },
+      }
+
     default:
       throw new Error(`Unknown forwarder type: ${type}`)
   }

--- a/website/docs/usecases/otlp.mdx
+++ b/website/docs/usecases/otlp.mdx
@@ -1,0 +1,47 @@
+---
+sidebar_position: 7
+---
+
+# Forwarding logs to OpenTelemetry
+
+## Introduction
+
+[OpenTelemetry](https://opentelemetry.io/) is an open-source observability framework that provides a standardized way to collect, process, and export telemetry data. FlowG allows you to forward logs to any OpenTelemetry-compatible system using the OTLP (OpenTelemetry Protocol) HTTP endpoint.
+
+## Setting up OpenTelemetry
+
+To receive logs from FlowG, you need an OpenTelemetry Collector or any system that supports the OTLP HTTP protocol. The default OTLP HTTP endpoint for logs is typically:
+
+```
+http://localhost:4318/v1/logs
+```
+
+## Setting up the FlowG pipeline
+
+First, let's create an "OpenTelemetry Forwarder" named `otlp`, with the following configuration:
+
+| Property | Value | Comment |
+| --- | --- | --- |
+| Endpoint | `http://localhost:4318/v1/logs` | The OTLP HTTP endpoint for logs |
+| Headers | `{}` | Optional headers to send with the request |
+
+Then, create a pipeline that forwards logs to the `otlp` forwarder.
+
+And that's it!
+
+## Testing
+
+You can test the setup by sending a log to the pipeline using the `logger` command:
+
+```bash
+logger -n localhost -P 5514 -t my-app 'hello world'
+```
+
+The log will be forwarded to your OpenTelemetry endpoint in the OTLP format.
+
+## What's next?
+
+Once the logs are received by your OpenTelemetry system, you can:
+- View them in your preferred observability platform
+- Process them using OpenTelemetry processors
+- Export them to other systems using OpenTelemetry exporters 


### PR DESCRIPTION
# Decision Record: Add OTLP Forwarder

## Summary
Added support for OpenTelemetry Protocol (OTLP) as a new forwarder type for exporting logs to OTLP-compatible endpoints.

## Changes
- Added OTLP forwarder with configurable endpoint and headers
- Added unit and integration tests for OTLP functionality