### PR TITLE
:sparkles: Add ability to reset user password on start

### DIFF
--- a/cmd/flowg-server/cmd/cli.go
+++ b/cmd/flowg-server/cmd/cli.go
@@ -37,6 +37,9 @@ type options struct {
 
 	authInitialUser     string
 	authInitialPassword string
+
+	authResetUser     string
+	authResetPassword string
 }
 
 func (opts *options) defineCliOptions(cmd *cobra.Command) {
@@ -228,17 +231,27 @@ func (opts *options) defineCliOptions(cmd *cobra.Command) {
 		&opts.authInitialUser,
 		"auth-initial-user",
 		defaultAuthInitialUser,
-		"Username for the initial admin user (defaults to FLOWG_AUTH_INITIAL_USER or 'root')",
+		"Username for the initial admin user",
 	)
 
 	cmd.Flags().StringVar(
 		&opts.authInitialPassword,
 		"auth-initial-password",
 		defaultAuthInitialPassword,
-		"Password for the initial admin user (defaults to FLOWG_AUTH_INITIAL_PASSWORD or 'root')",
+		"Password for the initial admin user",
 	)
 
-	// Bind environment variables to flags
-	cmd.Flags().Set("auth-initial-user", defaultAuthInitialUser)
-	cmd.Flags().Set("auth-initial-password", defaultAuthInitialPassword)
+	cmd.Flags().StringVar(
+		&opts.authResetUser,
+		"auth-reset-user",
+		defaultAuthResetUser,
+		"If set, this is the username for the user to reset the password for",
+	)
+
+	cmd.Flags().StringVar(
+		&opts.authResetPassword,
+		"auth-reset-password",
+		defaultAuthResetPassword,
+		"If set, this is the new password for the user to reset",
+	)
 }

--- a/cmd/flowg-server/cmd/config.go
+++ b/cmd/flowg-server/cmd/config.go
@@ -126,6 +126,9 @@ func newServerConfig(opts *options) (server.Options, error) {
 
 		AuthInitialUser:     opts.authInitialUser,
 		AuthInitialPassword: opts.authInitialPassword,
+
+		AuthResetUser:     opts.authResetUser,
+		AuthResetPassword: opts.authResetPassword,
 	}
 
 	return config, nil

--- a/cmd/flowg-server/cmd/env.go
+++ b/cmd/flowg-server/cmd/env.go
@@ -51,6 +51,9 @@ var (
 
 	defaultAuthInitialUser     = getEnvString("FLOWG_AUTH_INITIAL_USER", "root")
 	defaultAuthInitialPassword = getEnvString("FLOWG_AUTH_INITIAL_PASSWORD", "root")
+
+	defaultAuthResetUser     = getEnvString("FLOWG_AUTH_RESET_USER", "")
+	defaultAuthResetPassword = getEnvString("FLOWG_AUTH_RESET_PASSWORD", "")
 )
 
 func getEnvString(key string, defaultValue string) string {

--- a/internal/app/server/bootstrap.go
+++ b/internal/app/server/bootstrap.go
@@ -21,6 +21,9 @@ type bootstrapProcHandler struct {
 
 	initialUser     string
 	initialPassword string
+
+	resetUser     string
+	resetPassword string
 }
 
 var _ proctree.ProcessHandler = (*bootstrapProcHandler)(nil)
@@ -48,6 +51,11 @@ func (h *bootstrapProcHandler) Init(ctx actor.Context) proctree.ProcessResult {
 		)
 		return proctree.Terminate(err)
 	}
+
+	err = bootstrap.ResetUser(ctx, h.authStorage, bootstrap.ResetUserOptions{
+		User:     h.resetUser,
+		Password: h.resetPassword,
+	})
 
 	return proctree.Continue()
 }

--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -49,6 +49,9 @@ type Options struct {
 
 	AuthInitialUser     string
 	AuthInitialPassword string
+
+	AuthResetUser     string
+	AuthResetPassword string
 }
 
 func NewServer(opts Options) proctree.Process {
@@ -124,6 +127,8 @@ func NewServer(opts Options) proctree.Process {
 		configStorage:   configStorage,
 		initialUser:     opts.AuthInitialUser,
 		initialPassword: opts.AuthInitialPassword,
+		resetUser:       opts.AuthResetUser,
+		resetPassword:   opts.AuthResetPassword,
 	}
 
 	return proctree.NewProcessGroup(


### PR DESCRIPTION
## Decision Record

If the user forgets the root password, and has no personal access token to change it via API, there is currently no way to gain access to the application.

This PR adds the following environment variables:

| Variable | CLI option | Description |
| --- | --- |
| `FLOWG_AUTH_RESET_USER` | `--auth-reset-user` | Name of the user to reset the password for |
| `FLOWG_AUTH_RESET_PASSWORD` | `--auth-reset-password` | The new password |

If they are both set (and the user exists), this will update the user's password on startup.

The idea is that the system operator who can control how FlowG is run should at least have an escape hatch to reset the credentials.

## Changes

 - [x] :sparkles: Add ability to reset user password on start

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
