### PR TITLE
:recycle: Better logging

### DIFF
--- a/api/change_password.go
+++ b/api/change_password.go
@@ -8,6 +8,7 @@ import (
 	"github.com/swaggest/usecase"
 	"github.com/swaggest/usecase/status"
 
+	"link-society.com/flowg/internal/app/logging"
 	apiUtils "link-society.com/flowg/internal/utils/api"
 )
 
@@ -27,6 +28,8 @@ func (ctrl *controller) ChangePasswordUsecase() usecase.Interactor {
 			req ChangePasswordRequest,
 			resp *ChangePasswordResponse,
 		) error {
+			logging.MarkSensitive(ctx)
+
 			user := apiUtils.GetContextUser(ctx)
 
 			switch valid, err := ctrl.deps.AuthStorage.VerifyUserPassword(ctx, user.Name, req.OldPassword); {

--- a/api/ingest_logs_otlp.go
+++ b/api/ingest_logs_otlp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/swaggest/usecase"
 	"github.com/swaggest/usecase/status"
 
+	"link-society.com/flowg/internal/app/logging"
 	apiUtils "link-society.com/flowg/internal/utils/api"
 	"link-society.com/flowg/internal/utils/otlp"
 
@@ -114,6 +115,8 @@ func (ctrl *controller) IngestLogsOTLPUsecase() usecase.Interactor {
 				req *IngestLogsOTLPRequest,
 				resp *IngestLogsOTLPResponse,
 			) error {
+				logging.MarkSensitive(ctx)
+
 				for _, logRecord := range req.logRecords {
 					err := ctrl.deps.PipelineRunner.Run(
 						ctx,
@@ -122,7 +125,7 @@ func (ctrl *controller) IngestLogsOTLPUsecase() usecase.Interactor {
 						logRecord,
 					)
 					if err != nil {
-						ctrl.logger.ErrorContext(
+						ctrl.logger.DebugContext(
 							ctx,
 							"Failed to process log entry",
 							slog.String("pipeline", req.Pipeline),
@@ -132,7 +135,7 @@ func (ctrl *controller) IngestLogsOTLPUsecase() usecase.Interactor {
 						resp.Success = false
 						return status.Wrap(err, status.Internal)
 					}
-					ctrl.logger.InfoContext(
+					ctrl.logger.DebugContext(
 						ctx,
 						"Log entry processed",
 						slog.String("pipeline", req.Pipeline),

--- a/api/ingest_logs_struct.go
+++ b/api/ingest_logs_struct.go
@@ -7,6 +7,7 @@ import (
 	"github.com/swaggest/usecase"
 	"github.com/swaggest/usecase/status"
 
+	"link-society.com/flowg/internal/app/logging"
 	apiUtils "link-society.com/flowg/internal/utils/api"
 
 	"link-society.com/flowg/internal/models"
@@ -33,6 +34,8 @@ func (ctrl *controller) IngestLogsStructUsecase() usecase.Interactor {
 				req IngestLogsStructRequest,
 				resp *IngestLogsStructResponse,
 			) error {
+				logging.MarkSensitive(ctx)
+
 				for _, recordData := range req.Records {
 					record := models.NewLogRecord(recordData)
 					err := ctrl.deps.PipelineRunner.Run(
@@ -42,7 +45,7 @@ func (ctrl *controller) IngestLogsStructUsecase() usecase.Interactor {
 						record,
 					)
 					if err != nil {
-						ctrl.logger.ErrorContext(
+						ctrl.logger.DebugContext(
 							ctx,
 							"Failed to process log entry",
 							slog.String("pipeline", req.Pipeline),
@@ -53,7 +56,7 @@ func (ctrl *controller) IngestLogsStructUsecase() usecase.Interactor {
 						return status.Wrap(err, status.Internal)
 					}
 
-					ctrl.logger.InfoContext(
+					ctrl.logger.DebugContext(
 						ctx,
 						"Log entry processed",
 						slog.String("pipeline", req.Pipeline),

--- a/api/ingest_logs_text.go
+++ b/api/ingest_logs_text.go
@@ -10,6 +10,7 @@ import (
 	"github.com/swaggest/usecase"
 	"github.com/swaggest/usecase/status"
 
+	"link-society.com/flowg/internal/app/logging"
 	apiUtils "link-society.com/flowg/internal/utils/api"
 
 	"link-society.com/flowg/internal/models"
@@ -36,6 +37,8 @@ func (ctrl *controller) IngestLogsTextUsecase() usecase.Interactor {
 				req IngestLogsTextRequest,
 				resp *IngestLogsTextResponse,
 			) error {
+				logging.MarkSensitive(ctx)
+
 				lines := strings.Split(strings.ReplaceAll(req.TextBody, "\r\n", "\n"), "\n")
 				messages := []string{}
 
@@ -61,7 +64,7 @@ func (ctrl *controller) IngestLogsTextUsecase() usecase.Interactor {
 						record,
 					)
 					if err != nil {
-						ctrl.logger.ErrorContext(
+						ctrl.logger.DebugContext(
 							ctx,
 							"Failed to process log entry",
 							slog.String("pipeline", req.Pipeline),
@@ -72,7 +75,7 @@ func (ctrl *controller) IngestLogsTextUsecase() usecase.Interactor {
 						return status.Wrap(err, status.Internal)
 					}
 
-					ctrl.logger.InfoContext(
+					ctrl.logger.DebugContext(
 						ctx,
 						"Log entry processed",
 						slog.String("pipeline", req.Pipeline),

--- a/cmd/flowg-server/cmd/cli.go
+++ b/cmd/flowg-server/cmd/cli.go
@@ -36,7 +36,9 @@ type options struct {
 	authDir   string
 	logDir    string
 	configDir string
-	verbose   bool
+
+	verbose  bool
+	loglevel string
 
 	authInitialUser     string
 	authInitialPassword string
@@ -235,6 +237,13 @@ func (opts *options) defineCliOptions(cmd *cobra.Command) {
 		"verbose",
 		defaultVerbose,
 		"Enable verbose logging",
+	)
+
+	cmd.Flags().StringVar(
+		&opts.loglevel,
+		"loglevel",
+		defaultLogLevel,
+		"Set the logging level (one of \"debug\", \"info\", \"warn\", \"error\"), ignored if 'verbose' is set",
 	)
 
 	cmd.Flags().StringVar(

--- a/cmd/flowg-server/cmd/env.go
+++ b/cmd/flowg-server/cmd/env.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	defaultVerbose = getEnvBool("FLOWG_VERBOSE", false)
+	defaultVerbose  = getEnvBool("FLOWG_VERBOSE", false)
+	defaultLogLevel = getEnvString("FLOWG_LOGLEVEL", "info")
 
 	defaultHttpBindAddress = getEnvString("FLOWG_HTTP_BIND_ADDRESS", ":5080")
 	defaultHttpTlsEnabled  = getEnvBool("FLOWG_HTTP_TLS_ENABLED", false)

--- a/cmd/flowg-server/cmd/main.go
+++ b/cmd/flowg-server/cmd/main.go
@@ -27,7 +27,7 @@ func NewRootCommand() *cobra.Command {
 		Short: "Low-Code log management solution",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			syscall.Umask(0077)
-			logging.Setup(opts.verbose)
+			logging.Setup(opts.verbose, opts.loglevel)
 			metrics.Setup()
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/app/logging/context.go
+++ b/internal/app/logging/context.go
@@ -9,6 +9,11 @@ import (
 type key string
 
 const CORRELATION_ID = key("correlationId")
+const SENSITIVE_MARKER = key("sensitiveMarker")
+
+type sensitiveMarker struct {
+	marked bool
+}
 
 func WithCorrelationId(
 	ctx context.Context,
@@ -19,4 +24,23 @@ func WithCorrelationId(
 	}
 
 	return context.WithValue(ctx, CORRELATION_ID, correlationId)
+}
+
+func WithSensitiveMarker(ctx context.Context) context.Context {
+	return context.WithValue(ctx, SENSITIVE_MARKER, &sensitiveMarker{marked: false})
+}
+
+func MarkSensitive(ctx context.Context) {
+	m := ctx.Value(SENSITIVE_MARKER)
+	if m != nil {
+		m.(*sensitiveMarker).marked = true
+	}
+}
+
+func IsMarkedSensitive(ctx context.Context) bool {
+	m := ctx.Value(SENSITIVE_MARKER)
+	if m == nil {
+		return false
+	}
+	return m.(*sensitiveMarker).marked
 }

--- a/internal/app/logging/main.go
+++ b/internal/app/logging/main.go
@@ -4,16 +4,28 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 )
 
 var VERBOSE_LOGGING = false
 
-func Setup(verbose bool) {
+func Setup(verbose bool, levelName string) {
 	var level slog.Level
 	if verbose {
 		level = slog.LevelDebug
 	} else {
-		level = slog.LevelInfo
+		switch strings.ToLower(levelName) {
+		case "debug":
+			level = slog.LevelDebug
+		case "info":
+			level = slog.LevelInfo
+		case "warn":
+			level = slog.LevelWarn
+		case "error":
+			level = slog.LevelError
+		default:
+			level = slog.LevelInfo
+		}
 	}
 
 	VERBOSE_LOGGING = verbose


### PR DESCRIPTION
## Decision Record

At the moment, the only way we have to configure the logging level is through the `--verbose` option, which enables debug logging and erroneous response body logging.

On top of that, we are logging in the access log every request to API. But some routes should not log:

 - "change password": for security reasons, we should not log requests to this route
 - log ingestion: let's say we are forwarding FlowG's logs into itself, those routes would create a loop

This PR introduce a new CLI options `--loglevel` and its environment variable counterpart `FLOWG_LOGLEVEL` which can be set to either `debug`, `info`, `warn` or `error` (case insensitive).

> **NB:** enabling verbose logging through `--verbose` or `FLOWG_VERBOSE` ignores the `--loglevel` option.

It also switched the mentioned routes to "debug" logging instead of "info".

## Changes

 - [x] :sparkles: Add new `--loglevel` CLI option and `FLOWG_LOGLEVEL` environment variable
 - [x] :mute: Switch to debug logging for log ingestion routes and password change route

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
