### PR TITLE
:sparkles: Minimal ElasticSearch Input Middleware

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/swaggest/swgui/v5emb"
 	"github.com/swaggest/usecase"
 
+	"link-society.com/flowg/api/middlewares"
 	"link-society.com/flowg/internal/app"
 
 	apiUtils "link-society.com/flowg/internal/utils/api"
@@ -198,6 +199,15 @@ func NewHandler(deps *Dependencies) http.Handler {
 		r.Post("/api/v1/restore/logs", ctrl.RestoreLogsUsecase())
 		r.Post("/api/v1/restore/config", ctrl.RestoreConfigUsecase())
 	})
+
+	service.Mount("/api/v1/middlewares/", middlewares.NewHandler(&middlewares.Dependencies{
+		AuthStorage:   deps.AuthStorage,
+		LogStorage:    deps.LogStorage,
+		ConfigStorage: deps.ConfigStorage,
+
+		LogNotifier:    deps.LogNotifier,
+		PipelineRunner: deps.PipelineRunner,
+	}))
 
 	return service
 }

--- a/api/middlewares/elastic.go
+++ b/api/middlewares/elastic.go
@@ -1,0 +1,226 @@
+package middlewares
+
+import (
+	"log/slog"
+
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+
+	"fmt"
+	"slices"
+	"strings"
+
+	"net/http"
+
+	apiUtils "link-society.com/flowg/internal/utils/api"
+
+	"link-society.com/flowg/internal/engines/pipelines"
+	"link-society.com/flowg/internal/models"
+)
+
+func elasticProduct(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func elasticAuth(deps *Dependencies, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		basicAuthData := authHeader[len("Basic "):]
+		decoded, err := base64.StdEncoding.DecodeString(basicAuthData)
+		if err != nil {
+			http.Error(w, "Invalid Authorization header", http.StatusBadRequest)
+			return
+		}
+
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			http.Error(w, "Invalid Authorization header", http.StatusBadRequest)
+			return
+		}
+
+		username, password := parts[0], parts[1]
+		ok, err := deps.AuthStorage.VerifyUserPassword(r.Context(), username, password)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		user, err := deps.AuthStorage.FetchUser(r.Context(), username)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		ctx := apiUtils.ContextWithUser(r.Context(), user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newElasticHandler(deps *Dependencies) http.Handler {
+	logger := slog.Default().With(slog.String("channel", "input.middleware.elastic"))
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(
+		"HEAD /api/v1/middlewares/elastic/{index}",
+		func(w http.ResponseWriter, r *http.Request) {
+			index := r.PathValue("index")
+
+			user := apiUtils.GetContextUser(r.Context())
+			authorized, err := deps.AuthStorage.VerifyUserPermission(
+				r.Context(),
+				user.Name,
+				models.SCOPE_READ_PIPELINES,
+			)
+			if err != nil {
+				logger.ErrorContext(
+					r.Context(),
+					"Failed to verify user permission",
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			if !authorized {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			pipelines, err := deps.ConfigStorage.ListPipelines(r.Context())
+			if err != nil {
+				logger.ErrorContext(
+					r.Context(),
+					"Failed to list pipelines",
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			if slices.Contains(pipelines, index) {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			http.Error(w, "Not Found", http.StatusNotFound)
+		},
+	)
+
+	mux.HandleFunc(
+		"POST /api/v1/middlewares/elastic/{index}/_doc",
+		func(w http.ResponseWriter, r *http.Request) {
+			index := r.PathValue("index")
+
+			user := apiUtils.GetContextUser(r.Context())
+			authorized, err := deps.AuthStorage.VerifyUserPermission(
+				r.Context(),
+				user.Name,
+				models.SCOPE_SEND_LOGS,
+			)
+			if err != nil {
+				logger.ErrorContext(
+					r.Context(),
+					"Failed to verify user permission",
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			if !authorized {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			defer r.Body.Close()
+			dec := json.NewDecoder(r.Body)
+			dec.UseNumber()
+
+			var doc map[string]any
+			if err := dec.Decode(&doc); err != nil {
+				logger.ErrorContext(
+					r.Context(),
+					"Failed to decode request body",
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Bad Request", http.StatusBadRequest)
+				return
+			}
+
+			fields := map[string]string{}
+
+			joinKey := func(prefix, key string) string {
+				if prefix == "" {
+					return key
+				}
+				return prefix + "." + key
+			}
+
+			var flatten func(prefix string, v any)
+			flatten = func(prefix string, v any) {
+				switch t := v.(type) {
+				case map[string]any:
+					for k, val := range t {
+						flatten(joinKey(prefix, k), val)
+					}
+
+				case []any:
+					for i, val := range t {
+						flatten(joinKey(prefix, strconv.Itoa(i)), val)
+					}
+
+				case nil:
+					fields[prefix] = ""
+
+				case string:
+					fields[prefix] = t
+
+				case json.Number:
+					fields[prefix] = t.String()
+
+				case bool:
+					fields[prefix] = strconv.FormatBool(t)
+
+				default:
+					fields[prefix] = fmt.Sprint(t)
+				}
+			}
+
+			flatten("", doc)
+
+			record := models.NewLogRecord(fields)
+			err = deps.PipelineRunner.Run(
+				r.Context(),
+				index,
+				pipelines.DIRECT_ENTRYPOINT,
+				record,
+			)
+			if err != nil {
+				logger.ErrorContext(
+					r.Context(),
+					"Failed to process log entry",
+					slog.String("pipeline", index),
+					slog.String("error", err.Error()),
+				)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+		},
+	)
+
+	return elasticProduct(elasticAuth(deps, mux))
+}

--- a/api/middlewares/elastic_test.go
+++ b/api/middlewares/elastic_test.go
@@ -1,0 +1,107 @@
+package middlewares_test
+
+import (
+	"testing"
+
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/mock"
+
+	"context"
+
+	"bytes"
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v9"
+
+	"link-society.com/flowg/internal/engines/lognotify"
+	"link-society.com/flowg/internal/engines/pipelines"
+	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/storage/auth"
+	"link-society.com/flowg/internal/storage/config"
+	"link-society.com/flowg/internal/storage/log"
+
+	"link-society.com/flowg/api/middlewares"
+)
+
+func TestElasticEndpoint(t *testing.T) {
+	mockAuthStorage := auth.NewMockStorage().(*auth.MockStorage)
+	mockLogStorage := log.NewMockStorage().(*log.MockStorage)
+	mockConfigStorage := config.NewMockStorage().(*config.MockStorage)
+
+	mockLogNotifier := lognotify.NewMockNotifier().(*lognotify.MockNotifier)
+	mockPipelineRunner := pipelines.NewMockRunner().(*pipelines.MockRunner)
+
+	deps := &middlewares.Dependencies{
+		AuthStorage:   mockAuthStorage,
+		LogStorage:    mockLogStorage,
+		ConfigStorage: mockConfigStorage,
+
+		LogNotifier:    mockLogNotifier,
+		PipelineRunner: mockPipelineRunner,
+	}
+
+	mockAuthStorage.On("VerifyUserPassword", mock.Anything, "test", "test").
+		Return(true, nil)
+	mockAuthStorage.On("FetchUser", mock.Anything, "test").
+		Return(
+			&models.User{
+				Name:  "test",
+				Roles: []string{"admin"},
+			},
+			nil,
+		)
+	mockAuthStorage.On("VerifyUserPermission", mock.Anything, "test", mock.Anything).
+		Return(true, nil)
+
+	mockConfigStorage.On("ListPipelines", mock.Anything).
+		Return([]string{"test"}, nil)
+
+	mockPipelineRunner.On("Run", mock.Anything, "test", pipelines.DIRECT_ENTRYPOINT, mock.Anything).
+		Return(nil)
+
+	handler := middlewares.NewHandler(deps)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	cfg := elasticsearch.Config{
+		Username:  "test",
+		Password:  "test",
+		Addresses: []string{fmt.Sprintf("%s/api/v1/middlewares/elastic/", server.URL)},
+	}
+	client, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to create ElasticSearch client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	resp, err := client.Indices.Exists([]string{"test"}, client.Indices.Exists.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("failed to send ElasticSearch request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.IsError() {
+		t.Fatalf("failed to check index: %s", resp.String())
+	}
+
+	data := bytes.NewReader([]byte(`{"message": "test log"}`))
+	resp, err = client.Index("test", data, client.Index.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("failed to send ElasticSearch request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.IsError() {
+		t.Fatalf("failed to index document: %s", resp.String())
+	}
+
+	mockAuthStorage.AssertExpectations(t)
+	mockLogStorage.AssertExpectations(t)
+	mockConfigStorage.AssertExpectations(t)
+
+	mockLogNotifier.AssertExpectations(t)
+	mockPipelineRunner.AssertExpectations(t)
+}

--- a/api/middlewares/main.go
+++ b/api/middlewares/main.go
@@ -1,0 +1,29 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"link-society.com/flowg/internal/storage/auth"
+	"link-society.com/flowg/internal/storage/config"
+	"link-society.com/flowg/internal/storage/log"
+
+	"link-society.com/flowg/internal/engines/lognotify"
+	"link-society.com/flowg/internal/engines/pipelines"
+)
+
+type Dependencies struct {
+	AuthStorage   auth.Storage
+	LogStorage    log.Storage
+	ConfigStorage config.Storage
+
+	LogNotifier    lognotify.LogNotifier
+	PipelineRunner pipelines.Runner
+}
+
+func NewHandler(deps *Dependencies) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.Handle("/api/v1/middlewares/elastic/", newElasticHandler(deps))
+
+	return mux
+}

--- a/tests/specs/api/ingest_logs_struct.hurl
+++ b/tests/specs/api/ingest_logs_struct.hurl
@@ -27,6 +27,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.processed_count" == 2
+
 GET http://localhost:5080/api/v1/streams/default/logs
 Authorization: Bearer {{admin_token}}
 [Query]

--- a/tests/specs/api/middleware_elastic.hurl
+++ b/tests/specs/api/middleware_elastic.hurl
@@ -1,0 +1,52 @@
+###############################################################################
+# DESCRIPTION: Test ElasticSearch compatibility API
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Check that an index (a FlowG pipeline) exists
+#  - Verify that the endpoint returns the proper ElasticSearch headers
+
+HEAD http://localhost:5080/api/v1/middlewares/elastic/default
+[BasicAuth]
+root: root
+HTTP 200
+X-Elastic-Product: Elasticsearch
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Send logs to the default pipeline via the ElasticSearch API
+#  - Verify logs have been ingested
+#  - Purge the stream
+
+POST http://localhost:5080/api/v1/middlewares/elastic/default/_doc
+Content-Type: application/json
+[BasicAuth]
+root: root
+```
+{
+  "foo": {
+    "bar": "baz"
+  }
+}
+```
+HTTP 200
+X-Elastic-Product: Elasticsearch
+
+GET http://localhost:5080/api/v1/streams/default/logs
+Authorization: Bearer {{admin_token}}
+[Query]
+from: {{timewindow_begin}}
+to: {{timewindow_end}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.records" count == 1
+jsonpath "$.records[*].fields['foo.bar']" contains "baz"
+
+DELETE http://localhost:5080/api/v1/streams/default
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true

--- a/website/docs/usecases/interoperability/elasticsearch.md
+++ b/website/docs/usecases/interoperability/elasticsearch.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 1
+---
+
+# ElasticSearch API
+
+**FlowG** supports a subset of the ElasticSearch API, allowing you to plug it
+where you would use [ElasticSearch](https://www.elastic.co/elasticsearch),
+without any change in your application.
+
+The compatibility API is available under the follwing endpoint:
+`/api/v1/middlewares/elastic`.
+
+## Configure the ElasticSearch client
+
+> **NB:** Adapt the username/password and URL according to your setup.
+
+In Go:
+
+```go
+cfg := elasticsearch.Config{
+  Username:  "root",
+  Password:  "root",
+  Addresses: []string{"http://localhost:5080/api/v1/middlewares/elastic/"},
+}
+client, err := elasticsearch.NewClient(cfg)
+```
+
+In Javascript:
+
+```javascript
+const client = new Client({
+  node: 'http://localhost:5080/api/v1/middlewares/elastic/',
+  auth: {
+    username: 'root',
+    password: 'root',
+  },
+})
+```
+
+In Python:
+
+```python
+client = Elasticsearch(
+  hosts=["http://localhost:5080/api/v1/middlewares/elastic/"],
+  basic_auth=("root", "root"),
+)
+```
+
+## Supported authentication methods
+
+### HTTP Basic
+
+The given credentials map directly to FlowG users.
+
+### :construction: HTTP Bearer
+
+> :warning: **This feature is not yet supported.** :warning:
+
+The given token maps to either a FlowG JSON Web Token, or a FlowG Personal
+Access Token.
+
+## Supported operations
+
+### Check if index exists
+
+https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists
+
+```
+HEAD /api/v1/middlewares/elastic/{index}
+```
+
+> **NB:** The name of the index maps to the name of a FlowG pipeline
+
+| Response | When |
+| --- | --- |
+| `401 Unauthorized` | The user could not be authenticated (does not exist, or invalid password) |
+| `403 Forbidden` | The user does not have the `read_pipelines` permission |
+| `404 Not Found` | The pipeline does not exist |
+| `200 0K` | The pipeline exists |
+| `500 Internal Server Error` | An error occured in FlowG |
+
+**Example usage:**
+
+In Go:
+
+```go
+resp, err := client.Indices.Exists(
+  []string{"test"},
+  client.Indices.Exists.WithContext(context.TODO())
+)
+```
+
+In Javascript:
+
+```javascript
+resp = client.indices.exists({ index: 'test' })
+```
+
+In Python:
+
+```python
+resp = client.indices.exists(index="test")
+```
+
+### Index document
+
+https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-index
+
+```
+POST /api/v1/middlewares/elastic/{index}/_doc
+{
+  "@timestamp": "...",
+  "message": "..."
+}
+```
+
+> **NB:** The name of the index maps to the name of a FlowG pipeline
+
+| Response | When |
+| --- | --- |
+| `401 Unauthorized` | The user could not be authenticated (does not exist, or invalid password) |
+| `403 Forbidden` | The user does not have the `send_logs` permission |
+| `400 Bad Request` | The request body was not JSON |
+| `200 0K` | The document (in the request body) was successfully processed through the pipeline |
+| `500 Internal Server Error` | An error occured in FlowG |
+
+> **NB:** Since FlowG's datamodel is flat, the document will be flattenned first:
+
+```json
+{
+  "foo": {
+    "bar": "baz"
+  }
+}
+```
+
+will become
+
+```json
+{
+  "foo.bar": "baz"
+}
+```
+
+**Example usage:**
+
+In Go:
+
+```go
+resp, err = client.Index(
+  "test",
+  bytes.NewReader([]byte(`{"message": "hello world"}`)),
+  client.Index.WithContext(context.TODO()),
+)
+```
+
+In Javascript:
+
+```javascript
+resp = client.index({
+  index: 'test',
+  document: {foo: {bar: 'baz'}},
+})
+```
+
+In Python:
+
+```python
+resp = client.index(
+  index="test",
+  document={"foo": {"bar": "baz"}},
+)
+```
+
+## Roadmap
+
+You can find the tracking issue on Github
+[here](https://github.com/link-society/flowg/issues/853).
+
+Feel free to make new feature requests, or report bugs on the existing supported
+operations.

--- a/website/docs/usecases/interoperability/index.md
+++ b/website/docs/usecases/interoperability/index.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+---
+
+# Interoperability
+
+**FlowG** can be used as a drop-in replacement for other log aggregators:
+
+ - [Syslog Server](../setup/syslog)
+ - [OpenTelemetry Server](./receive-logs/traefik)
+
+But it also aims to provide (partial) support for other APIs:
+
+ - [ElasticSearch](./interoperability/elasticsearch)


### PR DESCRIPTION
## Decision Record

- See #853
- Close #854
- Close #855

## Changes

 - [x] :sparkles: Add ElasticSearch Input Middleware endpoint
 - [x] :white_check_mark: Add test suite (both via API and with a real ElasticSearch client)
 - [x] :memo: Add documentation

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
