### PR TITLE
:recycle: Use Interfaces instead of concrete types

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -26,9 +26,9 @@ import (
 )
 
 type Dependencies struct {
-	AuthStorage   *auth.Storage
-	LogStorage    *log.Storage
-	ConfigStorage *config.Storage
+	AuthStorage   auth.Storage
+	LogStorage    log.Storage
+	ConfigStorage config.Storage
 
 	LogNotifier    *lognotify.LogNotifier
 	PipelineRunner *pipelines.Runner

--- a/api/main.go
+++ b/api/main.go
@@ -30,8 +30,8 @@ type Dependencies struct {
 	LogStorage    log.Storage
 	ConfigStorage config.Storage
 
-	LogNotifier    *lognotify.LogNotifier
-	PipelineRunner *pipelines.Runner
+	LogNotifier    lognotify.LogNotifier
+	PipelineRunner pipelines.Runner
 }
 
 type controller struct {

--- a/internal/app/bootstrap/auth.go
+++ b/internal/app/bootstrap/auth.go
@@ -20,7 +20,7 @@ type ResetUserOptions struct {
 	Password string
 }
 
-func DefaultRolesAndUsers(ctx context.Context, authStorage *auth.Storage, opts BootstrapOptions) error {
+func DefaultRolesAndUsers(ctx context.Context, authStorage auth.Storage, opts BootstrapOptions) error {
 	roles, err := authStorage.ListRoles(ctx)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func DefaultRolesAndUsers(ctx context.Context, authStorage *auth.Storage, opts B
 	return nil
 }
 
-func ResetUser(ctx context.Context, authStorage *auth.Storage, opts ResetUserOptions) error {
+func ResetUser(ctx context.Context, authStorage auth.Storage, opts ResetUserOptions) error {
 	if opts.User == "" || opts.Password == "" {
 		return nil
 	}

--- a/internal/app/bootstrap/pipelines.go
+++ b/internal/app/bootstrap/pipelines.go
@@ -7,7 +7,7 @@ import (
 	"link-society.com/flowg/internal/storage/config"
 )
 
-func DefaultPipeline(ctx context.Context, configStorage *config.Storage) error {
+func DefaultPipeline(ctx context.Context, configStorage config.Storage) error {
 	pipelines, err := configStorage.ListPipelines(ctx)
 	if err != nil {
 		return err

--- a/internal/app/server/bootstrap.go
+++ b/internal/app/server/bootstrap.go
@@ -16,8 +16,8 @@ import (
 type bootstrapProcHandler struct {
 	logger *slog.Logger
 
-	authStorage   *auth.Storage
-	configStorage *config.Storage
+	authStorage   auth.Storage
+	configStorage config.Storage
 
 	initialUser     string
 	initialPassword string

--- a/internal/cluster/delegate.go
+++ b/internal/cluster/delegate.go
@@ -21,7 +21,7 @@ type delegate struct {
 	localEndpoint *url.URL
 	endpoints     map[string]*url.URL
 
-	clusterStateStorage *kvstore.Storage
+	clusterStateStorage kvstore.Storage
 	syncPool            *syncPool
 }
 

--- a/internal/cluster/main.go
+++ b/internal/cluster/main.go
@@ -26,9 +26,9 @@ type ManagerOptions struct {
 
 	LocalEndpointResolver func() (*url.URL, error)
 
-	AuthStorage         *auth.Storage
-	ConfigStorage       *config.Storage
-	LogStorage          *log.Storage
+	AuthStorage         auth.Storage
+	ConfigStorage       config.Storage
+	LogStorage          log.Storage
 	ClusterStateStorage *kvstore.Storage
 }
 

--- a/internal/cluster/main.go
+++ b/internal/cluster/main.go
@@ -18,6 +18,12 @@ import (
 	"link-society.com/flowg/internal/storage/log"
 )
 
+type Manager interface {
+	proctree.Process
+
+	HttpHandler() http.Handler
+}
+
 type ManagerOptions struct {
 	NodeID string
 	Cookie string
@@ -32,15 +38,15 @@ type ManagerOptions struct {
 	ClusterStateStorage *kvstore.Storage
 }
 
-type Manager struct {
+type managerImpl struct {
 	proctree.Process
 
 	handler *procHandler
 }
 
-var _ proctree.Process = (*Manager)(nil)
+var _ Manager = (*managerImpl)(nil)
 
-func NewManager(opts *ManagerOptions) *Manager {
+func NewManager(opts *ManagerOptions) Manager {
 	connM := actor.NewMailbox[net.Conn]()
 	packetM := actor.NewMailbox[*memberlist.Packet]()
 	joinM := actor.NewMailbox[*ClusterJoinNode]()
@@ -69,12 +75,12 @@ func NewManager(opts *ManagerOptions) *Manager {
 		proctree.NewProcess(handler),
 	)
 
-	return &Manager{
+	return &managerImpl{
 		Process: process,
 		handler: handler,
 	}
 }
 
-func (m *Manager) HttpHandler() http.Handler {
+func (m *managerImpl) HttpHandler() http.Handler {
 	return m.handler.httpHandler
 }

--- a/internal/cluster/main.go
+++ b/internal/cluster/main.go
@@ -35,7 +35,7 @@ type ManagerOptions struct {
 	AuthStorage         auth.Storage
 	ConfigStorage       config.Storage
 	LogStorage          log.Storage
-	ClusterStateStorage *kvstore.Storage
+	ClusterStateStorage kvstore.Storage
 }
 
 type managerImpl struct {

--- a/internal/cluster/node_state.go
+++ b/internal/cluster/node_state.go
@@ -22,7 +22,7 @@ type nodeSyncState struct {
 
 func fetchLocalState(
 	ctx context.Context,
-	storage *kvstore.Storage,
+	storage kvstore.Storage,
 	nodeID string,
 	endpoints []string,
 ) (*nodeState, error) {
@@ -86,7 +86,7 @@ func fetchLocalState(
 
 func updateLocalState(
 	ctx context.Context,
-	storage *kvstore.Storage,
+	storage kvstore.Storage,
 	nodeID string,
 	dbType string,
 	since uint64,

--- a/internal/cluster/transport.go
+++ b/internal/cluster/transport.go
@@ -40,9 +40,9 @@ type httpTransport struct {
 	connM   actor.Mailbox[net.Conn]
 	packetM actor.Mailbox[*memberlist.Packet]
 
-	authStorage   *auth.Storage
-	configStorage *config.Storage
-	logStorage    *log.Storage
+	authStorage   auth.Storage
+	configStorage config.Storage
+	logStorage    log.Storage
 }
 
 var _ memberlist.Transport = (*httpTransport)(nil)

--- a/internal/engines/pipelines/context.go
+++ b/internal/engines/pipelines/context.go
@@ -24,6 +24,6 @@ func getLogStorage(ctx context.Context) log.Storage {
 	return ctx.Value(logStorageKey).(log.Storage)
 }
 
-func getLogNotifier(ctx context.Context) *lognotify.LogNotifier {
-	return ctx.Value(logNotifierKey).(*lognotify.LogNotifier)
+func getLogNotifier(ctx context.Context) lognotify.LogNotifier {
+	return ctx.Value(logNotifierKey).(lognotify.LogNotifier)
 }

--- a/internal/engines/pipelines/context.go
+++ b/internal/engines/pipelines/context.go
@@ -16,12 +16,12 @@ const (
 	logNotifierKey   pipelineCtxKey = "logNotifier"
 )
 
-func getConfigStorage(ctx context.Context) *config.Storage {
-	return ctx.Value(configStorageKey).(*config.Storage)
+func getConfigStorage(ctx context.Context) config.Storage {
+	return ctx.Value(configStorageKey).(config.Storage)
 }
 
-func getLogStorage(ctx context.Context) *log.Storage {
-	return ctx.Value(logStorageKey).(*log.Storage)
+func getLogStorage(ctx context.Context) log.Storage {
+	return ctx.Value(logStorageKey).(log.Storage)
 }
 
 func getLogNotifier(ctx context.Context) *lognotify.LogNotifier {

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -24,8 +24,8 @@ type Runner struct {
 var _ proctree.Process = (*Runner)(nil)
 
 func NewRunner(
-	configStorage *config.Storage,
-	logStorage *log.Storage,
+	configStorage config.Storage,
+	logStorage log.Storage,
 	logNotifier *lognotify.LogNotifier,
 ) *Runner {
 	mbox := actor.NewMailbox[message]()

--- a/internal/engines/pipelines/process.go
+++ b/internal/engines/pipelines/process.go
@@ -17,7 +17,7 @@ type procHandler struct {
 
 	configStorage config.Storage
 	logStorage    log.Storage
-	logNotifier   *lognotify.LogNotifier
+	logNotifier   lognotify.LogNotifier
 }
 
 var _ proctree.ProcessHandler = (*procHandler)(nil)

--- a/internal/engines/pipelines/process.go
+++ b/internal/engines/pipelines/process.go
@@ -15,8 +15,8 @@ import (
 type procHandler struct {
 	mbox actor.MailboxReceiver[message]
 
-	configStorage *config.Storage
-	logStorage    *log.Storage
+	configStorage config.Storage
+	logStorage    log.Storage
 	logNotifier   *lognotify.LogNotifier
 }
 

--- a/internal/engines/pipelines/types.go
+++ b/internal/engines/pipelines/types.go
@@ -15,7 +15,7 @@ type Pipeline struct {
 	Entrypoints map[string]Node
 }
 
-func Build(ctx context.Context, configStorage *config.Storage, name string) (*Pipeline, error) {
+func Build(ctx context.Context, configStorage config.Storage, name string) (*Pipeline, error) {
 	flowGraph, err := configStorage.ReadPipeline(ctx, name)
 	if err != nil {
 		return nil, err

--- a/internal/services/http/main.go
+++ b/internal/services/http/main.go
@@ -23,8 +23,8 @@ type ServerOptions struct {
 	ConfigStorage config.Storage
 	LogStorage    log.Storage
 
-	LogNotifier    *lognotify.LogNotifier
-	PipelineRunner *pipelines.Runner
+	LogNotifier    lognotify.LogNotifier
+	PipelineRunner pipelines.Runner
 }
 
 func NewServer(opts *ServerOptions) proctree.Process {

--- a/internal/services/http/main.go
+++ b/internal/services/http/main.go
@@ -19,9 +19,9 @@ type ServerOptions struct {
 	BindAddress string
 	TlsConfig   *tls.Config
 
-	AuthStorage   *auth.Storage
-	ConfigStorage *config.Storage
-	LogStorage    *log.Storage
+	AuthStorage   auth.Storage
+	ConfigStorage config.Storage
+	LogStorage    log.Storage
 
 	LogNotifier    *lognotify.LogNotifier
 	PipelineRunner *pipelines.Runner

--- a/internal/services/mgmt/main.go
+++ b/internal/services/mgmt/main.go
@@ -28,9 +28,9 @@ type ServerOptions struct {
 	ClusterStateDir          string
 	ClusterFormationStrategy cluster.ClusterFormationStrategy
 
-	AuthStorage   *auth.Storage
-	ConfigStorage *config.Storage
-	LogStorage    *log.Storage
+	AuthStorage   auth.Storage
+	ConfigStorage config.Storage
+	LogStorage    log.Storage
 }
 
 func NewServer(opts *ServerOptions) proctree.Process {

--- a/internal/services/mgmt/server.go
+++ b/internal/services/mgmt/server.go
@@ -26,7 +26,7 @@ type serverHandler struct {
 	tlsConfig   *tls.Config
 
 	listenerH      *listenerHandler
-	clusterManager *cluster.Manager
+	clusterManager cluster.Manager
 
 	server *http.Server
 }

--- a/internal/services/syslog/main.go
+++ b/internal/services/syslog/main.go
@@ -19,7 +19,7 @@ type ServerOptions struct {
 	AllowOrigins []string
 
 	ConfigStorage  config.Storage
-	PipelineRunner *pipelines.Runner
+	PipelineRunner pipelines.Runner
 }
 
 func NewServer(opts *ServerOptions) proctree.Process {

--- a/internal/services/syslog/main.go
+++ b/internal/services/syslog/main.go
@@ -18,7 +18,7 @@ type ServerOptions struct {
 	TlsConfig    *tls.Config
 	AllowOrigins []string
 
-	ConfigStorage  *config.Storage
+	ConfigStorage  config.Storage
 	PipelineRunner *pipelines.Runner
 }
 

--- a/internal/storage/auth/main.go
+++ b/internal/storage/auth/main.go
@@ -66,7 +66,7 @@ func OptReadOnly(readOnly bool) func(*options) {
 type storageImpl struct {
 	proctree.Process
 
-	kvStore *kvstore.Storage
+	kvStore kvstore.Storage
 }
 
 var _ Storage = (*storageImpl)(nil)

--- a/internal/storage/auth/migrator.go
+++ b/internal/storage/auth/migrator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type migratorProcH struct {
-	kvStore *kvstore.Storage
+	kvStore kvstore.Storage
 }
 
 var _ proctree.ProcessHandler = (*migratorProcH)(nil)

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -72,7 +72,7 @@ func OptReadOnly(readOnly bool) func(*options) {
 type storageImpl struct {
 	proctree.Process
 
-	kvStore *kvstore.Storage
+	kvStore kvstore.Storage
 }
 
 var _ Storage = (*storageImpl)(nil)

--- a/internal/storage/config/migrator.go
+++ b/internal/storage/config/migrator.go
@@ -13,7 +13,7 @@ import (
 
 type migratorProcH struct {
 	baseDir string
-	storage *Storage
+	storage *storageImpl
 }
 
 var _ proctree.ProcessHandler = (*migratorProcH)(nil)

--- a/internal/storage/log/gc.go
+++ b/internal/storage/log/gc.go
@@ -13,7 +13,7 @@ import (
 )
 
 type gcWorker struct {
-	kvStore    *kvstore.Storage
+	kvStore    kvstore.Storage
 	gcInterval time.Duration
 }
 

--- a/internal/storage/log/main.go
+++ b/internal/storage/log/main.go
@@ -76,7 +76,7 @@ func OptGCInterval(interval time.Duration) func(*options) {
 type storageImpl struct {
 	proctree.Process
 
-	kvStore *kvstore.Storage
+	kvStore kvstore.Storage
 }
 
 var _ Storage = (*storageImpl)(nil)

--- a/internal/utils/api/decorator.go
+++ b/internal/utils/api/decorator.go
@@ -12,7 +12,7 @@ import (
 )
 
 func RequireScopeApiDecorator[Req any, Resp any](
-	authStorage *auth.Storage,
+	authStorage auth.Storage,
 	scope models.Scope,
 	next func(context.Context, Req, *Resp) error,
 ) func(context.Context, Req, *Resp) error {
@@ -50,7 +50,7 @@ func RequireScopeApiDecorator[Req any, Resp any](
 }
 
 func RequireScopesApiDecorator[Req any, Resp any](
-	authStorage *auth.Storage,
+	authStorage auth.Storage,
 	scopes []models.Scope,
 	next func(context.Context, Req, *Resp) error,
 ) func(context.Context, Req, *Resp) error {

--- a/internal/utils/api/middleware.go
+++ b/internal/utils/api/middleware.go
@@ -19,7 +19,7 @@ import (
 	"link-society.com/flowg/internal/storage/auth"
 )
 
-func ApiMiddleware(authStorage *auth.Storage) func(http.Handler) http.Handler {
+func ApiMiddleware(authStorage auth.Storage) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		serveError := func(w http.ResponseWriter, r *http.Request, err error) {
 			code, payload := rest.Err(status.Wrap(err, status.Unauthenticated))


### PR DESCRIPTION
## Decision Record

See: #77

When working with unit tests, we may want to mock the dependencies of the code being tested. To facilitate this, let's expose said dependencies as interfaces instead of concrete types.

## Changes

 - [x] :recycle: Expose `internal/storage` components (`auth.Storage`, `config.Storage`, `log.Storage`) as interfaces
 - [x] :recycle: Expose `internal/engines` components (`lognotify.LogNotifier`, `pipelines.Runner`) as interfaces
 - [x] :recycle: Expose `internal/cluster` components (`cluster.Manager`) as interfaces
 - [x] :recycle: Expose `internal/utils/kvstorage.Storage` as interface

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
