### PR TITLE
:clown_face: Add mocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
+	github.com/stretchr/testify v1.10.0
 	github.com/swaggest/openapi-go v0.2.59
 	github.com/swaggest/rest v0.2.75
 	github.com/swaggest/swgui v1.8.4
@@ -89,11 +90,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v3 v3.1.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/swaggest/form/v5 v5.1.1 // indirect
 	github.com/swaggest/jsonschema-go v0.3.78 // indirect
 	github.com/swaggest/refl v1.4.0 // indirect

--- a/internal/engines/lognotify/mock.go
+++ b/internal/engines/lognotify/mock.go
@@ -1,0 +1,49 @@
+package lognotify
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/models"
+)
+
+type MockNotifier struct {
+	mock.Mock
+}
+
+var _ LogNotifier = (*MockNotifier)(nil)
+
+func NewMockNotifier() LogNotifier {
+	return &MockNotifier{}
+}
+
+func (m *MockNotifier) Start() {
+	m.Called()
+}
+
+func (m *MockNotifier) Stop() {
+	m.Called()
+}
+
+func (m *MockNotifier) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockNotifier) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockNotifier) Subscribe(ctx context.Context, stream string) (actor.MailboxReceiver[LogMessage], error) {
+	args := m.Called(ctx, stream)
+	return args.Get(0).(actor.MailboxReceiver[LogMessage]), args.Error(1)
+}
+
+func (m *MockNotifier) Notify(ctx context.Context, stream string, logKey string, logRecord models.LogRecord) error {
+	args := m.Called(ctx, stream, logKey, logRecord)
+	return args.Error(0)
+}

--- a/internal/engines/pipelines/mock.go
+++ b/internal/engines/pipelines/mock.go
@@ -1,0 +1,41 @@
+package pipelines
+
+import (
+	"github.com/stretchr/testify/mock"
+	"link-society.com/flowg/internal/models"
+
+	"context"
+)
+
+type MockRunner struct {
+	mock.Mock
+}
+
+var _ Runner = (*MockRunner)(nil)
+
+func NewMockRunner() Runner {
+	return &MockRunner{}
+}
+
+func (m *MockRunner) Start() {
+	m.Called()
+}
+
+func (m *MockRunner) Stop() {
+	m.Called()
+}
+
+func (m *MockRunner) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockRunner) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockRunner) Run(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error {
+	args := m.Called(ctx, pipelineName, entrypoint, record)
+	return args.Error(0)
+}

--- a/internal/storage/auth/mock.go
+++ b/internal/storage/auth/mock.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+	"io"
+
+	"link-society.com/flowg/internal/models"
+)
+
+type MockStorage struct {
+	mock.Mock
+}
+
+var _ Storage = (*MockStorage)(nil)
+
+func NewMockStorage() Storage {
+	return &MockStorage{}
+}
+
+func (m *MockStorage) Start() {
+	m.Called()
+}
+
+func (m *MockStorage) Stop() {
+	m.Called()
+}
+
+func (m *MockStorage) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
+	args := m.Called(ctx, w, since)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (m *MockStorage) Load(ctx context.Context, r io.Reader) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListRoles(ctx context.Context) ([]models.Role, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.Role), args.Error(1)
+}
+
+func (m *MockStorage) FetchRole(ctx context.Context, name string) (*models.Role, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*models.Role), args.Error(1)
+}
+
+func (m *MockStorage) SaveRole(ctx context.Context, role models.Role) error {
+	args := m.Called(ctx, role)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteRole(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListUsers(ctx context.Context) ([]models.User, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.User), args.Error(1)
+}
+
+func (m *MockStorage) FetchUser(ctx context.Context, name string) (*models.User, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockStorage) ListUserScopes(ctx context.Context, name string) ([]models.Scope, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).([]models.Scope), args.Error(1)
+}
+
+func (m *MockStorage) SaveUser(ctx context.Context, user models.User, password string) error {
+	args := m.Called(ctx, user, password)
+	return args.Error(0)
+}
+
+func (m *MockStorage) PatchUserRoles(ctx context.Context, user models.User) error {
+	args := m.Called(ctx, user)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteUser(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *MockStorage) VerifyUserPassword(ctx context.Context, name string, password string) (bool, error) {
+	args := m.Called(ctx, name, password)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockStorage) VerifyUserPermission(ctx context.Context, username string, scope models.Scope) (bool, error) {
+	args := m.Called(ctx, username, scope)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockStorage) CreateToken(ctx context.Context, username string) (string, string, error) {
+	args := m.Called(ctx, username)
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *MockStorage) VerifyToken(ctx context.Context, token string) (*models.User, error) {
+	args := m.Called(ctx, token)
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockStorage) ListTokens(ctx context.Context, username string) ([]string, error) {
+	args := m.Called(ctx, username)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) DeleteToken(ctx context.Context, username string, tokenUUID string) error {
+	args := m.Called(ctx, username, tokenUUID)
+	return args.Error(0)
+}

--- a/internal/storage/config/mock.go
+++ b/internal/storage/config/mock.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+	"io"
+
+	"link-society.com/flowg/internal/models"
+)
+
+type MockStorage struct {
+	mock.Mock
+}
+
+var _ Storage = (*MockStorage)(nil)
+
+func NewMockStorage() Storage {
+	return &MockStorage{}
+}
+
+func (m *MockStorage) Start() {
+	m.Called()
+}
+
+func (m *MockStorage) Stop() {
+	m.Called()
+}
+
+func (m *MockStorage) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
+	args := m.Called(ctx, w, since)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (m *MockStorage) Load(ctx context.Context, r io.Reader) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListTransformers(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) ReadTransformer(ctx context.Context, name string) (string, error) {
+	args := m.Called(ctx, name)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockStorage) WriteTransformer(ctx context.Context, name string, content string) error {
+	args := m.Called(ctx, name, content)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteTransformer(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListPipelines(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) ReadPipeline(ctx context.Context, name string) (*models.FlowGraphV2, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*models.FlowGraphV2), args.Error(1)
+}
+
+func (m *MockStorage) WritePipeline(ctx context.Context, name string, content *models.FlowGraphV2) error {
+	args := m.Called(ctx, name, content)
+	return args.Error(0)
+}
+
+func (m *MockStorage) WriteRawPipeline(ctx context.Context, name string, content string) error {
+	args := m.Called(ctx, name, content)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeletePipeline(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListForwarders(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) ReadForwarder(ctx context.Context, name string) (*models.ForwarderV2, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*models.ForwarderV2), args.Error(1)
+}
+
+func (m *MockStorage) WriteForwarder(ctx context.Context, name string, content *models.ForwarderV2) error {
+	args := m.Called(ctx, name, content)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteForwarder(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}

--- a/internal/storage/log/mock.go
+++ b/internal/storage/log/mock.go
@@ -1,0 +1,96 @@
+package log
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+
+	"io"
+	"time"
+
+	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/utils/ffi/filterdsl"
+)
+
+type MockStorage struct {
+	mock.Mock
+}
+
+var _ Storage = (*MockStorage)(nil)
+
+func NewMockStorage() Storage {
+	return &MockStorage{}
+}
+
+func (m *MockStorage) Start() {
+	m.Called()
+}
+
+func (m *MockStorage) Stop() {
+	m.Called()
+}
+
+func (m *MockStorage) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Dump(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
+	args := m.Called(ctx, w, since)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (m *MockStorage) Load(ctx context.Context, r io.Reader) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListStreamConfigs(ctx context.Context) (map[string]models.StreamConfig, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(map[string]models.StreamConfig), args.Error(1)
+}
+
+func (m *MockStorage) ListStreamFields(ctx context.Context, stream string) ([]string, error) {
+	args := m.Called(ctx, stream)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) GetOrCreateStreamConfig(ctx context.Context, stream string) (models.StreamConfig, error) {
+	args := m.Called(ctx, stream)
+	return args.Get(0).(models.StreamConfig), args.Error(1)
+}
+
+func (m *MockStorage) ConfigureStream(ctx context.Context, stream string, config models.StreamConfig) error {
+	args := m.Called(ctx, stream, config)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteStream(ctx context.Context, stream string) error {
+	args := m.Called(ctx, stream)
+	return args.Error(0)
+}
+
+func (m *MockStorage) IndexField(ctx context.Context, stream string, field string) error {
+	args := m.Called(ctx, stream, field)
+	return args.Error(0)
+}
+
+func (m *MockStorage) UnindexField(ctx context.Context, stream string, field string) error {
+	args := m.Called(ctx, stream, field)
+	return args.Error(0)
+}
+
+func (m *MockStorage) Ingest(ctx context.Context, stream string, logRecord *models.LogRecord) ([]byte, error) {
+	args := m.Called(ctx, stream, logRecord)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockStorage) FetchLogs(ctx context.Context, stream string, from time.Time, to time.Time, filter filterdsl.Filter) ([]models.LogRecord, error) {
+	args := m.Called(ctx, stream, from, to, filter)
+	return args.Get(0).([]models.LogRecord), args.Error(1)
+}

--- a/internal/utils/kvstore/mock.go
+++ b/internal/utils/kvstore/mock.go
@@ -1,0 +1,58 @@
+package kvstore
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+	"io"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+type MockStorage struct {
+	mock.Mock
+}
+
+var _ Storage = (*MockStorage)(nil)
+
+func NewMockStorage() Storage {
+	return &MockStorage{}
+}
+
+func (m *MockStorage) Start() {
+	m.Called()
+}
+
+func (m *MockStorage) Stop() {
+	m.Called()
+}
+
+func (m *MockStorage) WaitReady(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Join(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStorage) Backup(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
+	args := m.Called(ctx, w, since)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (m *MockStorage) Restore(ctx context.Context, r io.Reader) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+func (m *MockStorage) View(ctx context.Context, txnFn func(txn *badger.Txn) error) error {
+	args := m.Called(ctx, txnFn)
+	return args.Error(0)
+}
+
+func (m *MockStorage) Update(ctx context.Context, txnFn func(txn *badger.Txn) error) error {
+	args := m.Called(ctx, txnFn)
+	return args.Error(0)
+}


### PR DESCRIPTION
## Decision Record

In PR #858, we introduced interfaces to facilitate testing. Now, we add configurable mocks to further facilitate testing.

## Changes

 - [x] :heavy_plus_sign: Add https://github.com/stretchr/testify
 - [x] :clown_face: Add mocks for storages, engines and kvstore

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
