### PR TITLE
:bug: OTLP forwarder should not nest the configuration

### DIFF
--- a/internal/models/forwarder_v2_otlp.go
+++ b/internal/models/forwarder_v2_otlp.go
@@ -1,9 +1,10 @@
 package models
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+
+	"bytes"
 	"io"
 	"net/http"
 
@@ -12,66 +13,14 @@ import (
 	proto "google.golang.org/protobuf/proto"
 )
 
-type OtlpForwarderConfig struct {
+type ForwarderOtlpV2 struct {
+	Type     string            `json:"type" enum:"otlp"`
 	Endpoint string            `json:"endpoint,omitempty"`
 	Headers  map[string]string `json:"headers,omitempty"`
 }
 
-type ForwarderOtlpV2 struct {
-	Type   string              `json:"type" enum:"otlp"`
-	Config OtlpForwarderConfig `json:"config"`
-	client *http.Client        `json:"-"`
-}
-
-// call sends a single log record
 func (f *ForwarderOtlpV2) call(ctx context.Context, record *LogRecord) error {
-	// Initialize client if nil
-	if f.client == nil {
-		f.client = &http.Client{}
-	}
-
-	// Convert single log to OTLP protobuf msg format
-	otlpLogs, err := ConvertToOtlpLogs([]*LogRecord{record})
-	if err != nil {
-		return err
-	}
-
-	// Marshal the OTLP logs to protobuf bytes
-	data, err := proto.Marshal(otlpLogs)
-	if err != nil {
-		return fmt.Errorf("failed to marshal OTLP logs: %w", err)
-	}
-
-	// Create HTTP POST request
-	req, err := http.NewRequestWithContext(ctx, "POST", f.Config.Endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set Headers
-	req.Header.Set("Content-Type", "application/x-protobuf")
-	for k, v := range f.Config.Headers {
-		req.Header.Set(k, v)
-	}
-
-	// Send the request
-	resp, err := f.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
-	}
-
-	return nil
-}
-
-// ConvertToOtlpLogs converts a slice of LogRecord to OTLP LogsData format
-func ConvertToOtlpLogs(records []*LogRecord) (*otlplogs.LogsData, error) {
-	otlpLogs := &otlplogs.LogsData{
+	logData := &otlplogs.LogsData{
 		ResourceLogs: []*otlplogs.ResourceLogs{
 			{
 				ScopeLogs: []*otlplogs.ScopeLogs{
@@ -83,44 +32,63 @@ func ConvertToOtlpLogs(records []*LogRecord) (*otlplogs.LogsData, error) {
 		},
 	}
 
-	for _, r := range records {
-		lr := &otlplogs.LogRecord{
-			TimeUnixNano: uint64(r.Timestamp.UnixNano()),
-			Body: &otlpcommon.AnyValue{
+	body, ok := record.Fields["body"]
+	if !ok {
+		body = ""
+	}
+
+	lr := &otlplogs.LogRecord{
+		TimeUnixNano: uint64(record.Timestamp.UnixNano()),
+		Body: &otlpcommon.AnyValue{
+			Value: &otlpcommon.AnyValue_StringValue{
+				StringValue: body,
+			},
+		},
+		Attributes: []*otlpcommon.KeyValue{},
+	}
+
+	for k, v := range record.Fields {
+		if k == "body" {
+			continue // Skip body as it's already set
+		}
+		attr := &otlpcommon.KeyValue{
+			Key: k,
+			Value: &otlpcommon.AnyValue{
 				Value: &otlpcommon.AnyValue_StringValue{
-					StringValue: getBody(r.Fields),
+					StringValue: v,
 				},
 			},
-			Attributes: []*otlpcommon.KeyValue{},
 		}
-
-		// Convert log fields to OTLP attributes
-		for k, v := range r.Fields {
-			if k == "body" {
-				continue // Skip body as it's already set
-			}
-			attr := &otlpcommon.KeyValue{
-				Key: k,
-				Value: &otlpcommon.AnyValue{
-					Value: &otlpcommon.AnyValue_StringValue{
-						StringValue: v,
-					},
-				},
-			}
-			lr.Attributes = append(lr.Attributes, attr)
-		}
-
-		otlpLogs.ResourceLogs[0].ScopeLogs[0].LogRecords = append(otlpLogs.ResourceLogs[0].ScopeLogs[0].LogRecords, lr)
+		lr.Attributes = append(lr.Attributes, attr)
 	}
 
-	return otlpLogs, nil
-}
+	logData.ResourceLogs[0].ScopeLogs[0].LogRecords = append(logData.ResourceLogs[0].ScopeLogs[0].LogRecords, lr)
 
-// getBody returns the body from fields or a default empty string
-func getBody(fields map[string]string) string {
-	body, ok := fields["body"]
-	if !ok || body == "" {
-		return ""
+	data, err := proto.Marshal(logData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OTLP logs: %w", err)
 	}
-	return body
+
+	req, err := http.NewRequestWithContext(ctx, "POST", f.Endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range f.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }

--- a/internal/models/forwarder_v2_otlp_test.go
+++ b/internal/models/forwarder_v2_otlp_test.go
@@ -39,12 +39,10 @@ func TestForwarderOtlpV2_Call_Success(t *testing.T) {
 		Version: 2,
 		Config: &models.ForwarderConfigV2{
 			Otlp: &models.ForwarderOtlpV2{
-				Type: "otlp",
-				Config: models.OtlpForwarderConfig{
-					Endpoint: testServer.URL,
-					Headers: map[string]string{
-						"X-Test-Header": "test-value",
-					},
+				Type:     "otlp",
+				Endpoint: testServer.URL,
+				Headers: map[string]string{
+					"X-Test-Header": "test-value",
 				},
 			},
 		},
@@ -72,10 +70,8 @@ func TestForwarderOtlpV2_Call_Failure(t *testing.T) {
 		Version: 2,
 		Config: &models.ForwarderConfigV2{
 			Otlp: &models.ForwarderOtlpV2{
-				Type: "otlp",
-				Config: models.OtlpForwarderConfig{
-					Endpoint: testServer.URL,
-				},
+				Type:     "otlp",
+				Endpoint: testServer.URL,
 			},
 		},
 	}

--- a/tests/specs/api/forwarder_otlp.hurl
+++ b/tests/specs/api/forwarder_otlp.hurl
@@ -12,13 +12,11 @@ Content-Type: application/json
     "version": 2,
     "config": {
       "type": "otlp",
-      "config": {
-        "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
-        "headers": {
-          "X-Custom-Header": "test-value",
-          "X-Test-Mode": "success",
-          "Content-Type": "application/x-protobuf"
-        }
+      "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
+      "headers": {
+        "X-Custom-Header": "test-value",
+        "X-Test-Mode": "success",
+        "Content-Type": "application/x-protobuf"
       }
     }
   }
@@ -83,13 +81,11 @@ Content-Type: application/json
     "version": 2,
     "config": {
       "type": "otlp",
-      "config": {
-        "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
-        "headers": {
-          "X-Custom-Header": "test-value",
-          "X-Test-Mode": "fail",
-          "Content-Type": "application/x-protobuf"
-        }
+      "endpoint": "http://test-flowg-mockserver:1080/v1/logs",
+      "headers": {
+        "X-Custom-Header": "test-value",
+        "X-Test-Mode": "fail",
+        "Content-Type": "application/x-protobuf"
       }
     }
   }


### PR DESCRIPTION
## Decision Record

The OpenTelemetry forwarder's datamodel had a nested `Config` field which was ignored by the editor in the Web UI.

It also embedded an `*http.Client` in the structure, in an attempt to cache it, but the forwarder structure is instantiated for every log (we should look into this later on by the way), so it is not a useful optimization at this point.

## Changes

 - [x] :bug: :card_file_box: Do not nest the OTLP configuration
 - [x] :recycle: Simplify OTLP forwarder code

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
