### PR TITLE
💚 Switch to token authentication for snyk

### DIFF
--- a/.github/workflows/security-snyk.yml
+++ b/.github/workflows/security-snyk.yml
@@ -29,7 +29,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORGANIZATION: ${{ secrets.SNYK_ORGANIZATION }}
         run: |
-          snyk auth $SNYK_TOKEN
+          snyk auth --auth-type=token $SNYK_TOKEN
           snyk config set org=$SNYK_ORGANIZATION
 
       - name: prepare@code


### PR DESCRIPTION
## Decision Record

It seems that snyk defaults to oauth2 authentication unless specifically requested otherwise, and oauth2 can't work in a CI pipeline because it doesn't have access to a browser with a valid snyk account

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
