### PR TITLE
💚 Pin the yamale version to fix end to end pipeline

### DIFF
--- a/.github/actions/setup-k8s/action.yml
+++ b/.github/actions/setup-k8s/action.yml
@@ -15,6 +15,8 @@ runs:
 
     - name: setup@ct
       uses: helm/chart-testing-action@v2
+      with:
+        yamale_version: "6.0.0"
 
     - name: setup@kind
       uses: helm/kind-action@v1


### PR DESCRIPTION
## Decision Record

Updating python broke end to end tests, and the solution seems to be to pin the version of yamale

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
