### PR TITLE
:wrench: Turn off some strict eslint rules that do not match reality

### DIFF
--- a/web/app/eslint.config.js
+++ b/web/app/eslint.config.js
@@ -2,9 +2,10 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import { defineConfig } from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       'dist',
@@ -26,6 +27,10 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': ['off'],
       'react-hooks/exhaustive-deps': ['off'],
+      'react-hooks/set-state-in-effect': ['off'],
+      'react-hooks/preserve-manual-memoization': ['off'],
+      'react-hooks/use-memo': ['off'],
+      'react-hooks/immutability': ['off'],
       'react-refresh/only-export-components': ['off'],
     },
   },


### PR DESCRIPTION
## Decision Record

Using `setState` inside `useEffect` is perfectly fine.

Not specifying all dependencies for `useEffect` or `useCallback` is not bad practice (in fact, the opposite could lead to way too much re-renders), you only want to specify what actually get to trigger re-renders.

Lastly, mutating a context without triggering re-renders is something we might want to do.

**eslint** is being too strict.

## Changes

 - [x] :wrench: Turn off some linting rules

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
