### PR TITLE
:bug: Accept empty `sourceHandle`

### DIFF
--- a/internal/models/flow_v2.go
+++ b/internal/models/flow_v2.go
@@ -16,7 +16,7 @@ type FlowNodeV2 struct {
 type FlowEdgeV2 struct {
 	ID           string `json:"id" required:"true"`
 	Source       string `json:"source" required:"true"`
-	SourceHandle string `json:"sourceHandle" required:"true"`
+	SourceHandle string `json:"sourceHandle" default:""`
 	Target       string `json:"target" required:"true"`
 }
 


### PR DESCRIPTION
## Decision Record
While working on a separate issue, I've found that when you create a new edge, react-flow does not set the `sourceHandle` field if there is only a single handle, but the backend expected a value there.
Seems like this is a regression introduced by #1009 

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
