### PR TITLE
:lipstick: :passport_control: Do not show edit actions in admin panel if the user does not have the permissions for it

### DIFF
--- a/web/app/src/views/app/admin/role-list/index.tsx
+++ b/web/app/src/views/app/admin/role-list/index.tsx
@@ -10,6 +10,7 @@ import { ColDef } from 'ag-grid-community'
 import { AgGridReact } from 'ag-grid-react'
 
 import * as aclApi from '@/lib/api/operations/acls'
+import { useProfile } from '@/lib/context/profile'
 import { useApiOperation } from '@/lib/hooks/api'
 import { useNotify } from '@/lib/hooks/notify'
 import { RoleModel } from '@/lib/models/auth'
@@ -24,6 +25,7 @@ type RoleListProps = Readonly<{
 }>
 
 export const RoleList = ({ roles }: RoleListProps) => {
+  const { permissions } = useProfile()
   const notify = useNotify()
 
   const gridRef = useRef<AgGridReact<RoleModel>>(null!)
@@ -56,11 +58,12 @@ export const RoleList = ({ roles }: RoleListProps) => {
   const [rowData] = useState<RoleModel[]>(roles)
   const [columnDefs] = useState<ColDef<RoleModel>[]>([
     {
+      hide: !permissions.can_edit_acls,
       headerName: 'Actions',
       headerClass: 'flowg-actions-header',
       cellRenderer: Actions,
       cellRendererParams: {
-        onDelete,
+        onDelete: permissions.can_edit_acls ? onDelete : undefined,
       },
       suppressMovable: true,
       sortable: false,
@@ -88,7 +91,9 @@ export const RoleList = ({ roles }: RoleListProps) => {
           <div className="flex items-center gap-3">
             <AdminPanelSettingsIcon />
             <span className="grow">Roles</span>
-            <CreateRoleButton onRoleCreated={onNewRole} />
+            {permissions.can_edit_acls && (
+              <CreateRoleButton onRoleCreated={onNewRole} />
+            )}
           </div>
         }
         className="bg-blue-400 text-white shadow-lg z-20"

--- a/web/app/src/views/app/admin/user-list/index.tsx
+++ b/web/app/src/views/app/admin/user-list/index.tsx
@@ -10,6 +10,7 @@ import { ColDef } from 'ag-grid-community'
 import { AgGridReact } from 'ag-grid-react'
 
 import * as aclApi from '@/lib/api/operations/acls'
+import { useProfile } from '@/lib/context/profile'
 import { useApiOperation } from '@/lib/hooks/api'
 import { useNotify } from '@/lib/hooks/notify'
 import { UserModel } from '@/lib/models/auth'
@@ -25,6 +26,7 @@ type UserListProps = Readonly<{
 }>
 
 export const UserList = ({ roles, users }: UserListProps) => {
+  const { permissions } = useProfile()
   const notify = useNotify()
 
   const gridRef = useRef<AgGridReact<UserModel>>(null!)
@@ -57,11 +59,12 @@ export const UserList = ({ roles, users }: UserListProps) => {
   const [rowData] = useState<UserModel[]>(users)
   const [columnDefs] = useState<ColDef<UserModel>[]>([
     {
+      hide: !permissions.can_edit_acls,
       headerName: 'Actions',
       headerClass: 'flowg-actions-header',
       cellRenderer: Actions,
       cellRendererParams: {
-        onDelete,
+        onDelete: permissions.can_edit_acls ? onDelete : undefined,
       },
       suppressMovable: true,
       sortable: false,
@@ -89,7 +92,9 @@ export const UserList = ({ roles, users }: UserListProps) => {
           <div className="flex items-center gap-3">
             <AccountCircleIcon />
             <span className="grow">Users</span>
-            <CreateUserButton roles={roles} onUserCreated={onNewUser} />
+            {permissions.can_edit_acls && (
+              <CreateUserButton roles={roles} onUserCreated={onNewUser} />
+            )}
           </div>
         }
         className="bg-blue-400 text-white shadow-lg z-20"


### PR DESCRIPTION
## Decision Record

The "New" and "Delete" buttons were still shown in the admin panel, which would lead to the API returning 403s because the user would not have the permissions to perform those actions.

To improve the user experience, we should not display them.

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
