### PR TITLE
:bug: broadcast cache invalidation

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -25,6 +25,8 @@ import (
 
 	"link-society.com/flowg/internal/engines/lognotify"
 	"link-society.com/flowg/internal/engines/pipelines"
+
+	"link-society.com/flowg/internal/cluster"
 )
 
 type Dependencies struct {
@@ -36,6 +38,8 @@ type Dependencies struct {
 
 	LogNotifier    lognotify.LogNotifier
 	PipelineRunner pipelines.Runner
+
+	ClusterManager cluster.Manager
 }
 
 type controller struct {

--- a/api/save_forwarder.go
+++ b/api/save_forwarder.go
@@ -55,6 +55,17 @@ func (ctrl *controller) SaveForwarderUsecase() usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
+				if err := ctrl.deps.ClusterManager.BroadcastInvalidatePipelineCache(ctx, ""); err != nil {
+					ctrl.logger.ErrorContext(
+						ctx,
+						"Failed to broadcast pipeline cache invalidation after forwarder save",
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.Internal)
+				}
+
 				resp.Success = true
 
 				return nil

--- a/api/save_pipeline.go
+++ b/api/save_pipeline.go
@@ -55,6 +55,17 @@ func (ctrl *controller) SavePipelineUsecase() usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
+				if err := ctrl.deps.ClusterManager.BroadcastInvalidatePipelineCache(ctx, req.Pipeline); err != nil {
+					ctrl.logger.ErrorContext(
+						ctx,
+						"Failed to broadcast pipeline cache invalidation after save",
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.Internal)
+				}
+
 				resp.Success = true
 
 				return nil

--- a/api/save_transformer.go
+++ b/api/save_transformer.go
@@ -54,6 +54,17 @@ func (ctrl *controller) SaveTransformerUsecase() usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
+				if err := ctrl.deps.ClusterManager.BroadcastInvalidatePipelineCache(ctx, ""); err != nil {
+					ctrl.logger.ErrorContext(
+						ctx,
+						"Failed to broadcast pipeline cache invalidation after transformer save",
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.Internal)
+				}
+
 				resp.Success = true
 
 				return nil

--- a/internal/cluster/broadcast_messages.go
+++ b/internal/cluster/broadcast_messages.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/memberlist"
+)
+
+var (
+	errInvalidBroadcastMessage = errors.New("invalid broadcast message")
+)
+
+const (
+	_                                                      = iota
+	BROADCAST_MESSAGE_TYPE_INVALIDATE_PIPELINE_BUILD_CACHE = iota
+)
+
+type broadcastMessage interface {
+	memberlist.Broadcast
+
+	Handle(ctx context.Context, delegate *delegate) error
+}
+
+type invalidatePipelineBuildCache struct {
+	pipelineName string // if empty, then all
+}
+
+var _ broadcastMessage = (*invalidatePipelineBuildCache)(nil)
+
+func (msg *invalidatePipelineBuildCache) Handle(ctx context.Context, delegate *delegate) error {
+	if msg.pipelineName == "" {
+		return delegate.pipelineRunner.InvalidateAllCachedBuilds(ctx)
+	} else {
+		return delegate.pipelineRunner.InvalidateCachedBuild(ctx, msg.pipelineName)
+	}
+}
+
+func (*invalidatePipelineBuildCache) Invalidates(memberlist.Broadcast) bool {
+	return false
+}
+
+func (msg *invalidatePipelineBuildCache) Message() []byte {
+	var payload []byte
+	payload = append(payload, BROADCAST_MESSAGE_TYPE_INVALIDATE_PIPELINE_BUILD_CACHE)
+	payload = append(payload, msg.pipelineName...)
+	return payload
+}
+
+func (*invalidatePipelineBuildCache) Finished() {
+	// No-op
+}
+
+func parseBroadcastMessage(data []byte) (broadcastMessage, error) {
+	if len(data) == 0 {
+		return nil, errInvalidBroadcastMessage
+	}
+
+	switch data[0] {
+	case BROADCAST_MESSAGE_TYPE_INVALIDATE_PIPELINE_BUILD_CACHE:
+		return &invalidatePipelineBuildCache{
+			pipelineName: string(data[1:]),
+		}, nil
+	default:
+		return nil, errInvalidBroadcastMessage
+	}
+}


### PR DESCRIPTION
## Decision Record

PR #1030 introduced a bug in the clustering.

Consider the following scenario:

- Node 0 & 1 & 2: logs are received, pipelines are built and cached
- Node 0: a user makes a change on the pipeline, cache on that node is invalidated
- Node 1 & 2 : receive new data due to replication
- Node 0: logs are received, new pipeline is used
- Node 1 & 2: logs are received, old pipeline is used (cache was not invalidated on those nodes)

We need to broadcast whether other nodes need to invalidate their cache as well.

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
