### PR TITLE
:bug: Replace history entry when redirecting to detail view

### DIFF
--- a/web/app/src/views/ForwarderSectionView.tsx
+++ b/web/app/src/views/ForwarderSectionView.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunction, redirect, useNavigate } from 'react-router'
+import { useEffect } from 'react'
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import * as configApi from '@/lib/api/operations/config'
 
@@ -9,13 +10,21 @@ import ButtonNewForwarder from '@/components/ButtonNewForwarder'
 export const loader: LoaderFunction = loginRequired(async () => {
   const forwarders = await configApi.listForwarders()
   if (forwarders.length > 0) {
-    throw redirect(`/web/forwarders/${forwarders[0]}`)
+    return { redirectTo: `/web/forwarders/${forwarders[0]}` }
   }
+
+  return { redirectTo: null }
 })
 
 const ForwarderSectionView = () => {
   const navigate = useNavigate()
-  console.log('Rendering ForwarderSectionView')
+  const { redirectTo } = useLoaderData<{ redirectTo: string | null }>()
+
+  useEffect(() => {
+    if (redirectTo !== null) {
+      navigate(redirectTo, { replace: true })
+    }
+  }, [redirectTo])
 
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-5">

--- a/web/app/src/views/PipelineSectionView.tsx
+++ b/web/app/src/views/PipelineSectionView.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunction, redirect, useNavigate } from 'react-router'
+import { useEffect } from 'react'
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import * as configApi from '@/lib/api/operations/config'
 
@@ -9,12 +10,21 @@ import ButtonNewPipeline from '@/components/ButtonNewPipeline'
 export const loader: LoaderFunction = loginRequired(async () => {
   const pipelines = await configApi.listPipelines()
   if (pipelines.length > 0) {
-    throw redirect(`/web/pipelines/${pipelines[0]}`)
+    return { redirectTo: `/web/pipelines/${pipelines[0]}` }
   }
+
+  return { redirectTo: null }
 })
 
 const PipelineSectionView = () => {
   const navigate = useNavigate()
+  const { redirectTo } = useLoaderData<{ redirectTo: string | null }>()
+
+  useEffect(() => {
+    if (redirectTo !== null) {
+      navigate(redirectTo, { replace: true })
+    }
+  }, [redirectTo])
 
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-5">

--- a/web/app/src/views/StorageSectionView.tsx
+++ b/web/app/src/views/StorageSectionView.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunction, redirect, useNavigate } from 'react-router'
+import { useEffect } from 'react'
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import * as configApi from '@/lib/api/operations/config'
 
@@ -10,12 +11,21 @@ export const loader: LoaderFunction = loginRequired(async () => {
   const streams = await configApi.listStreams()
   const streamNames = Object.keys(streams)
   if (streamNames.length > 0) {
-    throw redirect(`/web/storage/${streamNames[0]}`)
+    return { redirectTo: `/web/storage/${streamNames[0]}` }
   }
+
+  return { redirectTo: null }
 })
 
 const StorageSectionView = () => {
   const navigate = useNavigate()
+  const { redirectTo } = useLoaderData<{ redirectTo: string | null }>()
+
+  useEffect(() => {
+    if (redirectTo !== null) {
+      navigate(redirectTo, { replace: true })
+    }
+  }, [redirectTo])
 
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-5">

--- a/web/app/src/views/StreamSectionView.tsx
+++ b/web/app/src/views/StreamSectionView.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunction, redirect } from 'react-router'
+import { useEffect } from 'react'
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import * as configApi from '@/lib/api/operations/config'
 
@@ -8,14 +9,29 @@ export const loader: LoaderFunction = loginRequired(async () => {
   const streams = Object.keys(await configApi.listStreams())
   streams.sort((a, b) => a.localeCompare(b))
   if (streams.length > 0) {
-    throw redirect(`/web/streams/${streams[0]}`)
+    return { redirectTo: `/web/streams/${streams[0]}` }
   }
+
+  return { redirectTo: null }
 })
 
-const StreamSectionView = () => (
-  <div className="w-full h-full flex flex-col items-center justify-center gap-5">
-    <h1 className="text-3xl font-semibold">No stream found, send some logs.</h1>
-  </div>
-)
+const StreamSectionView = () => {
+  const navigate = useNavigate()
+  const { redirectTo } = useLoaderData<{ redirectTo: string | null }>()
+
+  useEffect(() => {
+    if (redirectTo !== null) {
+      navigate(redirectTo, { replace: true })
+    }
+  }, [redirectTo])
+
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-center gap-5">
+      <h1 className="text-3xl font-semibold">
+        No stream found, send some logs.
+      </h1>
+    </div>
+  )
+}
 
 export default StreamSectionView

--- a/web/app/src/views/TransformerSectionView.tsx
+++ b/web/app/src/views/TransformerSectionView.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunction, redirect, useNavigate } from 'react-router'
+import { useEffect } from 'react'
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import * as configApi from '@/lib/api/operations/config'
 
@@ -9,12 +10,21 @@ import ButtonNewTransformer from '@/components/ButtonNewTransformer'
 export const loader: LoaderFunction = loginRequired(async () => {
   const transformers = await configApi.listTransformers()
   if (transformers.length > 0) {
-    throw redirect(`/web/transformers/${transformers[0]}`)
+    return { redirectTo: `/web/transformers/${transformers[0]}` }
   }
+
+  return { redirectTo: null }
 })
 
 const TransformerSectionView = () => {
   const navigate = useNavigate()
+  const { redirectTo } = useLoaderData<{ redirectTo: string | null }>()
+
+  useEffect(() => {
+    if (redirectTo !== null) {
+      navigate(redirectTo, { replace: true })
+    }
+  }, [redirectTo])
 
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-5">


### PR DESCRIPTION
## Decision Record

Using `throw redirect('url')` in a loader function pushes a new entry in the browser history, making the "previous" button not work as expected.

But this redirection does not support replacing the browser history entry, therefore we need to do the navigation in the component rather than in the loader function.

## Changes

 - [x] :bug: Replace history entry when redirecting to detail view

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
