### PR TITLE
:sparkles: Add `system-config` subcommand to CLI

### DIFF
--- a/cmd/flowg-client/cmd/cmd_systemconfig.go
+++ b/cmd/flowg-client/cmd/cmd_systemconfig.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewSystemConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "system-config",
+		Short: "System configuration commands",
+	}
+
+	cmd.AddCommand(
+		NewSystemConfigShowCommand(),
+		NewSystemConfigUpdateCommand(),
+	)
+
+	return cmd
+}

--- a/cmd/flowg-client/cmd/cmd_systemconfig_show.go
+++ b/cmd/flowg-client/cmd/cmd_systemconfig_show.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"link-society.com/flowg/api"
+
+	"link-society.com/flowg/internal/utils/client"
+)
+
+func NewSystemConfigShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show system configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := cmd.Context().Value(ApiClient).(*client.Client)
+			url := "/api/v1/system-configuration"
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not prepare request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not send request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				fmt.Fprintf(os.Stderr, "ERROR: Received non-200 response: %s\n", resp.Status)
+				ExitCode = 1
+				return
+			}
+
+			var data api.GetSystemConfigurationResponse
+			if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not decode response: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			fmt.Println("System Configuration:")
+
+			if len(data.Configuration.SyslogAllowedOrigins) == 0 {
+				fmt.Println("  Syslog Allowed Origins: ALL")
+			} else {
+				fmt.Println("  Syslog Allowed Origins:")
+				for _, origin := range data.Configuration.SyslogAllowedOrigins {
+					fmt.Printf("    - %s\n", origin)
+				}
+			}
+		},
+	}
+}

--- a/cmd/flowg-client/cmd/cmd_systemconfig_update.go
+++ b/cmd/flowg-client/cmd/cmd_systemconfig_update.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"link-society.com/flowg/api"
+
+	"link-society.com/flowg/internal/utils/client"
+)
+
+func NewSystemConfigUpdateCommand() *cobra.Command {
+	type options struct {
+		SyslogAllowedOrigins []string
+		SyslogAllowAll       bool
+	}
+
+	opts := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update system configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := cmd.Context().Value(ApiClient).(*client.Client)
+			url := "/api/v1/system-configuration"
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not prepare request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not send request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				fmt.Fprintf(os.Stderr, "ERROR: Received non-200 response: %s\n", resp.Status)
+				ExitCode = 1
+				return
+			}
+
+			var data api.GetSystemConfigurationResponse
+			if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not decode response: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			if cmd.Flags().Changed("syslog-allowed-origins") {
+				data.Configuration.SyslogAllowedOrigins = opts.SyslogAllowedOrigins
+			}
+
+			if cmd.Flags().Changed("syslog-allow-all") && opts.SyslogAllowAll {
+				data.Configuration.SyslogAllowedOrigins = []string{}
+			}
+
+			payload, err := json.Marshal(data.Configuration)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not encode request body: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			req, err = http.NewRequest(http.MethodPut, url, bytes.NewBuffer(payload))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not prepare request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+
+			resp, err = client.Do(req)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: Could not send request: %v\n", err)
+				ExitCode = 1
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				fmt.Fprintf(os.Stderr, "ERROR: Failed to update system configuration: %s\n", resp.Status)
+				ExitCode = 1
+				return
+			}
+		},
+	}
+
+	cmd.Flags().StringArrayVar(
+		&opts.SyslogAllowedOrigins,
+		"syslog-allowed-origin",
+		[]string{},
+		"List of allowed origins for syslog (empty list means all origins are allowed)",
+	)
+
+	cmd.Flags().BoolVar(
+		&opts.SyslogAllowAll,
+		"syslog-allow-all",
+		false,
+		"Allow all origins for syslog (overrides --syslog-allowed-origin)",
+	)
+
+	return cmd
+}

--- a/cmd/flowg-client/cmd/main.go
+++ b/cmd/flowg-client/cmd/main.go
@@ -61,6 +61,7 @@ func NewRootCommand() *cobra.Command {
 		NewForwarderCommand(),
 		NewAclCommand(),
 		NewTokenCommand(),
+		NewSystemConfigCommand(),
 		NewAdminCommand(),
 	)
 


### PR DESCRIPTION
## Decision Record

See #1067 

A subcommand to the CLI was never added.

## Changes

 - [x] :sparkles: Add `system-config` subcommand to CLI

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
