### PR TITLE
🧑‍💻 Added optional dev server for faster frontend development

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "build:dev": "tsc -b && vite build --mode development",
     "lint": "eslint . && prettier --check .",

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -21,6 +21,18 @@ export default defineConfig({
       filename: '[path][base]',
       deleteOriginalAssets: true
     }),
+    {
+      name: 'rewrite-assets-path',
+      configureServer(serve) {
+        serve.middlewares.use((req, _res, next) => {
+          if (req.url?.startsWith('/web/assets/')) {
+            req.url = req.url?.replace('/web/assets', '/assets')
+          }
+
+          next()
+        })
+      }
+    }
   ],
   build: {
     sourcemap: true,
@@ -38,5 +50,14 @@ export default defineConfig({
   },
   define: {
     'import.meta.env.FLOWG_VERSION': JSON.stringify(fs.readFileSync('../../VERSION.txt', 'utf8').trim()),
+  },
+  server: {
+    open: '/web',
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5080',
+        changeOrigin: true
+      },
+    }
   },
 })


### PR DESCRIPTION
## Decision Record

Until now changing the frontend required recompiling bot the frontend and backend and restarting a backend server for even the smallest frontend changes to appear. Creating a frontend server allows us to have hot reload for the frontend while developing.

## Changes

 - [x] 🧑‍💻 Added optional dev server for faster frontend development

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
