### PR TITLE
:fire: remove deprecated FLOWG_SYSLOG_ALLOWED_ORIGINS env variable

### DIFF
--- a/cmd/flowg-server/cmd/env.go
+++ b/cmd/flowg-server/cmd/env.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"strconv"
-	"strings"
 )
 
 var (
@@ -40,14 +39,6 @@ var (
 
 	defaultSyslogProtocol     = getEnvString("FLOWG_SYSLOG_PROTOCOL", "udp")
 	defaultSyslogBindAddr     = getEnvString("FLOWG_SYSLOG_BIND_ADDRESS", ":5514")
-	defaultSyslogAllowOrigins = (func() []string {
-		origins := getEnvString("FLOWG_SYSLOG_ALLOW_ORIGINS", "")
-		if origins == "" {
-			return nil
-		} else {
-			return strings.Split(origins, ",")
-		}
-	})()
 
 	defaultSyslogTlsEnabled     = getEnvBool("FLOWG_SYSLOG_TLS_ENABLED", false)
 	defaultSyslogTlsCert        = getEnvString("FLOWG_SYSLOG_TLS_CERT", "")


### PR DESCRIPTION
## Decision Record
Closes #1207

The `--syslog-allow-origin` CLI option was removed in #1067 but the 
corresponding env var `FLOWG_SYSLOG_ALLOWED_ORIGINS` and its variable 
`defaultSyslogAllowOrigins` were left behind in env.go. Removed both, 
along with the now-unused `strings` import.

## **Changes**
 - [x] :fire: Remove deprecated `FLOWG_SYSLOG_ALLOWED_ORIGINS` env variable from `env.go`
 - [x] :fire: Remove unused `strings` import

## License Agreement
 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License