### PR TITLE
:sparkles: Bootstrap system configuration

### DIFF
--- a/cmd/flowg-server/cmd/cli.go
+++ b/cmd/flowg-server/cmd/cli.go
@@ -38,12 +38,13 @@ type options struct {
 	clusterFormationDnsDomain string
 	clusterFormationDnsScript string
 
-	syslogProtocol       string
-	syslogBindAddr       string
-	syslogTlsEnabled     bool
-	syslogTlsCert        string
-	syslogTlsCertKey     string
-	syslogTlsAuthEnabled bool
+	syslogProtocol              string
+	syslogBindAddr              string
+	syslogTlsEnabled            bool
+	syslogTlsCert               string
+	syslogTlsCertKey            string
+	syslogTlsAuthEnabled        bool
+	syslogInitialAllowedOrigins []string
 
 	authDir   string
 	logDir    string
@@ -268,6 +269,13 @@ func (opts *options) defineCliOptions(cmd *cobra.Command) {
 		"syslog-tls-auth",
 		defaultSyslogTlsAuthEnabled,
 		"Require clients to authenticate against the Syslog server with a client certificate",
+	)
+
+	cmd.Flags().StringArrayVar(
+		&opts.syslogInitialAllowedOrigins,
+		"syslog-initial-allowed-origin",
+		defaultSyslogInitialAllowedOrigins,
+		"Initial allowed origins for the Syslog server (can be set multiple times)",
 	)
 
 	cmd.Flags().StringVar(

--- a/cmd/flowg-server/cmd/config.go
+++ b/cmd/flowg-server/cmd/config.go
@@ -162,9 +162,10 @@ func newServerConfig(opts *options) (server.Options, error) {
 		ClusterStateDir:          opts.clusterStateDir,
 		ClusterFormationStrategy: clusterFormationStrategy,
 
-		SyslogTcpMode:     opts.syslogProtocol == "tcp",
-		SyslogBindAddress: opts.syslogBindAddr,
-		SyslogTlsConfig:   syslogTlsConfig,
+		SyslogTcpMode:               opts.syslogProtocol == "tcp",
+		SyslogBindAddress:           opts.syslogBindAddr,
+		SyslogTlsConfig:             syslogTlsConfig,
+		SyslogInitialAllowedOrigins: opts.syslogInitialAllowedOrigins,
 
 		ConfigStorageDir: opts.configDir,
 		AuthStorageDir:   opts.authDir,

--- a/cmd/flowg-server/cmd/env.go
+++ b/cmd/flowg-server/cmd/env.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"strconv"
+	"strings"
 )
 
 var (
@@ -45,10 +46,11 @@ var (
 	defaultSyslogProtocol = getEnvString("FLOWG_SYSLOG_PROTOCOL", "udp")
 	defaultSyslogBindAddr = getEnvString("FLOWG_SYSLOG_BIND_ADDRESS", ":5514")
 
-	defaultSyslogTlsEnabled     = getEnvBool("FLOWG_SYSLOG_TLS_ENABLED", false)
-	defaultSyslogTlsCert        = getEnvString("FLOWG_SYSLOG_TLS_CERT", "")
-	defaultSyslogTlsCertKey     = getEnvString("FLOWG_SYSLOG_TLS_KEY", "")
-	defaultSyslogTlsAuthEnabled = getEnvBool("FLOWG_SYSLOG_TLS_AUTH", false)
+	defaultSyslogTlsEnabled            = getEnvBool("FLOWG_SYSLOG_TLS_ENABLED", false)
+	defaultSyslogTlsCert               = getEnvString("FLOWG_SYSLOG_TLS_CERT", "")
+	defaultSyslogTlsCertKey            = getEnvString("FLOWG_SYSLOG_TLS_KEY", "")
+	defaultSyslogTlsAuthEnabled        = getEnvBool("FLOWG_SYSLOG_TLS_AUTH", false)
+	defaultSyslogInitialAllowedOrigins = getEnvListString("FLOWG_SYSLOG_INITIAL_ALLOWED_ORIGINS", []string{})
 
 	defaultAuthDir         = getEnvString("FLOWG_AUTH_DIR", "./data/auth")
 	defaultConfigDir       = getEnvString("FLOWG_CONFIG_DIR", "./data/config")
@@ -61,6 +63,20 @@ var (
 	defaultAuthResetUser     = getEnvString("FLOWG_AUTH_RESET_USER", "")
 	defaultAuthResetPassword = getEnvString("FLOWG_AUTH_RESET_PASSWORD", "")
 )
+
+func getEnvListString(key string, defaultValue []string) []string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+
+	items := strings.Split(value, ",")
+	for i := range items {
+		items[i] = strings.TrimSpace(items[i])
+	}
+
+	return items
+}
 
 func getEnvString(key string, defaultValue string) string {
 	value := os.Getenv(key)

--- a/internal/app/bootstrap/auth.go
+++ b/internal/app/bootstrap/auth.go
@@ -11,7 +11,7 @@ import (
 	"link-society.com/flowg/internal/storage/auth"
 )
 
-type BootstrapOptions struct {
+type BootstrapAuthOptions struct {
 	InitialUser     string
 	InitialPassword string
 }
@@ -21,7 +21,7 @@ type ResetUserOptions struct {
 	Password string
 }
 
-func DefaultRolesAndUsers(ctx context.Context, authStorage auth.Storage, opts BootstrapOptions) error {
+func DefaultRolesAndUsers(ctx context.Context, authStorage auth.Storage, opts BootstrapAuthOptions) error {
 	roles, err := authStorage.ListRoles(ctx)
 	if err != nil {
 		return err

--- a/internal/app/bootstrap/auth_test.go
+++ b/internal/app/bootstrap/auth_test.go
@@ -33,7 +33,7 @@ func TestDefaultRolesAndUsers(t *testing.T) {
 	app.RequireStart()
 	defer app.RequireStop()
 
-	err := bootstrap.DefaultRolesAndUsers(ctx, authStorage, bootstrap.BootstrapOptions{
+	err := bootstrap.DefaultRolesAndUsers(ctx, authStorage, bootstrap.BootstrapAuthOptions{
 		InitialUser:     "root",
 		InitialPassword: "root",
 	})

--- a/internal/app/bootstrap/system.go
+++ b/internal/app/bootstrap/system.go
@@ -1,0 +1,32 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/storage/config"
+)
+
+type BootstrapSystemOptions struct {
+	InitialSyslogAllowedOrigins []string
+}
+
+func DefaultSystemConfig(ctx context.Context, configStorage config.Storage, opts BootstrapSystemOptions) error {
+	hasConfig, err := configStorage.HasSystemConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if system config exists: %w", err)
+	}
+
+	if !hasConfig {
+		defaultConfig := &models.SystemConfiguration{
+			SyslogAllowedOrigins: opts.InitialSyslogAllowedOrigins,
+		}
+
+		if err := configStorage.WriteSystemConfig(ctx, defaultConfig); err != nil {
+			return fmt.Errorf("failed to write default system config: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/app/bootstrap/system_test.go
+++ b/internal/app/bootstrap/system_test.go
@@ -1,0 +1,53 @@
+package bootstrap_test
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/internal/app/bootstrap"
+	"link-society.com/flowg/internal/app/logging"
+
+	"link-society.com/flowg/internal/storage/config"
+)
+
+func TestDefaultSystemConfig(t *testing.T) {
+	logging.Discard()
+
+	ctx := t.Context()
+
+	confOpts := config.DefaultOptions()
+	confOpts.InMemory = true
+
+	var confStorage config.Storage
+
+	app := fxtest.New(
+		t,
+		config.NewStorage(confOpts),
+		fx.Populate(&confStorage),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	err := bootstrap.DefaultSystemConfig(ctx, confStorage, bootstrap.BootstrapSystemOptions{
+		InitialSyslogAllowedOrigins: []string{"127.0.0.1"},
+	})
+	if err != nil {
+		t.Fatalf("failed to bootstrap default system config: %v", err)
+	}
+
+	systemConfig, err := confStorage.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+
+	if len(systemConfig.SyslogAllowedOrigins) != 1 {
+		t.Fatalf("expected 1 allowed origin, got %d", len(systemConfig.SyslogAllowedOrigins))
+	}
+
+	if systemConfig.SyslogAllowedOrigins[0] != "127.0.0.1" {
+		t.Fatalf("expected allowed origin to be 127.0.0.1, got %s", systemConfig.SyslogAllowedOrigins[0])
+	}
+}

--- a/internal/app/server/bootstrap.go
+++ b/internal/app/server/bootstrap.go
@@ -17,6 +17,8 @@ type bootstrapHandler struct {
 	authStorage   auth.Storage
 	configStorage config.Storage
 
+	initialSyslogAllowedOrigins []string
+
 	initialUser     string
 	initialPassword string
 
@@ -25,7 +27,14 @@ type bootstrapHandler struct {
 }
 
 func (h *bootstrapHandler) Run(ctx context.Context) error {
-	err := bootstrap.DefaultRolesAndUsers(ctx, h.authStorage, bootstrap.BootstrapOptions{
+	err := bootstrap.DefaultSystemConfig(ctx, h.configStorage, bootstrap.BootstrapSystemOptions{
+		InitialSyslogAllowedOrigins: h.initialSyslogAllowedOrigins,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to bootstrap default system config: %w", err)
+	}
+
+	err = bootstrap.DefaultRolesAndUsers(ctx, h.authStorage, bootstrap.BootstrapAuthOptions{
 		InitialUser:     h.initialUser,
 		InitialPassword: h.initialPassword,
 	})

--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -34,9 +34,10 @@ type Options struct {
 	ClusterStateDir          string
 	ClusterFormationStrategy cluster.ClusterFormationStrategy
 
-	SyslogTcpMode     bool
-	SyslogBindAddress string
-	SyslogTlsConfig   *tls.Config
+	SyslogTcpMode               bool
+	SyslogBindAddress           string
+	SyslogTlsConfig             *tls.Config
+	SyslogInitialAllowedOrigins []string
 
 	AuthStorageDir   string
 	ConfigStorageDir string

--- a/internal/storage/config/main.go
+++ b/internal/storage/config/main.go
@@ -41,6 +41,7 @@ type Storage interface {
 	WriteForwarder(ctx context.Context, name string, forwarder *models.ForwarderV2) error
 	DeleteForwarder(ctx context.Context, name string) error
 
+	HasSystemConfig(ctx context.Context) (bool, error)
 	ReadSystemConfig(ctx context.Context) (*models.SystemConfiguration, error)
 	WriteSystemConfig(ctx context.Context, config *models.SystemConfiguration) error
 }
@@ -221,6 +222,19 @@ func (s *storageImpl) WriteForwarder(ctx context.Context, name string, forwarder
 
 func (s *storageImpl) DeleteForwarder(ctx context.Context, name string) error {
 	return s.deleteItem(ctx, forwarderItemType, name)
+}
+
+func (s *storageImpl) HasSystemConfig(ctx context.Context) (bool, error) {
+	_, err := s.readItem(ctx, systemItemType, "config")
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (s *storageImpl) ReadSystemConfig(ctx context.Context) (*models.SystemConfiguration, error) {

--- a/internal/storage/config/mock.go
+++ b/internal/storage/config/mock.go
@@ -94,6 +94,11 @@ func (m *MockStorage) DeleteForwarder(ctx context.Context, name string) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) HasSystemConfig(ctx context.Context) (bool, error) {
+	args := m.Called(ctx)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) ReadSystemConfig(ctx context.Context) (*models.SystemConfiguration, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(*models.SystemConfiguration), args.Error(0)

--- a/internal/storage/config/system_cofiguration_test.go
+++ b/internal/storage/config/system_cofiguration_test.go
@@ -24,6 +24,15 @@ func TestReadSystemConfig(t *testing.T) {
 	app.RequireStart()
 	defer app.RequireStop()
 
+	hasConfig, err := confStorage.HasSystemConfig(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hasConfig {
+		t.Fatal("expected no system config, but found one")
+	}
+
 	systemConfig, err := confStorage.ReadSystemConfig(ctx)
 
 	if err != nil {
@@ -42,6 +51,15 @@ func TestReadSystemConfig(t *testing.T) {
 
 	if err := confStorage.WriteSystemConfig(ctx, systemConfig); err != nil {
 		t.Fatal(err)
+	}
+
+	hasConfig, err = confStorage.HasSystemConfig(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasConfig {
+		t.Fatal("expected system config to exist, but it does not")
 	}
 
 	systemConfig, err = confStorage.ReadSystemConfig(ctx)


### PR DESCRIPTION
## Decision Record

Closes #1310

## Changes

 - [x] :wrench: Add `FLOWG_SYSLOG_INITIAL_ALLOWED_ORIGINS="127.0.0.1,127.0.0.2,..."` environment variable
 - [x] :wrench: Add `--syslog-initial-allowed-origin=127.0.0.1 --syslog-initial-allowed-origin=127.0.0.2 ...` CLI option
 - [x] :sparkles: Initialize system configuration if not present at startup

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
