### PR TITLE
:bug: pass option from server to bootstrap handler

### DIFF
--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -102,13 +102,14 @@ func NewServer(opts Options) fx.Option {
 			logStorage log.Storage,
 		) *bootstrapHandler {
 			h := &bootstrapHandler{
-				logger:          slog.Default().With(slog.String("channel", "bootstrap")),
-				authStorage:     authStorage,
-				configStorage:   configStorage,
-				initialUser:     opts.AuthInitialUser,
-				initialPassword: opts.AuthInitialPassword,
-				resetUser:       opts.AuthResetUser,
-				resetPassword:   opts.AuthResetPassword,
+				logger:                      slog.Default().With(slog.String("channel", "bootstrap")),
+				authStorage:                 authStorage,
+				configStorage:               configStorage,
+				initialSyslogAllowedOrigins: opts.SyslogInitialAllowedOrigins,
+				initialUser:                 opts.AuthInitialUser,
+				initialPassword:             opts.AuthInitialPassword,
+				resetUser:                   opts.AuthResetUser,
+				resetPassword:               opts.AuthResetPassword,
 			}
 
 			lc.Append(fx.Hook{

--- a/internal/services/syslog/worker.go
+++ b/internal/services/syslog/worker.go
@@ -44,7 +44,7 @@ func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
 			return actor.WorkerContinue
 		}
 
-		if systemConfig.SyslogAllowedOrigins != nil {
+		if len(systemConfig.SyslogAllowedOrigins) > 0 {
 			// no logging here to avoid potential performance issues
 
 			client := logParts["client"].(string)

--- a/tests/specs/api/system_configuration.hurl
+++ b/tests/specs/api/system_configuration.hurl
@@ -11,7 +11,7 @@ Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
-jsonpath "$.configuration.syslog_allowed_origins" == null
+jsonpath "$.configuration.syslog_allowed_origins" count == 0
 
 # -----------------------------------------------------------------------------
 # TEST:


### PR DESCRIPTION
## Decision Record

See also: #1310
Fixes: #1311

The value for the Syslog initial "Allowed Origins" wasn't passed to the bootstrap handler, hence an empty list was always used.

## Changes

 - [x] :bug: pass option from server to bootstrap handler

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
