### PR TITLE
💄 Clean styles files

### DIFF
--- a/web/app/src/components/AppContainer/component.tsx
+++ b/web/app/src/components/AppContainer/component.tsx
@@ -45,14 +45,16 @@ export const AppContainer = forwardRef<HTMLDivElement, AppContainerProps>(
         ref={ref}
         maxWidth={fluid ? false : 'xl'}
         {...props}
-        sx={(theme) => ({
-          ...getPadding(),
-          ...sx,
-          display: 'flex',
-          placeItems: 'center',
-          gap: theme.spacing(4),
-          flex: 1,
-        })}
+        sx={[
+          (theme) => ({
+            ...getPadding(),
+            display: 'flex',
+            placeItems: 'center',
+            gap: theme.spacing(4),
+            flex: 1,
+          }),
+          ...(Array.isArray(sx) ? sx : sx != null ? [sx] : []),
+        ]}
       >
         {children}
       </Container>

--- a/web/app/src/components/AppContainer/component.tsx
+++ b/web/app/src/components/AppContainer/component.tsx
@@ -53,7 +53,7 @@ export const AppContainer = forwardRef<HTMLDivElement, AppContainerProps>(
             gap: theme.spacing(4),
             flex: 1,
           }),
-          ...(Array.isArray(sx) ? sx : sx != null ? [sx] : []),
+          ...(sx == null ? [] : Array.isArray(sx) ? sx : [sx]),
         ]}
       >
         {children}

--- a/web/app/src/components/AppContainer/component.tsx
+++ b/web/app/src/components/AppContainer/component.tsx
@@ -45,14 +45,14 @@ export const AppContainer = forwardRef<HTMLDivElement, AppContainerProps>(
         ref={ref}
         maxWidth={fluid ? false : 'xl'}
         {...props}
-        sx={{
+        sx={(theme) => ({
           ...getPadding(),
           ...sx,
           display: 'flex',
           placeItems: 'center',
-          gap: '2rem',
+          gap: theme.spacing(4),
           flex: 1,
-        }}
+        })}
       >
         {children}
       </Container>

--- a/web/app/src/components/DialogForwarderEditor/component.tsx
+++ b/web/app/src/components/DialogForwarderEditor/component.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from 'react'
 
-import AppBar from '@mui/material/AppBar'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import Slide from '@mui/material/Slide'
-import TextField from '@mui/material/TextField'
 import { TransitionProps } from '@mui/material/transitions'
 
 import CloseIcon from '@mui/icons-material/Close'
@@ -24,10 +22,12 @@ import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
 import ForwarderEditor from '@/components/ForwarderEditor/component'
 
 import {
+  DialogAppBar,
   DialogBody,
   DialogLoading,
   DialogToolbar,
   DialogToolbarName,
+  ToolbarNameInput,
 } from './styles'
 
 const Transition = React.forwardRef(function Transition(
@@ -89,7 +89,7 @@ const DialogForwarderEditor = ({
           transition: Transition,
         }}
       >
-        <AppBar sx={{ position: 'relative' }}>
+        <DialogAppBar>
           <DialogToolbar>
             <IconButton
               edge="start"
@@ -100,7 +100,7 @@ const DialogForwarderEditor = ({
             </IconButton>
 
             <DialogToolbarName>
-              <TextField
+              <ToolbarNameInput
                 label="Forwarder name"
                 value={forwarderName}
                 type="text"
@@ -109,18 +109,6 @@ const DialogForwarderEditor = ({
                 slotProps={{
                   input: {
                     readOnly: true,
-                    sx: {
-                      color: 'white',
-                      backgroundColor: 'rgba(0,0,0,0.15)',
-                    },
-                  },
-                  inputLabel: {
-                    sx: {
-                      color: 'white',
-                      '&.Mui-focused': {
-                        color: 'white',
-                      },
-                    },
                   },
                 }}
               />
@@ -137,7 +125,7 @@ const DialogForwarderEditor = ({
               {saveLoading ? <CircularProgress size={24} /> : <>Save</>}
             </Button>
           </DialogToolbar>
-        </AppBar>
+        </DialogAppBar>
 
         <DialogBody>
           <React.Suspense

--- a/web/app/src/components/DialogForwarderEditor/styles.tsx
+++ b/web/app/src/components/DialogForwarderEditor/styles.tsx
@@ -1,4 +1,14 @@
-import { Box, Toolbar, styled } from '@mui/material'
+import {
+  Box,
+  AppBar as MuiAppBar,
+  TextField as MuiTextField,
+  Toolbar,
+  styled,
+} from '@mui/material'
+
+export const DialogAppBar = styled(MuiAppBar)({
+  position: 'relative',
+})
 
 export const DialogToolbar = styled(Toolbar)({
   gap: '0.75rem',
@@ -7,6 +17,22 @@ export const DialogToolbar = styled(Toolbar)({
 export const DialogToolbarName = styled('div')({
   flexGrow: 1,
 })
+
+export const ToolbarNameInput = styled(MuiTextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    color: theme.tokens.colors.primaryContrast,
+    backgroundColor: `rgba(0, 0, 0, ${theme.tokens.opacity.disabled})`,
+    '& fieldset': {
+      borderColor: theme.tokens.colors.toolbarInputBorder,
+    },
+  },
+  '& .MuiFormLabel-root': {
+    color: theme.tokens.colors.primaryContrast,
+    '&.Mui-focused': {
+      color: theme.tokens.colors.primaryContrast,
+    },
+  },
+}))
 
 export const DialogBody = styled(Box)({
   flex: 1,

--- a/web/app/src/components/DialogForwarderEditor/styles.tsx
+++ b/web/app/src/components/DialogForwarderEditor/styles.tsx
@@ -10,9 +10,9 @@ export const DialogAppBar = styled(MuiAppBar)({
   position: 'relative',
 })
 
-export const DialogToolbar = styled(Toolbar)({
-  gap: '0.75rem',
-})
+export const DialogToolbar = styled(Toolbar)(({ theme }) => ({
+  gap: theme.spacing(1.5),
+}))
 
 export const DialogToolbarName = styled('div')({
   flexGrow: 1,
@@ -34,11 +34,11 @@ export const ToolbarNameInput = styled(MuiTextField)(({ theme }) => ({
   },
 }))
 
-export const DialogBody = styled(Box)({
+export const DialogBody = styled(Box)(({ theme }) => ({
   flex: 1,
-  padding: '1.5rem',
+  padding: theme.spacing(3),
   overflow: 'auto',
-})
+}))
 
 export const DialogLoading = styled(Box)({
   width: '100%',

--- a/web/app/src/components/DialogNewForwarder/styles.tsx
+++ b/web/app/src/components/DialogNewForwarder/styles.tsx
@@ -1,18 +1,18 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
 
-export const DialogFormBody = styled(Box)({
-  paddingTop: '0.75rem',
+export const DialogFormBody = styled(Box)(({ theme }) => ({
+  paddingTop: theme.spacing(1.5),
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const TypeOption = styled(Box)({
+export const TypeOption = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))

--- a/web/app/src/components/DialogNewRole/component.tsx
+++ b/web/app/src/components/DialogNewRole/component.tsx
@@ -7,7 +7,6 @@ import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
-import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 
 import CancelIcon from '@mui/icons-material/Cancel'
@@ -23,7 +22,7 @@ import { ScopeLabels, Scopes } from '@/lib/models/Scopes'
 
 import InputTransferList from '@/components/InputTransferList/component'
 
-import { FieldLabel, FieldStack, FormStack } from './styles'
+import { FieldLabel, FieldStack, FormStack, FormTextField } from './styles'
 
 const DialogNewRole = ({
   open,
@@ -61,14 +60,13 @@ const DialogNewRole = ({
       <DialogTitle>Create a new role</DialogTitle>
       <DialogContent>
         <FormStack>
-          <TextField
+          <FormTextField
             id="input:admin.roles.modal.name"
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             type="text"
             variant="outlined"
-            sx={{ mt: 2 }}
             required
           />
 

--- a/web/app/src/components/DialogNewRole/styles.tsx
+++ b/web/app/src/components/DialogNewRole/styles.tsx
@@ -2,19 +2,19 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const FormStack = styled(Box)({
+export const FormStack = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const FieldStack = styled(Box)({
+export const FieldStack = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
 export const FieldLabel = styled(Typography)({
   fontWeight: 600,

--- a/web/app/src/components/DialogNewRole/styles.tsx
+++ b/web/app/src/components/DialogNewRole/styles.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
@@ -19,3 +20,7 @@ export const FieldStack = styled(Box)(({ theme }) => ({
 export const FieldLabel = styled(Typography)({
   fontWeight: 600,
 })
+
+export const FormTextField = styled(TextField)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+}))

--- a/web/app/src/components/DialogNewToken/component.tsx
+++ b/web/app/src/components/DialogNewToken/component.tsx
@@ -28,7 +28,7 @@ const DialogNewToken = ({
     <DialogTitle>Your Personal Access Token</DialogTitle>
     <DialogContent>
       <FieldRow>
-        <LabelIcon sx={{ mr: 1, my: 0.5 }} />
+        <LabelIcon />
         <TextField
           id="input:account.tokens.modal.token_uuid"
           label="Token UUID"
@@ -45,7 +45,7 @@ const DialogNewToken = ({
       </FieldRow>
 
       <FieldRow>
-        <KeyIcon sx={{ mr: 1, my: 0.5 }} />
+        <KeyIcon />
         <TextField
           id="input:account.tokens.modal.token"
           label="Token"

--- a/web/app/src/components/DialogNewToken/styles.tsx
+++ b/web/app/src/components/DialogNewToken/styles.tsx
@@ -1,9 +1,14 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
 
-export const FieldRow = styled(Box)({
+export const FieldRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'flex-end',
-  marginBottom: '0.75rem',
-})
+  marginBottom: theme.spacing(1.5),
+  '& > .MuiSvgIcon-root': {
+    marginRight: theme.spacing(1),
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
+  },
+}))

--- a/web/app/src/components/DialogNewUser/component.tsx
+++ b/web/app/src/components/DialogNewUser/component.tsx
@@ -65,7 +65,7 @@ const DialogNewUser = ({
       <DialogContent>
         <FormStack>
           <FieldRow>
-            <AccountCircleIcon sx={{ mr: 1, my: 0.5 }} />
+            <AccountCircleIcon />
             <TextField
               id="input:admin.users.modal.username"
               label="Username"
@@ -79,7 +79,7 @@ const DialogNewUser = ({
           </FieldRow>
 
           <FieldRow>
-            <LockIcon sx={{ mr: 1, my: 0.5 }} />
+            <LockIcon />
             <TextField
               id="input:admin.users.modal.password"
               label="Password"

--- a/web/app/src/components/DialogNewUser/styles.tsx
+++ b/web/app/src/components/DialogNewUser/styles.tsx
@@ -9,11 +9,16 @@ export const FormStack = styled(Box)(({ theme }) => ({
   gap: theme.spacing(1.5),
 }))
 
-export const FieldRow = styled(Box)({
+export const FieldRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'flex-end',
-})
+  '& > .MuiSvgIcon-root': {
+    marginRight: theme.spacing(1),
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
+  },
+}))
 
 export const FieldStack = styled(Box)(({ theme }) => ({
   display: 'flex',

--- a/web/app/src/components/DialogNewUser/styles.tsx
+++ b/web/app/src/components/DialogNewUser/styles.tsx
@@ -2,12 +2,12 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const FormStack = styled(Box)({
+export const FormStack = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const FieldRow = styled(Box)({
   display: 'flex',
@@ -15,12 +15,12 @@ export const FieldRow = styled(Box)({
   alignItems: 'flex-end',
 })
 
-export const FieldStack = styled(Box)({
+export const FieldStack = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
 export const FieldLabel = styled(Typography)({
   fontWeight: 600,

--- a/web/app/src/components/DialogStreamEditor/component.tsx
+++ b/web/app/src/components/DialogStreamEditor/component.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 
-import AppBar from '@mui/material/AppBar'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import Dialog from '@mui/material/Dialog'
@@ -25,6 +24,7 @@ import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
 import StreamEditor from '@/components/StreamEditor/component'
 
 import {
+  DialogAppBar,
   EditorToolbar,
   FallbackContainer,
   FullScreenBody,
@@ -92,7 +92,7 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
           transition: Transition,
         }}
       >
-        <AppBar sx={{ position: 'relative' }}>
+        <DialogAppBar>
           <EditorToolbar>
             <IconButton
               edge="start"
@@ -140,7 +140,7 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
               {saveLoading ? <CircularProgress size={24} /> : <>Save</>}
             </Button>
           </EditorToolbar>
-        </AppBar>
+        </DialogAppBar>
         <FullScreenBody>
           <React.Suspense
             fallback={

--- a/web/app/src/components/DialogStreamEditor/styles.tsx
+++ b/web/app/src/components/DialogStreamEditor/styles.tsx
@@ -1,3 +1,4 @@
+import AppBar from '@mui/material/AppBar'
 import Box from '@mui/material/Box'
 import Toolbar from '@mui/material/Toolbar'
 import { styled } from '@mui/material/styles'
@@ -25,3 +26,5 @@ export const FallbackContainer = styled(Box)({
   alignItems: 'center',
   justifyContent: 'center',
 })
+
+export const DialogAppBar = styled(AppBar)({ position: 'relative' })

--- a/web/app/src/components/DialogStreamEditor/styles.tsx
+++ b/web/app/src/components/DialogStreamEditor/styles.tsx
@@ -2,9 +2,9 @@ import Box from '@mui/material/Box'
 import Toolbar from '@mui/material/Toolbar'
 import { styled } from '@mui/material/styles'
 
-export const EditorToolbar = styled(Toolbar)({
-  gap: '0.75rem',
-})
+export const EditorToolbar = styled(Toolbar)(({ theme }) => ({
+  gap: theme.spacing(1.5),
+}))
 
 export const TitleField = styled(Box)({
   flexGrow: 1,
@@ -13,7 +13,7 @@ export const TitleField = styled(Box)({
 export const FullScreenBody = styled(Box)(({ theme }) => ({
   flexGrow: 1,
   backgroundColor: theme.tokens.colors.bodyBg,
-  padding: '1.5rem',
+  padding: theme.spacing(3),
   overflow: 'auto',
 }))
 

--- a/web/app/src/components/DialogTransformerEditor/component.tsx
+++ b/web/app/src/components/DialogTransformerEditor/component.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 
-import AppBar from '@mui/material/AppBar'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import Dialog from '@mui/material/Dialog'
@@ -22,6 +21,7 @@ import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
 import TransformerEditor from '@/components/TransformerEditor/component'
 
 import {
+  DialogAppBar,
   EditorToolbar,
   FallbackContainer,
   FullScreenBody,
@@ -83,7 +83,7 @@ const DialogTransformerEditor = ({
           transition: Transition,
         }}
       >
-        <AppBar sx={{ position: 'relative' }}>
+        <DialogAppBar>
           <EditorToolbar>
             <IconButton
               edge="start"
@@ -131,7 +131,7 @@ const DialogTransformerEditor = ({
               {saveLoading ? <CircularProgress size={24} /> : <>Save</>}
             </Button>
           </EditorToolbar>
-        </AppBar>
+        </DialogAppBar>
         <FullScreenBody>
           <React.Suspense
             fallback={

--- a/web/app/src/components/DialogTransformerEditor/styles.tsx
+++ b/web/app/src/components/DialogTransformerEditor/styles.tsx
@@ -2,9 +2,9 @@ import Box from '@mui/material/Box'
 import Toolbar from '@mui/material/Toolbar'
 import { styled } from '@mui/material/styles'
 
-export const EditorToolbar = styled(Toolbar)({
-  gap: '0.75rem',
-})
+export const EditorToolbar = styled(Toolbar)(({ theme }) => ({
+  gap: theme.spacing(1.5),
+}))
 
 export const TitleField = styled(Box)({
   flexGrow: 1,
@@ -13,7 +13,7 @@ export const TitleField = styled(Box)({
 export const FullScreenBody = styled(Box)(({ theme }) => ({
   flexGrow: 1,
   backgroundColor: theme.tokens.colors.bodyBg,
-  padding: '0.5rem',
+  padding: theme.spacing(1),
 }))
 
 export const FallbackContainer = styled(Box)({

--- a/web/app/src/components/DialogTransformerEditor/styles.tsx
+++ b/web/app/src/components/DialogTransformerEditor/styles.tsx
@@ -1,3 +1,4 @@
+import AppBar from '@mui/material/AppBar'
 import Box from '@mui/material/Box'
 import Toolbar from '@mui/material/Toolbar'
 import { styled } from '@mui/material/styles'
@@ -24,3 +25,5 @@ export const FallbackContainer = styled(Box)({
   alignItems: 'center',
   justifyContent: 'center',
 })
+
+export const DialogAppBar = styled(AppBar)({ position: 'relative' })

--- a/web/app/src/components/ErrorBoundary/styles.tsx
+++ b/web/app/src/components/ErrorBoundary/styles.tsx
@@ -25,7 +25,7 @@ export const CodeBlock = styled(Box)<BoxProps<'pre'>>(({ theme }) => ({
   padding: '0.5rem',
   backgroundColor: theme.tokens.colors.black,
   color: theme.tokens.colors.mutedText,
-  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+  boxShadow: theme.tokens.shadows.sm,
   fontFamily: 'monospace',
   whiteSpace: 'pre',
   overflow: 'auto',

--- a/web/app/src/components/ErrorBoundary/styles.tsx
+++ b/web/app/src/components/ErrorBoundary/styles.tsx
@@ -2,12 +2,12 @@ import Box, { BoxProps } from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const ErrorRoot = styled(Box)({
-  padding: '0.75rem',
+export const ErrorRoot = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'column',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const ErrorHeading = styled(Typography)(({ theme }) => ({
   fontSize: '1.5rem',
@@ -22,7 +22,7 @@ export const ErrorHeadingLabel = styled(Typography)({
 })
 
 export const CodeBlock = styled(Box)<BoxProps<'pre'>>(({ theme }) => ({
-  padding: '0.5rem',
+  padding: theme.spacing(1),
   backgroundColor: theme.tokens.colors.black,
   color: theme.tokens.colors.mutedText,
   boxShadow: theme.tokens.shadows.sm,

--- a/web/app/src/components/ForwarderEditorAmqp/styles.tsx
+++ b/web/app/src/components/ForwarderEditorAmqp/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorAmqpRoot = styled('div')({
+export const ForwarderEditorAmqpRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorClickhouse/styles.tsx
+++ b/web/app/src/components/ForwarderEditorClickhouse/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorClickhouseRoot = styled('div')({
+export const ForwarderEditorClickhouseRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorDatadog/styles.tsx
+++ b/web/app/src/components/ForwarderEditorDatadog/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorDatadogRoot = styled('div')({
+export const ForwarderEditorDatadogRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorElastic/styles.tsx
+++ b/web/app/src/components/ForwarderEditorElastic/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorElasticRoot = styled('div')({
+export const ForwarderEditorElasticRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorHttp/styles.tsx
+++ b/web/app/src/components/ForwarderEditorHttp/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorHttpRoot = styled('div')({
+export const ForwarderEditorHttpRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorOtlp/styles.tsx
+++ b/web/app/src/components/ForwarderEditorOtlp/styles.tsx
@@ -1,11 +1,11 @@
 import { TextField, styled } from '@mui/material'
 
-export const ForwarderEditorOtlpRoot = styled('div')({
+export const ForwarderEditorOtlpRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const ForwarderEditorOtlpEndpointField = styled(TextField)({
   width: '100%',

--- a/web/app/src/components/ForwarderEditorSplunk/styles.tsx
+++ b/web/app/src/components/ForwarderEditorSplunk/styles.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material'
 
-export const ForwarderEditorSplunkRoot = styled('div')({
+export const ForwarderEditorSplunkRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ForwarderEditorSyslog/styles.tsx
+++ b/web/app/src/components/ForwarderEditorSyslog/styles.tsx
@@ -1,24 +1,24 @@
 import { FormControl, TextField, styled } from '@mui/material'
 
-export const ForwarderEditorSyslogRoot = styled('div')({
+export const ForwarderEditorSyslogRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const ForwarderEditorSyslogRow = styled('div')({
+export const ForwarderEditorSyslogRow = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const ForwarderEditorSyslogColumn = styled('div')({
+export const ForwarderEditorSyslogColumn = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const ForwarderEditorSyslogAddressField = styled(TextField)({
   flexGrow: 1,

--- a/web/app/src/components/InputKeyValue/component.tsx
+++ b/web/app/src/components/InputKeyValue/component.tsx
@@ -48,7 +48,6 @@ const InputKeyValue = (props: InputKeyValueProps) => {
             }}
             variant="outlined"
             size="small"
-            sx={{ flexGrow: 1 }}
           />
 
           <TextField
@@ -64,7 +63,6 @@ const InputKeyValue = (props: InputKeyValueProps) => {
             }}
             variant="outlined"
             size="small"
-            sx={{ flexGrow: 1 }}
           />
 
           <Button
@@ -95,7 +93,6 @@ const InputKeyValue = (props: InputKeyValueProps) => {
           }}
           variant="outlined"
           size="small"
-          sx={{ flexGrow: 1 }}
         />
 
         <TextField
@@ -107,7 +104,6 @@ const InputKeyValue = (props: InputKeyValueProps) => {
           }}
           variant="outlined"
           size="small"
-          sx={{ flexGrow: 1 }}
         />
 
         <Button

--- a/web/app/src/components/InputKeyValue/styles.tsx
+++ b/web/app/src/components/InputKeyValue/styles.tsx
@@ -12,4 +12,5 @@ export const InputKVRow = styled('div')(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
+  '& .MuiTextField-root': { flexGrow: 1 },
 }))

--- a/web/app/src/components/InputKeyValue/styles.tsx
+++ b/web/app/src/components/InputKeyValue/styles.tsx
@@ -1,15 +1,15 @@
 import { styled } from '@mui/material'
 
-export const InputKVRoot = styled('div')({
+export const InputKVRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
-export const InputKVRow = styled('div')({
+export const InputKVRow = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))

--- a/web/app/src/components/InputList/component.tsx
+++ b/web/app/src/components/InputList/component.tsx
@@ -67,7 +67,6 @@ const InputList = (props: InputListProps) => {
             }}
             variant="outlined"
             size="small"
-            sx={{ flexGrow: 1 }}
           />
 
           <Button
@@ -98,7 +97,6 @@ const InputList = (props: InputListProps) => {
           }}
           variant="outlined"
           size="small"
-          sx={{ flexGrow: 1 }}
           required
         />
 

--- a/web/app/src/components/InputList/styles.tsx
+++ b/web/app/src/components/InputList/styles.tsx
@@ -13,4 +13,5 @@ export const InputListRow = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
+  '& .MuiTextField-root': { flexGrow: 1 },
 }))

--- a/web/app/src/components/InputList/styles.tsx
+++ b/web/app/src/components/InputList/styles.tsx
@@ -1,16 +1,16 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
 
-export const InputListRoot = styled(Box)({
+export const InputListRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
-export const InputListRow = styled(Box)({
+export const InputListRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))

--- a/web/app/src/components/InputTransferList/component.tsx
+++ b/web/app/src/components/InputTransferList/component.tsx
@@ -128,7 +128,6 @@ const InputTransferList = <T,>(props: InputTransferListProps<T>) => {
       <TransferControls>
         <Button
           id="btn:generic.transfer-list.all-right"
-          sx={{ my: 0.5 }}
           variant="outlined"
           size="small"
           onClick={handleAllRight}
@@ -139,7 +138,6 @@ const InputTransferList = <T,>(props: InputTransferListProps<T>) => {
         </Button>
         <Button
           id="btn:generic.transfer-list.selected-right"
-          sx={{ my: 0.5 }}
           variant="outlined"
           size="small"
           onClick={handleCheckedRight}
@@ -150,7 +148,6 @@ const InputTransferList = <T,>(props: InputTransferListProps<T>) => {
         </Button>
         <Button
           id="btn:generic.transfer-list.selected-left"
-          sx={{ my: 0.5 }}
           variant="outlined"
           size="small"
           onClick={handleCheckedLeft}
@@ -161,7 +158,6 @@ const InputTransferList = <T,>(props: InputTransferListProps<T>) => {
         </Button>
         <Button
           id="btn:generic.transfer-list.all-left"
-          sx={{ my: 0.5 }}
           variant="outlined"
           size="small"
           onClick={handleAllLeft}

--- a/web/app/src/components/InputTransferList/styles.tsx
+++ b/web/app/src/components/InputTransferList/styles.tsx
@@ -2,13 +2,13 @@ import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import { styled } from '@mui/material/styles'
 
-export const TransferRoot = styled(Box)({
+export const TransferRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '1rem',
-})
+  gap: theme.spacing(2),
+}))
 
 export const TransferColumn = styled(Box)({
   flex: 1,

--- a/web/app/src/components/InputTransferList/styles.tsx
+++ b/web/app/src/components/InputTransferList/styles.tsx
@@ -15,12 +15,16 @@ export const TransferColumn = styled(Box)({
   minWidth: 0,
 })
 
-export const TransferControls = styled(Box)({
+export const TransferControls = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   flexShrink: 0,
-})
+  '& .MuiButtonBase-root': {
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
+  },
+}))
 
 export const TransferListPaper = styled(Paper)({
   minHeight: '15rem',

--- a/web/app/src/components/ListEdit/component.tsx
+++ b/web/app/src/components/ListEdit/component.tsx
@@ -28,7 +28,6 @@ const ListEdit = ({
             variant="outlined"
             type="text"
             value={field}
-            sx={{ flexGrow: 1 }}
             onChange={({ target }) => {
               setList(list.map((e, i) => (index == i ? target.value : e)))
             }}
@@ -53,7 +52,6 @@ const ListEdit = ({
           id={`input:${id}.new.name`}
           variant="outlined"
           type="text"
-          sx={{ flexGrow: 1 }}
           value={newItem}
           onChange={({ target }) => setNewItem(target.value)}
         />

--- a/web/app/src/components/ListEdit/styles.tsx
+++ b/web/app/src/components/ListEdit/styles.tsx
@@ -1,15 +1,15 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
 
-export const Root = styled(Box)({
+export const Root = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 12,
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const Row = styled(Box)({
+export const Row = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 12,
-})
+  gap: theme.spacing(1.5),
+}))

--- a/web/app/src/components/ListEdit/styles.tsx
+++ b/web/app/src/components/ListEdit/styles.tsx
@@ -12,4 +12,5 @@ export const Row = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1.5),
+  '& .MuiTextField-root': { flexGrow: 1 },
 }))

--- a/web/app/src/components/LogQueryPanel/styles.tsx
+++ b/web/app/src/components/LogQueryPanel/styles.tsx
@@ -1,11 +1,11 @@
 import { styled } from '@mui/material'
 
-export const LogQueryPanelContainer = styled('div')({
+export const LogQueryPanelContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: 16,
-  padding: 12,
-})
+  gap: theme.spacing(2),
+  padding: theme.spacing(1.5),
+}))
 
 export const LogQueryPanelFilterForm = styled('form')({
   flex: 3,

--- a/web/app/src/components/LogTable/styles.tsx
+++ b/web/app/src/components/LogTable/styles.tsx
@@ -20,6 +20,6 @@ export const LogTableDetailPre = styled('pre')(({ theme }) => ({
   overflow: 'auto',
   fontFamily: 'monospace',
   backgroundColor: theme.tokens.colors.codeBg,
-  border: '1px solid rgba(0, 0, 0, 0.12)',
+  border: `1px solid rgba(0, 0, 0, ${theme.tokens.opacity.medium})`,
   borderRadius: 4,
 }))

--- a/web/app/src/components/LogTable/styles.tsx
+++ b/web/app/src/components/LogTable/styles.tsx
@@ -7,15 +7,15 @@ export const LogTableContainer = styled(Paper)({
   flexGrow: 1,
 })
 
-export const LogTableDrawer = styled(Drawer)({
+export const LogTableDrawer = styled(Drawer)(({ theme }) => ({
   '& .MuiDrawer-paper': {
     width: '33vw',
-    padding: '0.75rem',
+    padding: theme.spacing(1.5),
   },
-})
+}))
 
 export const LogTableDetailPre = styled('pre')(({ theme }) => ({
-  padding: '0.5rem',
+  padding: theme.spacing(1),
   width: '100%',
   overflow: 'auto',
   fontFamily: 'monospace',

--- a/web/app/src/components/NavBar/styles.ts
+++ b/web/app/src/components/NavBar/styles.ts
@@ -4,7 +4,7 @@ export const NavToolbar = styled('div')`
   background-color: ${({ theme }) => theme.tokens.colors.black};
   display: flex;
   align-items: center;
-  padding: 0 16px;
+  padding: 0 ${({ theme }) => theme.spacing(2)};
   min-height: 64px;
   width: 100%;
 `
@@ -14,7 +14,7 @@ export const NavBarLeftSection = styled('section')`
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  gap: 0.75rem;
+  gap: ${({ theme }) => theme.spacing(1.5)};
   flex-grow: 1;
 
   img {
@@ -27,7 +27,7 @@ export const NavBarRightSection = styled('section')`
   display: flex;
   flex-direction: row-reverse;
   align-items: stretch;
-  gap: 0.75rem;
+  gap: ${({ theme }) => theme.spacing(1.5)};
 `
 
 export const NavBarDesktopMenus = styled('div')`
@@ -36,7 +36,7 @@ export const NavBarDesktopMenus = styled('div')`
 
 export const NavBarDrawerClose = styled(IconButton)`
   align-self: flex-end;
-  margin: 8px;
+  margin: ${({ theme }) => theme.spacing(1)};
 `
 
 export const NavBarDrawerList = styled('div')`
@@ -45,18 +45,18 @@ export const NavBarDrawerList = styled('div')`
 
 export const NavBarButtonLogo = styled(Button)`
   display: flex;
-  gap: 8px;
+  gap: ${({ theme }) => theme.spacing(1)};
   width: auto;
   text-transform: none;
 
-  @media (max-width: 990px) {
-    padding: 8px;
+  ${({ theme }) => theme.breakpoints.down('md')} {
+    padding: ${({ theme }) => theme.spacing(1)};
     min-width: fit-content;
   }
 
   .nav-text {
     display: none;
-    @media (min-width: 990px) {
+    ${({ theme }) => theme.breakpoints.up('md')} {
       display: block;
     }
   }
@@ -64,19 +64,19 @@ export const NavBarButtonLogo = styled(Button)`
 
 export const NavBarButton = styled(Button)`
   display: flex;
-  gap: 8px;
+  gap: ${({ theme }) => theme.spacing(1)};
   width: auto;
   text-transform: none;
 
-  @media (max-width: 990px) {
-    padding: 8px;
+  ${({ theme }) => theme.breakpoints.down('md')} {
+    padding: ${({ theme }) => theme.spacing(1)};
     min-width: fit-content;
   }
 
   .nav-text {
     display: none;
     font-size: 14px;
-    @media (min-width: 990px) {
+    ${({ theme }) => theme.breakpoints.up('md')} {
       display: block;
     }
   }
@@ -84,20 +84,20 @@ export const NavBarButton = styled(Button)`
 
 export const NavBarLink = styled(Link)`
   display: flex;
-  gap: 8px;
+  gap: ${({ theme }) => theme.spacing(1)};
   width: auto;
   text-transform: none;
   place-items: center;
 
-  @media (max-width: 990px) {
-    padding: 8px;
+  ${({ theme }) => theme.breakpoints.down('md')} {
+    padding: ${({ theme }) => theme.spacing(1)};
     min-width: fit-content;
   }
 
   .nav-text {
     font-size: 14px;
     display: none;
-    @media (min-width: 990px) {
+    ${({ theme }) => theme.breakpoints.up('md')} {
       display: block;
     }
   }

--- a/web/app/src/components/NodeTraceTabPanel/styles.tsx
+++ b/web/app/src/components/NodeTraceTabPanel/styles.tsx
@@ -2,17 +2,17 @@ import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const TraceSection = styled('div')({
+export const TraceSection = styled('div')(({ theme }) => ({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
-export const TraceRow = styled('div')({
+export const TraceRow = styled('div')(({ theme }) => ({
   display: 'flex',
-  gap: 20,
-})
+  gap: theme.spacing(2.5),
+}))
 
 export const TraceLabel = styled(Typography)(({ theme }) => ({
   color: theme.tokens.colors.labelText,
@@ -20,7 +20,7 @@ export const TraceLabel = styled(Typography)(({ theme }) => ({
 }))
 
 export const TraceCode = styled(Paper)(({ theme }) => ({
-  padding: 8,
+  padding: theme.spacing(1),
   flex: 1,
   flexShrink: 1,
   overflow: 'auto',

--- a/web/app/src/components/Notification/component.tsx
+++ b/web/app/src/components/Notification/component.tsx
@@ -2,8 +2,6 @@ import { Fragment, useCallback, useContext } from 'react'
 
 import useSlotProps from '@mui/utils/useSlotProps'
 
-import Alert from '@mui/material/Alert'
-import Badge from '@mui/material/Badge'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Snackbar, { SnackbarCloseReason } from '@mui/material/Snackbar'
@@ -16,6 +14,7 @@ import NotificationsContext from '@/lib/context/notifications'
 
 import { RootPropsContext } from '@/components/NotificationsProvider/context'
 
+import { NotificationAlert, NotificationBadge } from './styles'
 import { NotificationProps } from './types'
 
 const Notification = ({
@@ -74,15 +73,15 @@ const Notification = ({
 
   return (
     <SnackbarComponent key={notificationKey} {...snackbarSlotProps}>
-      <Badge badgeContent={badge} color="primary" sx={{ width: '100%' }}>
+      <NotificationBadge badgeContent={badge} color="primary">
         {severity ? (
-          <Alert severity={severity} sx={{ width: '100%' }} action={action}>
+          <NotificationAlert severity={severity} action={action}>
             {message}
-          </Alert>
+          </NotificationAlert>
         ) : (
           <SnackbarContent message={message} action={action} />
         )}
-      </Badge>
+      </NotificationBadge>
     </SnackbarComponent>
   )
 }

--- a/web/app/src/components/Notification/styles.tsx
+++ b/web/app/src/components/Notification/styles.tsx
@@ -1,0 +1,11 @@
+import Alert from '@mui/material/Alert'
+import Badge from '@mui/material/Badge'
+import { styled } from '@mui/material/styles'
+
+export const NotificationBadge = styled(Badge)({
+  width: '100%',
+})
+
+export const NotificationAlert = styled(Alert)({
+  width: '100%',
+})

--- a/web/app/src/components/PageFooter/component.tsx
+++ b/web/app/src/components/PageFooter/component.tsx
@@ -1,8 +1,6 @@
-import { Typography } from '@mui/material'
-
 import { useFeatureFlags } from '@/lib/hooks/featureflags'
 
-import { PageFooterContainer } from './styles'
+import { PageFooterContainer, PageFooterText } from './styles'
 
 const PageFooter = () => {
   const { demoMode } = useFeatureFlags()
@@ -10,15 +8,13 @@ const PageFooter = () => {
   return (
     <PageFooterContainer>
       {demoMode && (
-        <Typography variant="text" sx={{ fontWeight: 600 }}>
-          Demo Mode Enabled
-        </Typography>
+        <PageFooterText variant="text">Demo Mode Enabled</PageFooterText>
       )}
 
       <div>
-        <Typography variant="text" sx={{ fontWeight: 600 }}>
+        <PageFooterText variant="text">
           {import.meta.env.FLOWG_VERSION}
-        </Typography>
+        </PageFooterText>
       </div>
     </PageFooterContainer>
   )

--- a/web/app/src/components/PageFooter/styles.ts
+++ b/web/app/src/components/PageFooter/styles.ts
@@ -1,11 +1,15 @@
-import { styled } from '@mui/material'
+import { Typography, styled } from '@mui/material'
 
 export const PageFooterContainer = styled('footer')`
   display: flex;
-  padding: 0.75rem;
+  padding: ${({ theme }) => theme.spacing(1.5)};
   background-color: ${({ theme }) => theme.tokens.colors.borderLight};
 
   > div {
     margin-left: auto;
   }
 `
+
+export const PageFooterText = styled(Typography)({
+  fontWeight: 600,
+})

--- a/web/app/src/components/PasswordChange/component.tsx
+++ b/web/app/src/components/PasswordChange/component.tsx
@@ -49,7 +49,6 @@ const PasswordChange = () => {
           type="password"
           onChange={(e) => setOldPassword(e.target.value)}
           variant="outlined"
-          sx={{ flexGrow: 1 }}
           required
         />
 
@@ -60,7 +59,6 @@ const PasswordChange = () => {
           type="password"
           onChange={(e) => setNewPassword(e.target.value)}
           variant="outlined"
-          sx={{ flexGrow: 1 }}
           required
         />
 
@@ -68,7 +66,6 @@ const PasswordChange = () => {
           id="btn:account.settings.change-password.submit"
           variant="contained"
           color="secondary"
-          sx={{ flexGrow: 0, alignSelf: 'stretch' }}
           type="submit"
           disabled={loading}
         >

--- a/web/app/src/components/PasswordChange/styles.tsx
+++ b/web/app/src/components/PasswordChange/styles.tsx
@@ -12,6 +12,8 @@ export const FormRow = styled('form')(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'center',
   gap: theme.spacing(1),
+  '& .MuiTextField-root': { flexGrow: 1 },
+  '& > .MuiButtonBase-root': { flexGrow: 0, alignSelf: 'stretch' },
 }))
 
 export const IconBox = styled(Box)({

--- a/web/app/src/components/PasswordChange/styles.tsx
+++ b/web/app/src/components/PasswordChange/styles.tsx
@@ -2,17 +2,17 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const Label = styled(Typography)({
+export const Label = styled(Typography)(({ theme }) => ({
   fontWeight: 600,
-  marginBottom: 8,
-})
+  marginBottom: theme.spacing(1),
+}))
 
-export const FormRow = styled('form')({
+export const FormRow = styled('form')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const IconBox = styled(Box)({
   flexGrow: 0,

--- a/web/app/src/components/PermissionDisplay/styles.tsx
+++ b/web/app/src/components/PermissionDisplay/styles.tsx
@@ -2,19 +2,19 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const Label = styled(Typography)({
+export const Label = styled(Typography)(({ theme }) => ({
   fontWeight: 600,
-  marginBottom: 4,
+  marginBottom: theme.spacing(0.5),
   display: 'block',
-})
+}))
 
 export const PermissionGrid = styled(Box)(({ theme }) => ({
-  padding: 4,
+  padding: theme.spacing(0.5),
   display: 'block',
   [theme.breakpoints.up('md')]: {
     display: 'grid',
     gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: 4,
+    gap: theme.spacing(0.5),
   },
 }))
 

--- a/web/app/src/components/PipelineEditorFlow/component.tsx
+++ b/web/app/src/components/PipelineEditorFlow/component.tsx
@@ -8,9 +8,7 @@ import React, {
   useState,
 } from 'react'
 
-import Chip from '@mui/material/Chip'
 import Typography from '@mui/material/Typography'
-import * as colors from '@mui/material/colors'
 
 import DeviceHubIcon from '@mui/icons-material/DeviceHub'
 
@@ -47,6 +45,7 @@ import {
   FlowPanelLabel,
   FlowPanelPaper,
   FlowRoot,
+  SwitchNodeChip,
 } from './styles'
 
 type ShortcutMap = {
@@ -242,18 +241,10 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
               </FlowPanelLabel>
 
               <FlowPanelChips>
-                <Chip
+                <SwitchNodeChip
                   icon={<DeviceHubIcon />}
                   label="switch"
                   variant="outlined"
-                  sx={{
-                    backgroundColor: colors.red[50],
-                    borderColor: colors.red[500],
-                    borderRadius: 0,
-                    boxShadow: 1,
-                    fontFamily: 'monospace',
-                    '&:hover': { boxShadow: 4 },
-                  }}
                   draggable
                   onDragStart={(evt) => {
                     evt.dataTransfer.setData('item-type', 'switch')

--- a/web/app/src/components/PipelineEditorFlow/styles.tsx
+++ b/web/app/src/components/PipelineEditorFlow/styles.tsx
@@ -9,7 +9,7 @@ export const FlowPanelPaper = styled(Paper)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
   boxShadow: theme.shadows[1],
 }))
 
@@ -22,13 +22,13 @@ export const FlowPanelLabel = styled('div')(({ theme }) => ({
   fontWeight: 600,
   backgroundColor: theme.palette.grey[100],
   borderRight: `1px solid ${theme.palette.grey[200]}`,
-  padding: '0.5rem',
+  padding: theme.spacing(1),
 }))
 
-export const FlowPanelChips = styled('div')({
+export const FlowPanelChips = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.5rem',
-  padding: '0.5rem',
-})
+  gap: theme.spacing(1),
+  padding: theme.spacing(1),
+}))

--- a/web/app/src/components/PipelineEditorFlow/styles.tsx
+++ b/web/app/src/components/PipelineEditorFlow/styles.tsx
@@ -1,4 +1,4 @@
-import { Paper, styled } from '@mui/material'
+import { Chip, Paper, styled } from '@mui/material'
 
 export const FlowRoot = styled(Paper)({
   width: '100%',
@@ -31,4 +31,13 @@ export const FlowPanelChips = styled('div')(({ theme }) => ({
   alignItems: 'center',
   gap: theme.spacing(1),
   padding: theme.spacing(1),
+}))
+
+export const SwitchNodeChip = styled(Chip)(({ theme }) => ({
+  backgroundColor: theme.tokens.colors.switchChipBg,
+  borderColor: theme.tokens.colors.switchChipBorder,
+  borderRadius: 0,
+  boxShadow: theme.shadows[1],
+  fontFamily: 'monospace',
+  '&:hover': { boxShadow: theme.shadows[4] },
 }))

--- a/web/app/src/components/PipelineEditorNodeList/component.tsx
+++ b/web/app/src/components/PipelineEditorNodeList/component.tsx
@@ -1,12 +1,12 @@
 import { ReactElement, ReactNode, useEffect, useState } from 'react'
 
-import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import * as colors from '@mui/material/colors'
 
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import {
+  NodeChip,
   NodeListHeader,
   NodeListItems,
   NodeListLoading,
@@ -74,21 +74,15 @@ const PipelineEditorNodeList = (props: PipelineEditorNodeListProps) => {
       ) : (
         <NodeListItems>
           {items.map((item) => (
-            <Chip
+            <NodeChip
               key={item}
               icon={props.itemIcon}
               label={item}
               onDelete={() => props.onItemOpen(item)}
               deleteIcon={<OpenInNewIcon />}
               variant="outlined"
-              sx={{
-                backgroundColor,
-                borderColor,
-                borderRadius: 0,
-                boxShadow: 1,
-                fontFamily: 'monospace',
-                '&:hover': { boxShadow: 4 },
-              }}
+              chipBgColor={backgroundColor}
+              chipBorderColor={borderColor}
               draggable
               onDragStart={(evt) => {
                 evt.dataTransfer.setData('item-type', props.itemType)

--- a/web/app/src/components/PipelineEditorNodeList/styles.tsx
+++ b/web/app/src/components/PipelineEditorNodeList/styles.tsx
@@ -1,4 +1,4 @@
-import { Paper, styled } from '@mui/material'
+import { Chip, Paper, styled } from '@mui/material'
 
 export const NodeListRoot = styled(Paper)({
   height: '100%',
@@ -40,3 +40,17 @@ export const NodeListItems = styled('div')(({ theme }) => ({
   gap: theme.spacing(1),
   padding: theme.spacing(1),
 }))
+
+export const NodeChip = styled(Chip, {
+  shouldForwardProp: (prop) =>
+    prop !== 'chipBgColor' && prop !== 'chipBorderColor',
+})<{ chipBgColor: string; chipBorderColor: string }>(
+  ({ theme, chipBgColor, chipBorderColor }) => ({
+    backgroundColor: chipBgColor,
+    borderColor: chipBorderColor,
+    borderRadius: 0,
+    boxShadow: theme.shadows[1],
+    fontFamily: 'monospace',
+    '&:hover': { boxShadow: theme.shadows[4] },
+  })
+)

--- a/web/app/src/components/PipelineEditorNodeList/styles.tsx
+++ b/web/app/src/components/PipelineEditorNodeList/styles.tsx
@@ -8,7 +8,7 @@ export const NodeListRoot = styled(Paper)({
 })
 
 export const NodeListHeader = styled('div')(({ theme }) => ({
-  padding: '0.5rem',
+  padding: theme.spacing(1),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
@@ -30,13 +30,13 @@ export const NodeListLoading = styled('div')({
   justifyContent: 'center',
 })
 
-export const NodeListItems = styled('div')({
+export const NodeListItems = styled('div')(({ theme }) => ({
   flex: '1 1 0',
   minHeight: 0,
   overflow: 'auto',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  gap: '0.5rem',
-  padding: '0.5rem',
-})
+  gap: theme.spacing(1),
+  padding: theme.spacing(1),
+}))

--- a/web/app/src/components/PipelineNodeForwarder/styles.tsx
+++ b/web/app/src/components/PipelineNodeForwarder/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,7 +16,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeForwarderBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
@@ -28,18 +28,18 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodeForwarderBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeForwarder/styles.tsx
+++ b/web/app/src/components/PipelineNodeForwarder/styles.tsx
@@ -19,11 +19,10 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   gap: 8,
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeForwarderBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 

--- a/web/app/src/components/PipelineNodePipeline/styles.tsx
+++ b/web/app/src/components/PipelineNodePipeline/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,31 +16,30 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodePipelineBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodePipelineBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeRouter/styles.tsx
+++ b/web/app/src/components/PipelineNodeRouter/styles.tsx
@@ -19,11 +19,10 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   gap: 8,
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeRouterBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 

--- a/web/app/src/components/PipelineNodeRouter/styles.tsx
+++ b/web/app/src/components/PipelineNodeRouter/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,7 +16,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeRouterBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
@@ -28,18 +28,18 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodeRouterBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeSource/styles.tsx
+++ b/web/app/src/components/PipelineNodeSource/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,31 +16,30 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeSourceBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodeSourceBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeSwitch/styles.tsx
+++ b/web/app/src/components/PipelineNodeSwitch/styles.tsx
@@ -19,11 +19,10 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   gap: 8,
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeSwitchBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 

--- a/web/app/src/components/PipelineNodeSwitch/styles.tsx
+++ b/web/app/src/components/PipelineNodeSwitch/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,7 +16,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeSwitchBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
@@ -28,18 +28,18 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodeSwitchBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeTransformer/styles.tsx
+++ b/web/app/src/components/PipelineNodeTransformer/styles.tsx
@@ -3,12 +3,12 @@ import { styled } from '@mui/material/styles'
 
 import { NodeToolbar } from '@xyflow/react'
 
-export const ToolbarRow = styled(NodeToolbar)({
+export const ToolbarRow = styled(NodeToolbar)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 8,
-})
+  gap: theme.spacing(1),
+}))
 
 export const NodeRoot = styled(Box)(({ theme }) => ({
   width: 270,
@@ -16,7 +16,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeTransformerBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
@@ -28,18 +28,18 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
 
 export const NodeIcon = styled(Box)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.nodeTransformerBg,
-  color: theme.tokens.colors.white,
-  padding: 12,
+  color: theme.tokens.colors.primaryContrast,
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
 }))
 
-export const NodeBody = styled(Box)({
-  padding: 12,
+export const NodeBody = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 export const handleStyle = { width: 12, height: 12 }

--- a/web/app/src/components/PipelineNodeTransformer/styles.tsx
+++ b/web/app/src/components/PipelineNodeTransformer/styles.tsx
@@ -19,11 +19,10 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   gap: 8,
   backgroundColor: theme.tokens.colors.white,
   border: `4px solid ${theme.tokens.colors.nodeTransformerBorder}`,
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-  transition: 'box-shadow 150ms ease-in-out',
+  boxShadow: theme.tokens.shadows.nodeElevated,
+  transition: theme.tokens.transitions.shadow,
   '&:hover': {
-    boxShadow:
-      '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    boxShadow: theme.tokens.shadows.nodeElevatedHover,
   },
 }))
 

--- a/web/app/src/components/PipelineTraceNodeButton/component.tsx
+++ b/web/app/src/components/PipelineTraceNodeButton/component.tsx
@@ -1,15 +1,14 @@
 import { Visibility } from '@mui/icons-material'
-import { Tab, Tabs } from '@mui/material'
+import { Tab } from '@mui/material'
 
 import { useState } from 'react'
 
 import Button from '@mui/material/Button'
-import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 
-import { TraceDialogContent } from './styles'
+import { TraceDialog, TraceDialogContent, TraceTabs } from './styles'
 import { PipelineTraceNodeButtonProps } from './types'
 
 import NodeTraceTabPanel from '../NodeTraceTabPanel/component'
@@ -33,32 +32,15 @@ const PipelineTraceNodeButton = ({ traces }: PipelineTraceNodeButtonProps) => {
         Inspect
       </Button>
 
-      <Dialog
-        open={open}
-        onClose={() => setOpen(false)}
-        maxWidth={false}
-        slotProps={{
-          paper: {
-            sx: {
-              width: '80%',
-              height: '90%',
-            },
-          },
-        }}
-      >
+      <TraceDialog open={open} onClose={() => setOpen(false)} maxWidth={false}>
         <DialogTitle>Node traces</DialogTitle>
         <DialogContent>
           <TraceDialogContent>
-            <Tabs
-              variant="scrollable"
-              sx={{ borderBottom: 1, borderColor: 'divider' }}
-              value={tab}
-              onChange={onTabChange}
-            >
+            <TraceTabs variant="scrollable" value={tab} onChange={onTabChange}>
               {traces.map((_trace, index) => (
                 <Tab key={`tab-${index + 1}`} label={`Event #${index + 1}`} />
               ))}
-            </Tabs>
+            </TraceTabs>
 
             {traces.map((trace, index) => (
               <NodeTraceTabPanel
@@ -73,7 +55,7 @@ const PipelineTraceNodeButton = ({ traces }: PipelineTraceNodeButtonProps) => {
         <DialogActions>
           <Button onClick={() => setOpen(false)}>Close</Button>
         </DialogActions>
-      </Dialog>
+      </TraceDialog>
     </>
   )
 }

--- a/web/app/src/components/PipelineTraceNodeButton/styles.tsx
+++ b/web/app/src/components/PipelineTraceNodeButton/styles.tsx
@@ -1,8 +1,21 @@
 import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import Tabs from '@mui/material/Tabs'
 import { styled } from '@mui/material/styles'
 
 export const TraceDialogContent = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(2.5),
+}))
+
+export const TraceDialog = styled(Dialog)({
+  '& .MuiDialog-paper': {
+    width: '80%',
+    height: '90%',
+  },
+})
+
+export const TraceTabs = styled(Tabs)(({ theme }) => ({
+  borderBottom: `1px solid ${theme.palette.divider}`,
 }))

--- a/web/app/src/components/PipelineTraceNodeButton/styles.tsx
+++ b/web/app/src/components/PipelineTraceNodeButton/styles.tsx
@@ -1,8 +1,8 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
 
-export const TraceDialogContent = styled(Box)({
+export const TraceDialogContent = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: '1.25rem',
-})
+  gap: theme.spacing(2.5),
+}))

--- a/web/app/src/components/ProfileInfo/styles.tsx
+++ b/web/app/src/components/ProfileInfo/styles.tsx
@@ -13,17 +13,17 @@ export const ProfileInfoCardHeader = styled(CardHeader)(({ theme }) => ({
   boxShadow: theme.shadows[4],
 }))
 
-export const ProfileInfoCardHeaderTitle = styled('div')({
+export const ProfileInfoCardHeaderTitle = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const ProfileInfoCardContent = styled(CardContent)({
+export const ProfileInfoCardContent = styled(CardContent)(({ theme }) => ({
   flex: '1 1 0',
   overflow: 'auto',
   display: 'flex',
   flexDirection: 'column',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
   alignItems: 'stretch',
-})
+}))

--- a/web/app/src/components/RoleTable/styles.tsx
+++ b/web/app/src/components/RoleTable/styles.tsx
@@ -17,11 +17,11 @@ export const RoleTableCardHeader = styled(CardHeader)(({ theme }) => ({
   zIndex: 20,
 }))
 
-export const RoleTableCardHeaderTitle = styled('div')({
+export const RoleTableCardHeaderTitle = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const RoleTableCardHeaderTitleText = styled('span')({
   flex: 1,
@@ -46,11 +46,11 @@ export const RoleTableCardContent = styled(CardContent)({
   },
 })
 
-export const ScopesCellRoot = styled('div')({
+export const ScopesCellRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: 4,
-  padding: '8px 0',
+  gap: theme.spacing(0.5),
+  padding: theme.spacing(1, 0),
   alignContent: 'center',
   width: '100%',
-})
+}))

--- a/web/app/src/components/RoleTable/styles.tsx
+++ b/web/app/src/components/RoleTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const RoleTableCard = styled(Card)(({ theme }) => ({
+export const RoleTableCard = styled(Card)({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  [theme.breakpoints.down('lg')]: {
+  '@media (max-width: 990px)': {
     minHeight: '24rem',
   },
-}))
+})
 
 export const RoleTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,

--- a/web/app/src/components/RoleTable/styles.tsx
+++ b/web/app/src/components/RoleTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const RoleTableCard = styled(Card)({
+export const RoleTableCard = styled(Card)(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     minHeight: '24rem',
   },
-})
+}))
 
 export const RoleTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,
@@ -27,11 +27,11 @@ export const RoleTableCardHeaderTitleText = styled('span')({
   flex: 1,
 })
 
-export const RoleTableCardContent = styled(CardContent)({
+export const RoleTableCardContent = styled(CardContent)(({ theme }) => ({
   padding: '0 !important',
   flex: '1 1 0',
   overflow: 'hidden',
-  '@media (max-width: 990px)': {
+  [theme.breakpoints.down('md')]: {
     overflowX: 'auto',
   },
   '& .ag-cell-wrapper': {
@@ -44,7 +44,7 @@ export const RoleTableCardContent = styled(CardContent)({
   '& .flowg-actions-cell': {
     justifyContent: 'center',
   },
-})
+}))
 
 export const ScopesCellRoot = styled('div')(({ theme }) => ({
   display: 'flex',

--- a/web/app/src/components/RolesDisplay/styles.tsx
+++ b/web/app/src/components/RolesDisplay/styles.tsx
@@ -2,17 +2,17 @@ import Paper, { PaperProps } from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const Label = styled(Typography)({
+export const Label = styled(Typography)(({ theme }) => ({
   fontWeight: 600,
-  marginBottom: 4,
+  marginBottom: theme.spacing(0.5),
   display: 'block',
-})
+}))
 
-export const RolesPaper = styled(Paper)<PaperProps<'ul'>>({
-  padding: 4,
+export const RolesPaper = styled(Paper)<PaperProps<'ul'>>(({ theme }) => ({
+  padding: theme.spacing(0.5),
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
   flexWrap: 'wrap',
   listStyle: 'none',
-})
+}))

--- a/web/app/src/components/StatCard/component.tsx
+++ b/web/app/src/components/StatCard/component.tsx
@@ -1,15 +1,8 @@
-import {
-  Button,
-  Card,
-  CardActions,
-  CardHeader,
-  Divider,
-  Typography,
-} from '@mui/material'
+import { Button, Card, CardActions, CardHeader, Divider } from '@mui/material'
 
 import { useNavigate } from 'react-router'
 
-import { StatCardContent, StatCardHeaderWrapper } from './styles'
+import { StatCardContent, StatCardHeaderWrapper, StatCardValue } from './styles'
 import { StatCardProps } from './types'
 
 const StatCard = ({ icon, title, value, to }: StatCardProps) => {
@@ -27,9 +20,7 @@ const StatCard = ({ icon, title, value, to }: StatCardProps) => {
       />
 
       <StatCardContent>
-        <Typography variant="titleLg" sx={{ fontWeight: 700 }}>
-          {value}
-        </Typography>
+        <StatCardValue variant="titleLg">{value}</StatCardValue>
         <Divider />
       </StatCardContent>
 

--- a/web/app/src/components/StatCard/styles.tsx
+++ b/web/app/src/components/StatCard/styles.tsx
@@ -1,4 +1,4 @@
-import { CardContent, styled } from '@mui/material'
+import { CardContent, Typography, styled } from '@mui/material'
 
 export const StatCardHeaderWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -17,3 +17,7 @@ export const StatCardContent = styled(CardContent)(({ theme }) => ({
   flexDirection: 'column',
   gap: theme.spacing(1.25),
 }))
+
+export const StatCardValue = styled(Typography)({
+  fontWeight: 700,
+})

--- a/web/app/src/components/StatCard/styles.tsx
+++ b/web/app/src/components/StatCard/styles.tsx
@@ -1,19 +1,19 @@
 import { CardContent, styled } from '@mui/material'
 
-export const StatCardHeaderWrapper = styled('div')({
+export const StatCardHeaderWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
   fontSize: '1.5rem',
   lineHeight: '2rem',
   fontWeight: 600,
-})
+}))
 
-export const StatCardContent = styled(CardContent)({
+export const StatCardContent = styled(CardContent)(({ theme }) => ({
   padding: 0,
   textAlign: 'center',
   display: 'flex',
   flexDirection: 'column',
-  gap: 10,
-})
+  gap: theme.spacing(1.25),
+}))

--- a/web/app/src/components/StreamEditor/component.tsx
+++ b/web/app/src/components/StreamEditor/component.tsx
@@ -1,5 +1,4 @@
 import Divider from '@mui/material/Divider'
-import LinearProgress from '@mui/material/LinearProgress'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
@@ -10,6 +9,7 @@ import {
   StreamEditorPanel,
   StreamEditorPanelBody,
   StreamEditorPanelHeader,
+  StreamEditorProgress,
   StreamEditorRoot,
   StreamEditorUsageRow,
 } from './styles'
@@ -27,9 +27,7 @@ const StreamEditor = ({
     <StreamEditorRoot>
       <StreamEditorPanel>
         <StreamEditorPanelHeader>
-          <Typography variant="titleSm" sx={{ fontWeight: 700 }}>
-            Retention
-          </Typography>
+          <Typography variant="titleSm">Retention</Typography>
         </StreamEditorPanelHeader>
         <Divider />
         <StreamEditorPanelBody>
@@ -38,8 +36,7 @@ const StreamEditor = ({
               Estimated storage usage: {usageMB.toFixed(2)}MB
             </Typography>
             {streamConfig.size > 0 && (
-              <LinearProgress
-                sx={{ flexGrow: 1, height: '20px' }}
+              <StreamEditorProgress
                 variant="determinate"
                 color={usagePercent < 100 ? 'primary' : 'error'}
                 value={Math.round(Math.min(usagePercent, 100) * 100) / 100}
@@ -83,9 +80,7 @@ const StreamEditor = ({
 
       <StreamEditorPanel>
         <StreamEditorPanelHeader>
-          <Typography variant="titleSm" sx={{ fontWeight: 700 }}>
-            Indexes
-          </Typography>
+          <Typography variant="titleSm">Indexes</Typography>
         </StreamEditorPanelHeader>
         <Divider />
         <StreamEditorPanelBody>

--- a/web/app/src/components/StreamEditor/styles.tsx
+++ b/web/app/src/components/StreamEditor/styles.tsx
@@ -10,7 +10,7 @@ export const StreamEditorRoot = styled(Box)(({ theme }) => ({
   alignItems: 'stretch',
   gap: theme.spacing(1.5),
 
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
 }))

--- a/web/app/src/components/StreamEditor/styles.tsx
+++ b/web/app/src/components/StreamEditor/styles.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box'
+import LinearProgress from '@mui/material/LinearProgress'
 import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
@@ -28,6 +29,7 @@ export const StreamEditorPanelHeader = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.grey[100],
   boxShadow: theme.shadows[1],
   textAlign: 'center',
+  '& .MuiTypography-root': { fontWeight: 700 },
 }))
 
 export const StreamEditorPanelBody = styled(Box)(({ theme }) => ({
@@ -51,4 +53,9 @@ export const StreamEditorUsageRow = styled(Box)(({ theme }) => ({
 
 export const StreamEditorHint = styled(Typography)({
   fontStyle: 'italic',
+})
+
+export const StreamEditorProgress = styled(LinearProgress)({
+  flexGrow: 1,
+  height: '20px',
 })

--- a/web/app/src/components/StreamEditor/styles.tsx
+++ b/web/app/src/components/StreamEditor/styles.tsx
@@ -3,17 +3,17 @@ import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const StreamEditorRoot = styled(Box)({
+export const StreamEditorRoot = styled(Box)(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
 
   '@media (min-width: 990px)': {
     flexDirection: 'row',
   },
-})
+}))
 
 export const StreamEditorPanel = styled(Paper)({
   flex: 1,
@@ -24,30 +24,30 @@ export const StreamEditorPanel = styled(Paper)({
 })
 
 export const StreamEditorPanelHeader = styled(Box)(({ theme }) => ({
-  padding: '0.75rem',
+  padding: theme.spacing(1.5),
   backgroundColor: theme.palette.grey[100],
   boxShadow: theme.shadows[1],
   textAlign: 'center',
 }))
 
-export const StreamEditorPanelBody = styled(Box)({
+export const StreamEditorPanelBody = styled(Box)(({ theme }) => ({
   flex: '1 1 0',
   height: 0,
   overflow: 'auto',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-  padding: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+  padding: theme.spacing(1.5),
+}))
 
-export const StreamEditorUsageRow = styled(Box)({
+export const StreamEditorUsageRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '2.5rem',
+  gap: theme.spacing(5),
   marginBottom: '0.5rem',
-})
+}))
 
 export const StreamEditorHint = styled(Typography)({
   fontStyle: 'italic',

--- a/web/app/src/components/StreamIndexSelector/styles.tsx
+++ b/web/app/src/components/StreamIndexSelector/styles.tsx
@@ -7,20 +7,20 @@ export const StreamIndexSelectorContainer = styled(Paper)({
   overflow: 'auto',
 })
 
-export const StreamIndexSelectorValueList = styled('div')({
+export const StreamIndexSelectorValueList = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 4,
-})
+  gap: theme.spacing(0.5),
+}))
 
 export const StreamIndexSelectorChip = styled('button')<{
   $selected?: boolean
 }>(({ $selected, theme }) => ({
   cursor: 'pointer',
-  padding: '0 8px',
+  padding: theme.spacing(0, 1),
   textAlign: 'left',
-  transition: 'all 150ms ease-in-out',
-  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+  transition: `all ${theme.tokens.transitions.normal}`,
+  boxShadow: `0 1px 2px rgba(0, 0, 0, ${theme.tokens.opacity.light})`,
   backgroundColor: $selected
     ? theme.tokens.colors.selectedBg
     : theme.tokens.colors.disabledBg,

--- a/web/app/src/components/TimeWindowSelector/component.tsx
+++ b/web/app/src/components/TimeWindowSelector/component.tsx
@@ -7,13 +7,21 @@ import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
 import Menu from '@mui/material/Menu'
 import ToggleButton from '@mui/material/ToggleButton'
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckIcon from '@mui/icons-material/Check'
 
-import { LabelRow, LabelStrong, MenuPad, MenuSection } from './styles'
+import {
+  LabelRow,
+  LabelStrong,
+  MenuBody,
+  MenuPad,
+  MenuSection,
+  TimeWindowButton,
+  TimeWindowToggleButton,
+  TimeWindowToggleGroup,
+} from './styles'
 import {
   LabelRendererProps,
   RelTimeWindowOption,
@@ -117,20 +125,13 @@ const TimeWindowSelector = ({
 
   return (
     <>
-      <Button
+      <TimeWindowButton
         id="btn:streams.timewindow-selector.open"
         variant="outlined"
         onClick={(evt) => {
           setMenu(evt.currentTarget)
         }}
         endIcon={<ArrowDropDownIcon />}
-        sx={{
-          width: '100%',
-          height: '100%',
-          '& .MuiButton-icon': {
-            marginLeft: 'auto',
-          },
-        }}
       >
         <LabelRenderer
           timewindowType={timeWindowType}
@@ -139,7 +140,7 @@ const TimeWindowSelector = ({
           to={to}
           live={live}
         />
-      </Button>
+      </TimeWindowButton>
       <Menu
         id="menu:streams.timewindow-selector"
         anchorEl={menu}
@@ -147,12 +148,12 @@ const TimeWindowSelector = ({
         onClose={handleClose}
         slotProps={{
           list: {
-            sx: { width: menu?.offsetWidth },
+            style: { width: menu?.offsetWidth },
           },
         }}
       >
-        <MenuSection sx={{ p: 0, gap: 0 }}>
-          <ToggleButtonGroup
+        <MenuBody>
+          <TimeWindowToggleGroup
             color="primary"
             value={timeWindowType}
             exclusive
@@ -161,27 +162,24 @@ const TimeWindowSelector = ({
                 setTimeWindowType(value)
               }
             }}
-            sx={{ p: 1.5, width: '100%' }}
           >
-            <ToggleButton
+            <TimeWindowToggleButton
               id="btn:streams.timewindow-selector.type.relative"
               value="relative"
-              sx={{ flexGrow: 1 }}
             >
               Relative
-            </ToggleButton>
-            <ToggleButton
+            </TimeWindowToggleButton>
+            <TimeWindowToggleButton
               id="btn:streams.timewindow-selector.type.absolute"
               value="absolute"
-              sx={{ flexGrow: 1 }}
             >
               Absolute
-            </ToggleButton>
-          </ToggleButtonGroup>
+            </TimeWindowToggleButton>
+          </TimeWindowToggleGroup>
           <Divider />
 
           {timeWindowType === 'relative' && (
-            <ToggleButtonGroup
+            <TimeWindowToggleGroup
               color="secondary"
               orientation="vertical"
               exclusive
@@ -191,7 +189,6 @@ const TimeWindowSelector = ({
                   setRelativeTimeWindow(value)
                 }
               }}
-              sx={{ p: 1.5, width: '100%' }}
             >
               {RELATIVE_TIMEWINDOW_OPTIONS.map((option) => (
                 <ToggleButton
@@ -202,7 +199,7 @@ const TimeWindowSelector = ({
                   {option.label}
                 </ToggleButton>
               ))}
-            </ToggleButtonGroup>
+            </TimeWindowToggleGroup>
           )}
           {timeWindowType === 'absolute' && (
             <MenuSection>
@@ -230,7 +227,7 @@ const TimeWindowSelector = ({
 
           <Divider />
 
-          <ToggleButtonGroup
+          <TimeWindowToggleGroup
             color="info"
             orientation="vertical"
             exclusive
@@ -238,7 +235,6 @@ const TimeWindowSelector = ({
             onChange={(_, value) => {
               setLive(value !== null)
             }}
-            sx={{ p: 1.5, width: '100%' }}
           >
             <ToggleButton
               id="btn:streams.timewindow-selector.live"
@@ -246,9 +242,7 @@ const TimeWindowSelector = ({
             >
               Watch Logs
             </ToggleButton>
-          </ToggleButtonGroup>
-
-          <Divider />
+          </TimeWindowToggleGroup>
 
           <MenuPad>
             <Button
@@ -262,7 +256,7 @@ const TimeWindowSelector = ({
               Apply
             </Button>
           </MenuPad>
-        </MenuSection>
+        </MenuBody>
       </Menu>
     </>
   )

--- a/web/app/src/components/TimeWindowSelector/styles.tsx
+++ b/web/app/src/components/TimeWindowSelector/styles.tsx
@@ -2,28 +2,28 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const LabelRow = styled(Box)({
+export const LabelRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '0.25rem',
-})
+  gap: theme.spacing(0.5),
+}))
 
 export const LabelStrong = styled(Typography)({
   fontWeight: 600,
 })
 
-export const MenuSection = styled(Box)({
-  padding: '0.75rem',
+export const MenuSection = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const MenuPad = styled(Box)({
-  padding: '0.75rem',
+export const MenuPad = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   width: '100%',
-})
+}))

--- a/web/app/src/components/TimeWindowSelector/styles.tsx
+++ b/web/app/src/components/TimeWindowSelector/styles.tsx
@@ -1,4 +1,7 @@
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
@@ -27,3 +30,25 @@ export const MenuPad = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1.5),
   width: '100%',
 }))
+
+export const MenuBody = styled(Box)({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+})
+
+export const TimeWindowButton = styled(Button)({
+  width: '100%',
+  height: '100%',
+  '& .MuiButton-icon': { marginLeft: 'auto' },
+})
+
+export const TimeWindowToggleGroup = styled(ToggleButtonGroup)(({ theme }) => ({
+  padding: theme.spacing(1.5),
+  width: '100%',
+}))
+
+export const TimeWindowToggleButton = styled(ToggleButton)({
+  flexGrow: 1,
+})

--- a/web/app/src/components/TokenTable/styles.tsx
+++ b/web/app/src/components/TokenTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const TokenTableCard = styled(Card)(({ theme }) => ({
+export const TokenTableCard = styled(Card)({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  [theme.breakpoints.down('lg')]: {
+  '@media (max-width: 990px)': {
     minHeight: '24rem',
   },
-}))
+})
 
 export const TokenTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,

--- a/web/app/src/components/TokenTable/styles.tsx
+++ b/web/app/src/components/TokenTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const TokenTableCard = styled(Card)({
+export const TokenTableCard = styled(Card)(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     minHeight: '24rem',
   },
-})
+}))
 
 export const TokenTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,

--- a/web/app/src/components/TokenTable/styles.tsx
+++ b/web/app/src/components/TokenTable/styles.tsx
@@ -17,11 +17,11 @@ export const TokenTableCardHeader = styled(CardHeader)(({ theme }) => ({
   zIndex: 20,
 }))
 
-export const TokenTableCardHeaderTitle = styled('div')({
+export const TokenTableCardHeaderTitle = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const TokenTableCardHeaderTitleText = styled('span')({
   flex: 1,

--- a/web/app/src/components/TransformerEditor/styles.tsx
+++ b/web/app/src/components/TransformerEditor/styles.tsx
@@ -3,28 +3,28 @@ import Paper, { PaperProps } from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
-export const EditorRoot = styled(Box)({
+export const EditorRoot = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   width: '100%',
   height: '100%',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
 export const EditorMain = styled(Box)({
   flex: '0 0 calc(66.666% - 0.25rem)',
   minWidth: 0,
 })
 
-export const EditorSide = styled(Box)({
+export const EditorSide = styled(Box)(({ theme }) => ({
   flex: '0 0 calc(33.333% - 0.25rem)',
   minWidth: 0,
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
 export const EditorPaper = styled(Paper)({
   width: '100%',
@@ -36,19 +36,19 @@ export const SidePanel = styled(Box)({
   height: 0,
 })
 
-export const SidePanelInner = styled(Paper)({
-  padding: '0.5rem',
+export const SidePanelInner = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
   height: '100%',
   overflow: 'auto',
-})
+}))
 
-export const SidePanelOutput = styled(Paper)({
-  padding: '0.5rem',
+export const SidePanelOutput = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(1),
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-})
+}))
 
 export const SideLabel = styled(Typography)(({ theme }) => ({
   fontSize: '0.875rem',
@@ -64,7 +64,7 @@ export const RunButtonRow = styled(Box)({
 })
 
 export const ResultBox = styled(Paper)<PaperProps<'pre'>>(({ theme }) => ({
-  padding: '0.5rem',
+  padding: theme.spacing(1),
   flex: 1,
   flexShrink: 1,
   height: 0,

--- a/web/app/src/components/UserTable/styles.tsx
+++ b/web/app/src/components/UserTable/styles.tsx
@@ -17,11 +17,11 @@ export const UserTableCardHeader = styled(CardHeader)(({ theme }) => ({
   zIndex: 20,
 }))
 
-export const UserTableCardHeaderTitle = styled('div')({
+export const UserTableCardHeaderTitle = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const UserTableCardHeaderTitleText = styled('span')({
   flex: 1,
@@ -43,11 +43,11 @@ export const UserTableCardContent = styled(CardContent)({
   },
 })
 
-export const RolesCellRoot = styled('div')({
+export const RolesCellRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: 4,
-  padding: '8px 0',
+  gap: theme.spacing(0.5),
+  padding: theme.spacing(1, 0),
   alignContent: 'center',
   width: '100%',
-})
+}))

--- a/web/app/src/components/UserTable/styles.tsx
+++ b/web/app/src/components/UserTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const UserTableCard = styled(Card)(({ theme }) => ({
+export const UserTableCard = styled(Card)({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  [theme.breakpoints.down('lg')]: {
+  '@media (max-width: 990px)': {
     minHeight: '24rem',
   },
-}))
+})
 
 export const UserTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,

--- a/web/app/src/components/UserTable/styles.tsx
+++ b/web/app/src/components/UserTable/styles.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, styled } from '@mui/material'
 
-export const UserTableCard = styled(Card)({
+export const UserTableCard = styled(Card)(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     minHeight: '24rem',
   },
-})
+}))
 
 export const UserTableCardHeader = styled(CardHeader)(({ theme }) => ({
   backgroundColor: theme.tokens.colors.cardHeaderBkg,

--- a/web/app/src/theme/tokens/colors.ts
+++ b/web/app/src/theme/tokens/colors.ts
@@ -27,6 +27,10 @@ export type ColorsType = {
   statusSuccess: string
   shadowOverlay: string
 
+  // Switch node chip
+  switchChipBg: string
+  switchChipBorder: string
+
   // Pipeline nodes (bg = header band, border = node outline)
   nodeRouterBg: string
   nodeRouterBorder: string
@@ -70,6 +74,10 @@ export const colors: ColorsType = {
   statusError: '#ff4444',
   statusSuccess: '#20b834',
   shadowOverlay: '#00000055',
+
+  // Switch node chip
+  switchChipBg: '#ffebee',
+  switchChipBorder: '#f44336',
 
   // Pipeline nodes
   nodeRouterBg: '#7e22ce',

--- a/web/app/src/theme/tokens/colors.ts
+++ b/web/app/src/theme/tokens/colors.ts
@@ -7,6 +7,7 @@ export type ColorsType = {
   bodyBg: string
   primary: string
   primaryContrast: string
+  toolbarInputBorder: string
   cardHeaderBkg: string
   toolbarBkg: string
   editorToolbarBkg: string
@@ -50,6 +51,7 @@ export const colors: ColorsType = {
   bodyBg: '#e2e8f0',
   primary: '#1565c0',
   primaryContrast: '#ffffff',
+  toolbarInputBorder: 'rgba(255, 255, 255, 0.23)',
   cardHeaderBkg: '#51a2ff',
   toolbarBkg: '#2d7eff',
   editorToolbarBkg: '#3b82f6',

--- a/web/app/src/theme/tokens/index.ts
+++ b/web/app/src/theme/tokens/index.ts
@@ -1,19 +1,31 @@
 import breakpoints, { BreakpointsType } from './breakpoints'
 import colors, { ColorsType } from './colors'
+import opacity, { OpacityType } from './opacity'
+import shadows, { ShadowsType } from './shadows'
+import transitions, { TransitionsType } from './transitions'
 import typography, { TypographyType } from './typography'
 
 export const tokens = {
   breakpoints,
   colors,
   typography,
+  shadows,
+  transitions,
+  opacity,
 }
 
 export type TokensType = {
   breakpoints: BreakpointsType
   colors: ColorsType
   typography: TypographyType
+  shadows: ShadowsType
+  transitions: TransitionsType
+  opacity: OpacityType
 }
 
 export type { BreakpointsType } from './breakpoints'
 export type { ColorsType } from './colors'
 export type { TypographyType } from './typography'
+export type { ShadowsType } from './shadows'
+export type { TransitionsType } from './transitions'
+export type { OpacityType } from './opacity'

--- a/web/app/src/theme/tokens/opacity.ts
+++ b/web/app/src/theme/tokens/opacity.ts
@@ -1,0 +1,19 @@
+export type OpacityType = {
+  xLight: number
+  light: number
+  medium: number
+  disabled: number
+  hover: number
+  overlay: number
+}
+
+export const opacity: OpacityType = {
+  xLight: 0.06,
+  light: 0.1,
+  medium: 0.12,
+  disabled: 0.15,
+  hover: 0.2,
+  overlay: 0.6,
+}
+
+export default opacity

--- a/web/app/src/theme/tokens/shadows.ts
+++ b/web/app/src/theme/tokens/shadows.ts
@@ -1,0 +1,21 @@
+export type ShadowsType = {
+  sm: string
+  md: string
+  lg: string
+  nodeElevated: string
+  nodeElevatedHover: string
+  errorModal: string
+}
+
+export const shadows: ShadowsType = {
+  sm: '0 1px 3px rgba(0, 0, 0, 0.1)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  nodeElevated:
+    '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  nodeElevatedHover:
+    '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  errorModal: '0 1px 3px rgba(0,0,0,0.1)',
+}
+
+export default shadows

--- a/web/app/src/theme/tokens/transitions.ts
+++ b/web/app/src/theme/tokens/transitions.ts
@@ -1,0 +1,18 @@
+export type TransitionsType = {
+  fast: string
+  normal: string
+  slow: string
+  // Component-specific transitions
+  shadow: string
+}
+
+export const transitions: TransitionsType = {
+  // Transition durations (ms)
+  fast: '100ms ease-in-out',
+  normal: '150ms ease-in-out',
+  slow: '250ms ease-in-out',
+  // Component-specific transitions
+  shadow: 'box-shadow 150ms ease-in-out',
+}
+
+export default transitions

--- a/web/app/src/views/AccountView/styles.tsx
+++ b/web/app/src/views/AccountView/styles.tsx
@@ -2,21 +2,21 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const AccountViewContainer = styled(AppContainer)(({ theme }) => ({
+export const AccountViewContainer = styled(AppContainer)({
   display: 'flex',
   height: '100%',
-  padding: theme.spacing(1),
-  gap: theme.spacing(1),
-  [theme.breakpoints.down('lg')]: {
+  padding: '8px',
+  gap: '8px',
+  '@media (max-width: 990px)': {
     flexDirection: 'column',
     overflow: 'auto',
   },
-}))
+})
 
-export const AccountViewPanel = styled('div')(({ theme }) => ({
+export const AccountViewPanel = styled('div')({
   flex: 1,
   height: '100%',
-  [theme.breakpoints.down('lg')]: {
+  '@media (max-width: 990px)': {
     height: 'auto',
   },
-}))
+})

--- a/web/app/src/views/AccountView/styles.tsx
+++ b/web/app/src/views/AccountView/styles.tsx
@@ -2,16 +2,16 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const AccountViewContainer = styled(AppContainer)({
+export const AccountViewContainer = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   height: '100%',
-  padding: '8px',
-  gap: '8px',
+  padding: theme.spacing(1),
+  gap: theme.spacing(1),
   '@media (max-width: 1200px)': {
     flexDirection: 'column',
     overflow: 'auto',
   },
-})
+}))
 
 export const AccountViewPanel = styled('div')({
   flex: 1,

--- a/web/app/src/views/AccountView/styles.tsx
+++ b/web/app/src/views/AccountView/styles.tsx
@@ -7,16 +7,16 @@ export const AccountViewContainer = styled(AppContainer)(({ theme }) => ({
   height: '100%',
   padding: theme.spacing(1),
   gap: theme.spacing(1),
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     flexDirection: 'column',
     overflow: 'auto',
   },
 }))
 
-export const AccountViewPanel = styled('div')({
+export const AccountViewPanel = styled('div')(({ theme }) => ({
   flex: 1,
   height: '100%',
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     height: 'auto',
   },
-})
+}))

--- a/web/app/src/views/AdminView/styles.tsx
+++ b/web/app/src/views/AdminView/styles.tsx
@@ -2,24 +2,22 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const AdminViewContainer = styled(AppContainer)(({ theme }) => ({
+export const AdminViewContainer = styled(AppContainer)({
   display: 'flex',
   height: '100%',
-  padding: theme.spacing(1),
-  gap: theme.spacing(1),
-  [theme.breakpoints.down('lg')]: {
+  padding: '8px',
+  gap: '8px',
+  '@media (max-width: 990px)': {
     flexDirection: 'column',
     overflow: 'auto',
   },
-}))
+})
 
-export const AdminViewPanel = styled('div')(({ theme }) => ({
+export const AdminViewPanel = styled('div')({
   flex: 1,
   height: '100%',
-  [theme.breakpoints.down('lg')]: {
+  '@media (max-width: 990px)': {
     height: 'auto',
-  },
-  [theme.breakpoints.down('md')]: {
     width: '100%',
   },
-}))
+})

--- a/web/app/src/views/AdminView/styles.tsx
+++ b/web/app/src/views/AdminView/styles.tsx
@@ -7,19 +7,19 @@ export const AdminViewContainer = styled(AppContainer)(({ theme }) => ({
   height: '100%',
   padding: theme.spacing(1),
   gap: theme.spacing(1),
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     flexDirection: 'column',
     overflow: 'auto',
   },
 }))
 
-export const AdminViewPanel = styled('div')({
+export const AdminViewPanel = styled('div')(({ theme }) => ({
   flex: 1,
   height: '100%',
-  '@media (max-width: 1200px)': {
+  [theme.breakpoints.down('lg')]: {
     height: 'auto',
   },
-  '@media (max-width: 990px)': {
+  [theme.breakpoints.down('md')]: {
     width: '100%',
   },
-})
+}))

--- a/web/app/src/views/AdminView/styles.tsx
+++ b/web/app/src/views/AdminView/styles.tsx
@@ -2,16 +2,16 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const AdminViewContainer = styled(AppContainer)({
+export const AdminViewContainer = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   height: '100%',
-  padding: '8px',
-  gap: '8px',
+  padding: theme.spacing(1),
+  gap: theme.spacing(1),
   '@media (max-width: 1200px)': {
     flexDirection: 'column',
     overflow: 'auto',
   },
-})
+}))
 
 export const AdminViewPanel = styled('div')({
   flex: 1,

--- a/web/app/src/views/ForwarderDetailView/styles.tsx
+++ b/web/app/src/views/ForwarderDetailView/styles.tsx
@@ -20,44 +20,44 @@ export const ForwarderDetailViewHeader = styled(AppContainer)(({ theme }) => ({
   flex: 0,
 }))
 
-export const ForwarderDetailViewHeaderLeft = styled('div')({
+export const ForwarderDetailViewHeaderLeft = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const ForwarderDetailViewHeaderRight = styled('div')({
+export const ForwarderDetailViewHeaderRight = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const ForwarderDetailViewHeaderTest = styled('div')({
   display: 'flex',
   alignItems: 'center',
 })
 
-export const ForwarderDetailViewHeaderActions = styled('div')({
+export const ForwarderDetailViewHeaderActions = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const ForwarderDetailViewBody = styled(AppContainer)({
+export const ForwarderDetailViewBody = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
+  gap: theme.spacing(1),
   flex: 1,
   overflow: 'hidden',
   '@media (min-width: 990px)': {
     flexDirection: 'row',
   },
-})
+}))
 
 export const ForwarderDetailViewSidebar = styled('div')({
   flex: '0 0 16.67%',
@@ -74,11 +74,11 @@ export const ForwarderDetailViewContent = styled('div')({
   minWidth: 0,
 })
 
-export const ForwarderDetailViewEditorPaper = styled(Paper)({
+export const ForwarderDetailViewEditorPaper = styled(Paper)(({ theme }) => ({
   height: '100%',
   overflow: 'auto',
-  padding: '0.75rem',
-})
+  padding: theme.spacing(1.5),
+}))
 
 export const TestDialogHint = styled('div')({
   marginBottom: '0.5rem',

--- a/web/app/src/views/ForwarderDetailView/styles.tsx
+++ b/web/app/src/views/ForwarderDetailView/styles.tsx
@@ -54,19 +54,19 @@ export const ForwarderDetailViewBody = styled(AppContainer)(({ theme }) => ({
   gap: theme.spacing(1),
   flex: 1,
   overflow: 'hidden',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
 }))
 
-export const ForwarderDetailViewSidebar = styled('div')({
+export const ForwarderDetailViewSidebar = styled('div')(({ theme }) => ({
   flex: '0 0 16.67%',
   height: '100%',
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
-})
+}))
 
 export const ForwarderDetailViewContent = styled('div')({
   flex: 1,

--- a/web/app/src/views/HomeView/styles.tsx
+++ b/web/app/src/views/HomeView/styles.tsx
@@ -2,23 +2,23 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const HomeViewContainer = styled(AppContainer)({
+export const HomeViewContainer = styled(AppContainer)(({ theme }) => ({
   placeContent: 'space-evenly',
   flexDirection: 'column',
   '& h1': {
     display: 'flex',
-    gap: 8,
+    gap: theme.spacing(1),
     placeItems: 'center',
     img: {
       height: '2rem',
     },
   },
-})
+}))
 
-export const HomeViewPermissionsWrapper = styled('div')({
+export const HomeViewPermissionsWrapper = styled('div')(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: '1fr',
-  gap: 16,
+  gap: theme.spacing(2),
   width: '100%',
   '@media (min-width: 990px)': {
     gridAutoColumns: '1fr',
@@ -26,4 +26,4 @@ export const HomeViewPermissionsWrapper = styled('div')({
     gridTemplateColumns: 'unset',
     width: 'auto',
   },
-})
+}))

--- a/web/app/src/views/HomeView/styles.tsx
+++ b/web/app/src/views/HomeView/styles.tsx
@@ -20,7 +20,7 @@ export const HomeViewPermissionsWrapper = styled('div')(({ theme }) => ({
   gridTemplateColumns: '1fr',
   gap: theme.spacing(2),
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     gridAutoColumns: '1fr',
     gridAutoFlow: 'column',
     gridTemplateColumns: 'unset',

--- a/web/app/src/views/LoginView/styles.tsx
+++ b/web/app/src/views/LoginView/styles.tsx
@@ -2,7 +2,7 @@ import { Card, styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const LoginViewContainer = styled(AppContainer)({
+export const LoginViewContainer = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -12,7 +12,7 @@ export const LoginViewContainer = styled(AppContainer)({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: '0.5rem',
+    gap: theme.spacing(1),
     '& img': {
       height: '4rem',
     },
@@ -23,18 +23,18 @@ export const LoginViewContainer = styled(AppContainer)({
       textAlign: 'center',
     },
   },
-})
+}))
 
-export const LoginViewCard = styled(Card)({
+export const LoginViewCard = styled(Card)(({ theme }) => ({
   width: '100%',
   maxWidth: '28rem',
-  padding: '0.75rem',
+  padding: theme.spacing(1.5),
   minWidth: 550,
   '& > form': {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'stretch',
-    gap: '0.75rem',
+    gap: theme.spacing(1.5),
     '& header h2': {
       fontSize: '1.5rem',
       lineHeight: '2rem',
@@ -45,21 +45,21 @@ export const LoginViewCard = styled(Card)({
   '@media (max-width: 990px)': {
     minWidth: '100%',
   },
-})
+}))
 
-export const LoginViewCardFields = styled('section')({
+export const LoginViewCardFields = styled('section')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
   '& > div': {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'flex-end',
     '& .icon': {
-      marginRight: 8,
-      marginTop: 4,
-      marginBottom: 4,
+      marginRight: theme.spacing(1),
+      marginTop: theme.spacing(0.5),
+      marginBottom: theme.spacing(0.5),
     },
   },
 })

--- a/web/app/src/views/LoginView/styles.tsx
+++ b/web/app/src/views/LoginView/styles.tsx
@@ -42,7 +42,7 @@ export const LoginViewCard = styled(Card)(({ theme }) => ({
       fontWeight: 400,
     },
   },
-  '@media (max-width: 990px)': {
+  [theme.breakpoints.down('md')]: {
     minWidth: '100%',
   },
 }))
@@ -62,4 +62,4 @@ export const LoginViewCardFields = styled('section')(({ theme }) => ({
       marginBottom: theme.spacing(0.5),
     },
   },
-})
+}))

--- a/web/app/src/views/LogoutView/styles.tsx
+++ b/web/app/src/views/LogoutView/styles.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material'
 
-export const LogoutViewRoot = styled('div')({
-  padding: '1.5rem 0',
-})
+export const LogoutViewRoot = styled('div')(({ theme }) => ({
+  padding: theme.spacing(3, 0),
+}))

--- a/web/app/src/views/NotFoundView/component.tsx
+++ b/web/app/src/views/NotFoundView/component.tsx
@@ -1,38 +1,35 @@
-import { Typography } from '@mui/material'
-
 import { useNavigate } from 'react-router'
 
 import Button from '@mui/material/Button'
-
-import SearchOffIcon from '@mui/icons-material/SearchOff'
+import Typography from '@mui/material/Typography'
 
 import { buildUrl } from '@/router'
 
-import { NotFoundViewContainer } from './styles'
+import {
+  NotFoundHint,
+  NotFoundIcon,
+  NotFoundTitle,
+  NotFoundViewContainer,
+} from './styles'
 
 const NotFoundView = () => {
   const navigate = useNavigate()
 
   return (
     <NotFoundViewContainer>
-      <SearchOffIcon sx={{ fontSize: '5rem', opacity: 0.3 }} />
+      <NotFoundIcon />
 
-      <Typography variant="titleLg" component="h1" sx={{ fontWeight: 700 }}>
+      <NotFoundTitle variant="titleLg" component="h1">
         404
-      </Typography>
+      </NotFoundTitle>
 
       <Typography variant="titleMd" component="h2">
         Page not found
       </Typography>
 
-      <Typography
-        variant="text"
-        sx={{
-          color: (theme) => `rgba(0, 0, 0, ${theme.tokens.opacity.overlay})`,
-        }}
-      >
+      <NotFoundHint variant="text">
         The page you are looking for does not exist or has been moved.
-      </Typography>
+      </NotFoundHint>
 
       <Button
         variant="contained"

--- a/web/app/src/views/NotFoundView/component.tsx
+++ b/web/app/src/views/NotFoundView/component.tsx
@@ -25,7 +25,12 @@ const NotFoundView = () => {
         Page not found
       </Typography>
 
-      <Typography variant="text" sx={{ color: 'rgba(0, 0, 0, 0.6)' }}>
+      <Typography
+        variant="text"
+        sx={{
+          color: (theme) => `rgba(0, 0, 0, ${theme.tokens.opacity.overlay})`,
+        }}
+      >
         The page you are looking for does not exist or has been moved.
       </Typography>
 

--- a/web/app/src/views/NotFoundView/component.tsx
+++ b/web/app/src/views/NotFoundView/component.tsx
@@ -19,9 +19,7 @@ const NotFoundView = () => {
     <NotFoundViewContainer>
       <NotFoundIcon />
 
-      <NotFoundTitle variant="titleLg" component="h1">
-        404
-      </NotFoundTitle>
+      <NotFoundTitle variant="titleLg">404</NotFoundTitle>
 
       <Typography variant="titleMd" component="h2">
         Page not found

--- a/web/app/src/views/NotFoundView/styles.tsx
+++ b/web/app/src/views/NotFoundView/styles.tsx
@@ -1,12 +1,12 @@
 import { styled } from '@mui/material'
 
-export const NotFoundViewContainer = styled('div')({
+export const NotFoundViewContainer = styled('div')(({ theme }) => ({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '1rem',
-  padding: '2rem',
+  gap: theme.spacing(2),
+  padding: theme.spacing(4),
   textAlign: 'center',
-})
+}))

--- a/web/app/src/views/NotFoundView/styles.tsx
+++ b/web/app/src/views/NotFoundView/styles.tsx
@@ -1,4 +1,6 @@
-import { styled } from '@mui/material'
+import { Typography, styled } from '@mui/material'
+
+import SearchOffIcon from '@mui/icons-material/SearchOff'
 
 export const NotFoundViewContainer = styled('div')(({ theme }) => ({
   flex: 1,
@@ -9,4 +11,17 @@ export const NotFoundViewContainer = styled('div')(({ theme }) => ({
   gap: theme.spacing(2),
   padding: theme.spacing(4),
   textAlign: 'center',
+}))
+
+export const NotFoundIcon = styled(SearchOffIcon)({
+  fontSize: '5rem',
+  opacity: 0.3,
+})
+
+export const NotFoundTitle = styled(Typography)({
+  fontWeight: 700,
+})
+
+export const NotFoundHint = styled(Typography)(({ theme }) => ({
+  color: `rgba(0, 0, 0, ${theme.tokens.opacity.overlay})`,
 }))

--- a/web/app/src/views/PipelineDetailView/component.tsx
+++ b/web/app/src/views/PipelineDetailView/component.tsx
@@ -9,7 +9,6 @@ import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
-import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
 import CancelIcon from '@mui/icons-material/Cancel'
@@ -41,6 +40,7 @@ import PipelineEditorNodeListTransformer from '@/components/PipelineEditorNodeLi
 import { buildUrl } from '@/router'
 
 import {
+  HeaderNameInput,
   PipelineDetailViewBody,
   PipelineDetailViewCenter,
   PipelineDetailViewHeader,
@@ -159,7 +159,7 @@ const PipelineDetailView = () => {
       <PipelineDetailViewRoot>
         <PipelineDetailViewHeader variant="toolbar">
           <PipelineDetailViewHeaderLeft>
-            <TextField
+            <HeaderNameInput
               label="Pipeline name"
               value={currentPipeline.name}
               type="text"
@@ -168,18 +168,6 @@ const PipelineDetailView = () => {
               slotProps={{
                 input: {
                   readOnly: true,
-                  sx: {
-                    color: 'white',
-                    backgroundColor: 'rgba(0,0,0,0.15)',
-                  },
-                },
-                inputLabel: {
-                  sx: {
-                    color: 'white',
-                    '&.Mui-focused': {
-                      color: 'white',
-                    },
-                  },
                 },
               }}
             />

--- a/web/app/src/views/PipelineDetailView/styles.tsx
+++ b/web/app/src/views/PipelineDetailView/styles.tsx
@@ -20,36 +20,36 @@ export const PipelineDetailViewHeader = styled(AppContainer)(({ theme }) => ({
   flex: 0,
 }))
 
-export const PipelineDetailViewHeaderLeft = styled('div')({
+export const PipelineDetailViewHeaderLeft = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const PipelineDetailViewHeaderRight = styled('div')({
+export const PipelineDetailViewHeaderRight = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const PipelineDetailViewHeaderTest = styled('div')({
   display: 'flex',
   alignItems: 'center',
 })
 
-export const PipelineDetailViewHeaderActions = styled('div')({
+export const PipelineDetailViewHeaderActions = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const PipelineDetailViewBody = styled(AppContainer)({
+export const PipelineDetailViewBody = styled(AppContainer)(({ theme }) => ({
   alignItems: 'stretch',
-  gap: '0.5rem',
+  gap: theme.spacing(1),
   overflow: 'auto',
   flex: 1,
   flexDirection: 'column',
@@ -57,7 +57,7 @@ export const PipelineDetailViewBody = styled(AppContainer)({
     flexDirection: 'row',
     overflow: 'hidden',
   },
-})
+}))
 
 export const PipelineDetailViewLeft = styled('div')({
   flex: '0 0 16.67%',
@@ -74,18 +74,18 @@ export const PipelineDetailViewCenter = styled('div')({
   minHeight: 600,
 })
 
-export const PipelineDetailViewRight = styled('div')({
+export const PipelineDetailViewRight = styled('div')(({ theme }) => ({
   width: '100%',
   height: '100%',
   flexShrink: 0,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
+  gap: theme.spacing(1),
   '@media (min-width: 990px)': {
     width: 'calc(100% / 6)',
   },
-})
+}))
 
 export const PipelineDetailViewRightItem = styled('div')({
   flex: '1 1 0',

--- a/web/app/src/views/PipelineDetailView/styles.tsx
+++ b/web/app/src/views/PipelineDetailView/styles.tsx
@@ -1,4 +1,4 @@
-import { Box, styled } from '@mui/material'
+import { Box, TextField as MuiTextField, styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
@@ -98,3 +98,19 @@ export const PipelineDetailViewRightItem = styled('div')({
 export const TestDialogHint = styled('div')({
   marginBottom: '0.5rem',
 })
+
+export const HeaderNameInput = styled(MuiTextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    color: theme.tokens.colors.primaryContrast,
+    backgroundColor: `rgba(0, 0, 0, ${theme.tokens.opacity.disabled})`,
+    '& fieldset': {
+      borderColor: theme.tokens.colors.toolbarInputBorder,
+    },
+  },
+  '& .MuiFormLabel-root': {
+    color: theme.tokens.colors.primaryContrast,
+    '&.Mui-focused': {
+      color: theme.tokens.colors.primaryContrast,
+    },
+  },
+}))

--- a/web/app/src/views/PipelineDetailView/styles.tsx
+++ b/web/app/src/views/PipelineDetailView/styles.tsx
@@ -53,20 +53,20 @@ export const PipelineDetailViewBody = styled(AppContainer)(({ theme }) => ({
   overflow: 'auto',
   flex: 1,
   flexDirection: 'column',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
     overflow: 'hidden',
   },
 }))
 
-export const PipelineDetailViewLeft = styled('div')({
+export const PipelineDetailViewLeft = styled('div')(({ theme }) => ({
   flex: '0 0 16.67%',
   height: '100%',
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
-})
+}))
 
 export const PipelineDetailViewCenter = styled('div')({
   flex: 1,
@@ -82,7 +82,7 @@ export const PipelineDetailViewRight = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     width: 'calc(100% / 6)',
   },
 }))

--- a/web/app/src/views/StorageDetailView/component.tsx
+++ b/web/app/src/views/StorageDetailView/component.tsx
@@ -3,7 +3,6 @@ import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
-import Typography from '@mui/material/Typography'
 
 import DeleteIcon from '@mui/icons-material/Delete'
 import HelpIcon from '@mui/icons-material/Help'
@@ -26,6 +25,7 @@ import StreamEditor from '@/components/StreamEditor/component'
 import { buildUrl } from '@/router'
 
 import {
+  DemoModeBanner,
   StorageDetailViewBody,
   StorageDetailViewContent,
   StorageDetailViewHeader,
@@ -95,9 +95,9 @@ const StorageDetailView = () => {
           </Button>
 
           {featureFlags.demoMode && (
-            <Typography variant="text" sx={{ fontStyle: 'italic' }}>
+            <DemoModeBanner variant="text">
               Demo Mode Active, changes will be ignored.
-            </Typography>
+            </DemoModeBanner>
           )}
         </StorageDetailViewHeaderLeft>
 

--- a/web/app/src/views/StorageDetailView/styles.tsx
+++ b/web/app/src/views/StorageDetailView/styles.tsx
@@ -42,19 +42,19 @@ export const StorageDetailViewBody = styled(AppContainer)(({ theme }) => ({
   gap: theme.spacing(1),
   flex: '1 1 0',
   overflow: 'hidden',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
 }))
 
-export const StorageDetailViewSidebar = styled('div')({
+export const StorageDetailViewSidebar = styled('div')(({ theme }) => ({
   flex: '0 0 16.67%',
   height: '100%',
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
-})
+}))
 
 export const StorageDetailViewContent = styled('div')({
   flex: 1,

--- a/web/app/src/views/StorageDetailView/styles.tsx
+++ b/web/app/src/views/StorageDetailView/styles.tsx
@@ -1,4 +1,4 @@
-import { Box, styled } from '@mui/material'
+import { Box, Typography, styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
@@ -60,4 +60,8 @@ export const StorageDetailViewContent = styled('div')({
   flex: 1,
   height: '100%',
   minWidth: 0,
+})
+
+export const DemoModeBanner = styled(Typography)({
+  fontStyle: 'italic',
 })

--- a/web/app/src/views/StorageDetailView/styles.tsx
+++ b/web/app/src/views/StorageDetailView/styles.tsx
@@ -20,32 +20,32 @@ export const StorageDetailViewHeader = styled(AppContainer)(({ theme }) => ({
   flex: 0,
 }))
 
-export const StorageDetailViewHeaderLeft = styled('div')({
+export const StorageDetailViewHeaderLeft = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const StorageDetailViewHeaderActions = styled('div')({
+export const StorageDetailViewHeaderActions = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const StorageDetailViewBody = styled(AppContainer)({
+export const StorageDetailViewBody = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.5rem',
+  gap: theme.spacing(1),
   flex: '1 1 0',
   overflow: 'hidden',
   '@media (min-width: 990px)': {
     flexDirection: 'row',
   },
-})
+}))
 
 export const StorageDetailViewSidebar = styled('div')({
   flex: '0 0 16.67%',

--- a/web/app/src/views/StreamDetailView/styles.tsx
+++ b/web/app/src/views/StreamDetailView/styles.tsx
@@ -2,19 +2,19 @@ import { styled } from '@mui/material'
 
 import AppContainer from '@/components/AppContainer/component'
 
-export const StreamDetailViewContainer = styled(AppContainer)({
-  '@media (max-width: 990px)': {
+export const StreamDetailViewContainer = styled(AppContainer)(({ theme }) => ({
+  [theme.breakpoints.down('md')]: {
     flexDirection: 'column',
   },
-})
+}))
 
-export const StreamDetailViewSidebar = styled('div')({
+export const StreamDetailViewSidebar = styled('div')(({ theme }) => ({
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flex: '0 0 16.67%',
     height: '100%',
   },
-})
+}))
 
 export const StreamDetailViewContent = styled('div')(({ theme }) => ({
   flex: 1,

--- a/web/app/src/views/StreamDetailView/styles.tsx
+++ b/web/app/src/views/StreamDetailView/styles.tsx
@@ -16,11 +16,11 @@ export const StreamDetailViewSidebar = styled('div')({
   },
 })
 
-export const StreamDetailViewContent = styled('div')({
+export const StreamDetailViewContent = styled('div')(({ theme }) => ({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: 8,
+  gap: theme.spacing(1),
   height: '100%',
-})
+}))

--- a/web/app/src/views/SystemConfiguration/component.tsx
+++ b/web/app/src/views/SystemConfiguration/component.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { LoaderFunction, useLoaderData } from 'react-router'
 
 import Button from '@mui/material/Button'
-import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
 
 import {
@@ -19,7 +18,9 @@ import ListEdit from '@/components/ListEdit/component'
 
 import {
   SystemConfigurationCard,
+  SystemConfigurationCardContent,
   SystemConfigurationCardHeader,
+  SystemConfigurationCardTitle,
   SystemConfigurationHeader,
   SystemConfigurationRoot,
   SystemConfigurationWrapper,
@@ -48,11 +49,11 @@ const SystemConfiguration = () => {
       <SystemConfigurationWrapper>
         <SystemConfigurationCard>
           <SystemConfigurationCardHeader>
-            <Typography variant="titleSm" sx={{ flexGrow: 1 }}>
+            <SystemConfigurationCardTitle variant="titleSm">
               Allowed Syslog Origins
-            </Typography>
+            </SystemConfigurationCardTitle>
           </SystemConfigurationCardHeader>
-          <CardContent sx={{ p: 1.5 }}>
+          <SystemConfigurationCardContent>
             <ListEdit
               id="editor.config.syslog_allowed_origins"
               list={config.syslog_allowed_origins ?? []}
@@ -60,7 +61,7 @@ const SystemConfiguration = () => {
                 setConfig({ ...config, syslog_allowed_origins: list })
               }
             />
-          </CardContent>
+          </SystemConfigurationCardContent>
         </SystemConfigurationCard>
 
         <Button

--- a/web/app/src/views/SystemConfiguration/styles.tsx
+++ b/web/app/src/views/SystemConfiguration/styles.tsx
@@ -20,21 +20,21 @@ export const SystemConfigurationCard = styled(Card)({
   flexDirection: 'column',
 })
 
-export const SystemConfigurationWrapper = styled('div')({
+export const SystemConfigurationWrapper = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   maxWidth: 400,
   width: '100%',
-  gap: '1rem',
-})
+  gap: theme.spacing(2),
+}))
 
 export const SystemConfigurationCardHeader = styled(Box)(({ theme }) => ({
-  padding: '0.75rem 1rem',
+  padding: theme.spacing(1.5, 2),
   backgroundColor: theme.tokens.colors.cardHeaderBkg,
   color: theme.tokens.colors.primaryContrast,
   boxShadow: theme.shadows[4],
   zIndex: 20,
   display: 'flex',
   alignItems: 'center',
-  gap: '0.75rem',
+  gap: theme.spacing(1.5),
 }))

--- a/web/app/src/views/SystemConfiguration/styles.tsx
+++ b/web/app/src/views/SystemConfiguration/styles.tsx
@@ -1,5 +1,7 @@
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 
 import AppContainer from '@/components/AppContainer/component'
@@ -38,3 +40,13 @@ export const SystemConfigurationCardHeader = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   gap: theme.spacing(1.5),
 }))
+
+export const SystemConfigurationCardTitle = styled(Typography)({
+  flexGrow: 1,
+})
+
+export const SystemConfigurationCardContent = styled(CardContent)(
+  ({ theme }) => ({
+    padding: theme.spacing(1.5),
+  })
+)

--- a/web/app/src/views/TransformerDetailView/styles.tsx
+++ b/web/app/src/views/TransformerDetailView/styles.tsx
@@ -22,32 +22,32 @@ export const TransformerDetailViewToolbar = styled(AppContainer)(
   })
 )
 
-export const TransformerDetailViewToolbarLeft = styled('div')({
+export const TransformerDetailViewToolbarLeft = styled('div')(({ theme }) => ({
   flexGrow: 1,
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 12,
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const TransformerDetailViewToolbarRight = styled('div')({
+export const TransformerDetailViewToolbarRight = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 12,
-})
+  gap: theme.spacing(1.5),
+}))
 
-export const TransformerDetailViewBody = styled(AppContainer)({
+export const TransformerDetailViewBody = styled(AppContainer)(({ theme }) => ({
   flexGrow: 1,
   flexShrink: 1,
   height: 0,
   display: 'flex',
   flexDirection: 'column',
-  gap: 8,
+  gap: theme.spacing(1),
   '@media (min-width: 990px)': {
     flexDirection: 'row',
   },
-})
+}))
 
 export const TransformerDetailViewSidebar = styled('div')({
   flex: '0 0 16.67%',

--- a/web/app/src/views/TransformerDetailView/styles.tsx
+++ b/web/app/src/views/TransformerDetailView/styles.tsx
@@ -14,12 +14,11 @@ export const TransformerDetailViewToolbar = styled(AppContainer)(
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'stretch',
-    color: 'white',
+    color: theme.tokens.colors.primaryContrast,
     backgroundColor: theme.tokens.colors.editorToolbarBkg,
     zIndex: 10,
     flex: 0,
-    boxShadow:
-      '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+    boxShadow: theme.tokens.shadows.md,
   })
 )
 

--- a/web/app/src/views/TransformerDetailView/styles.tsx
+++ b/web/app/src/views/TransformerDetailView/styles.tsx
@@ -44,32 +44,32 @@ export const TransformerDetailViewBody = styled(AppContainer)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(1),
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
 }))
 
-export const TransformerDetailViewSidebar = styled('div')({
+export const TransformerDetailViewSidebar = styled('div')(({ theme }) => ({
   flex: '0 0 16.67%',
   height: '100%',
   width: '100%',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
-})
+}))
 
-export const TransformerDetailViewEditor = styled('div')({
+export const TransformerDetailViewEditor = styled('div')(({ theme }) => ({
   flex: 1,
   height: '100%',
   flexDirection: 'column',
-  '@media (min-width: 990px)': {
+  [theme.breakpoints.up('md')]: {
     flexDirection: 'row',
   },
   '& > div': {
     display: 'flex',
     flexDirection: 'column',
-    '@media (min-width: 990px)': {
+    [theme.breakpoints.up('md')]: {
       flexDirection: 'row',
     },
   },
-})
+}))

--- a/web/app/src/views/UploadView/component.tsx
+++ b/web/app/src/views/UploadView/component.tsx
@@ -41,7 +41,7 @@ const UploadView = () => {
   const notify = useNotify()
 
   const { pipelines } = useLoaderData() as LoaderData
-  const [pipeline, setPipeline] = useState<string | null>(null)
+  const [pipeline, setPipeline] = useState<string>('')
   const [file, setFile] = useState<File | null>(null)
 
   const onSelectPipeline = (event: any) => {
@@ -49,14 +49,14 @@ const UploadView = () => {
   }
 
   const [uploadLogs, loading] = useApiOperation(async () => {
-    if (pipeline === null || file === null) {
+    if (pipeline === '' || file === null) {
       return
     }
 
     await logsApi.uploadTextLogs(pipeline, file)
     notify.success('Logs uploaded successfully')
 
-    setPipeline(null)
+    setPipeline('')
     setFile(null)
   }, [pipeline, file])
 

--- a/web/app/src/views/UploadView/styles.tsx
+++ b/web/app/src/views/UploadView/styles.tsx
@@ -8,26 +8,26 @@ export const UploadViewRoot = styled(AppContainer)({
   flexDirection: 'column',
 })
 
-export const UploadViewHeader = styled(Box)({
+export const UploadViewHeader = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '0.5rem',
-})
+  gap: theme.spacing(1),
+}))
 
-export const UploadViewCard = styled(Card)({
-  padding: '0.75rem',
+export const UploadViewCard = styled(Card)(({ theme }) => ({
+  padding: theme.spacing(1.5),
   maxWidth: 400,
   width: '100%',
-})
+}))
 
-export const UploadViewForm = styled('form')({
+export const UploadViewForm = styled('form')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '0.75rem',
-})
+  gap: theme.spacing(1.5),
+}))
 
 export const VisuallyHiddenInput = styled('input')({
   clip: 'rect(0 0 0 0)',

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -29,7 +29,29 @@ export default defineConfig({
           next()
         })
       }
-    }
+    },
+    {
+      name: 'go-template-substitution',
+      transformIndexHtml(html) {
+        return html
+          .replace(/\{\{\s*\.MountPath\s*\}\}/g, '')
+          .replace(/\{\{\s*\.FeatureFlags\.DemoMode\s*\}\}/g, 'false')
+      },
+    },
+    {
+      name: 'trailing-slash-redirect',
+      configureServer(serve) {
+        serve.middlewares.use((req, res, next) => {
+          if (req.url === '/web') {
+            res.writeHead(302, { Location: '/web/' })
+            res.end()
+            return
+          }
+
+          next()
+        })
+      },
+    },
   ],
   build: {
     sourcemap: true,
@@ -49,7 +71,7 @@ export default defineConfig({
     'import.meta.env.FLOWG_VERSION': JSON.stringify(fs.readFileSync('../../VERSION.txt', 'utf8').trim()),
   },
   server: {
-    open: '/web',
+    open: '/web/',
     proxy: {
       '/api': {
         target: 'http://localhost:5080',

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -38,20 +38,6 @@ export default defineConfig({
           .replace(/\{\{\s*\.FeatureFlags\.DemoMode\s*\}\}/g, 'false')
       },
     },
-    {
-      name: 'trailing-slash-redirect',
-      configureServer(serve) {
-        serve.middlewares.use((req, res, next) => {
-          if (req.url === '/web') {
-            res.writeHead(302, { Location: '/web/' })
-            res.end()
-            return
-          }
-
-          next()
-        })
-      },
-    },
   ],
   build: {
     sourcemap: true,


### PR DESCRIPTION
## Decision Record

Hard-coded CSS values (hex colors, rgba(...) opacity literals, raw box-shadow strings, inline transition strings) were scattered across component style files. Centralizing them as design tokens enforces consistency, makes future theme changes a single-file edit, and aligns with the architecture rule that forbids hard-coded values in styles.tsx

 - Closes #1190 

## Changes

  - [x]  :sparkles: Add theme/tokens/transitions.ts — transition scale (fast, normal, slow, shadow)
  - [x]   :sparkles: Add theme/tokens/opacity.ts — opacity scale (xLight, light, medium, disabled, hover, overlay)
  - [x]   :art: Replace hard-coded box-shadow strings in all PipelineNode* components with theme.tokens.shadows
  - [x]   :art: Replace hard-coded transition strings in all PipelineNode* components with theme.tokens.transitions.shadow
  - [x]   :art: Replace hard-coded opacity literals in LogTable, NotFoundView, and ErrorBoundary with theme.tokens.opacity
  - [x]   :art: Replace color: 'white' 
  - [x]  :art: Extract ToolbarNameInput and DialogAppBar styled components in DialogForwarderEditor (removes inline sx with hard-coded colors)
  - [x]  :art: Extract HeaderNameInput styled component in PipelineDetailView (removes inline sx with hard-coded colors)
   - [x] :wrench: Add Vite go-template-substitution plugin. substitutes Go template variables in index.html during dev so the dev server serves valid HTML (fixes 404 on startup and doubled API base paths)

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
