### PR TITLE
Add optional Proxy URL to HTTP (Webhook) Forwarder

### DIFF
--- a/internal/models/forwarder_v2_http.go
+++ b/internal/models/forwarder_v2_http.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"net/http"
+	"net/url"
 
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
@@ -23,6 +24,7 @@ type ForwarderHttpV2 struct {
 	Type    string                   `json:"type" enum:"http" required:"true"`
 	Url     string                   `json:"url" required:"true" format:"uri"`
 	Headers map[string]string        `json:"headers,omitempty"`
+	Proxy   string                   `json:"proxy,omitempty"`
 	Body    ForwarderHttpV2BodyField `json:"body,omitempty"`
 
 	state *forwarderStateHttpV2
@@ -91,6 +93,14 @@ func (f *ForwarderHttpV2) call(ctx context.Context, record *LogRecord) error {
 
 	for key, value := range f.Headers {
 		req.Header.Add(key, value)
+	}
+
+	if len(f.Proxy) > 0 {
+		proxy, err := url.Parse(f.Proxy)
+		if err != nil {
+			return fmt.Errorf("failed to parse proxy: %w", err)
+		}
+		f.state.client.Transport = &http.Transport{Proxy: http.ProxyURL(proxy)}
 	}
 
 	resp, err := f.state.client.Do(req)

--- a/web/app/src/components/ForwarderEditorHttp/component.tsx
+++ b/web/app/src/components/ForwarderEditorHttp/component.tsx
@@ -24,6 +24,7 @@ const ForwarderEditorHttp = ({
     validators.minLength(1),
     validators.formatUri,
   ])
+
   const [headers, setHeaders] = useInput<Record<string, string>>(
     config.headers ?? {},
     []
@@ -31,6 +32,10 @@ const ForwarderEditorHttp = ({
 
   const [body, setBody] = useInput<DynamicField<string>>(config.body, [
     validators.dynamicField([]),
+  ])
+
+  const [proxy, setProxy] = useInput<string>(config.proxy ?? '', [
+    validators.formatUri,
   ])
 
   useEffect(() => {
@@ -43,9 +48,10 @@ const ForwarderEditorHttp = ({
         url: url.value,
         headers: headers.value,
         body: body.value,
+        proxy: proxy.value,
       })
     }
-  }, [url, headers])
+  }, [url, headers, proxy])
 
   return (
     <ForwarderEditorHttpRoot id="container:editor.forwarders.http">
@@ -81,6 +87,18 @@ const ForwarderEditorHttp = ({
         error={!body.valid}
         value={body.value}
         onChange={setBody}
+      />
+
+      <TextField
+        id="input:editor.forwarders.http.proxy_url"
+        label="Proxy URL"
+        variant="outlined"
+        type="text"
+        error={proxy.value.length > 0 && !proxy.valid}
+        value={proxy.value}
+        onChange={(e) => {
+          setProxy(e.target.value)
+        }}
       />
     </ForwarderEditorHttpRoot>
   )

--- a/web/app/src/lib/models/ForwarderConfigHttpModel.ts
+++ b/web/app/src/lib/models/ForwarderConfigHttpModel.ts
@@ -5,6 +5,7 @@ type ForwarderConfigHttpModel = {
   url: string
   headers?: Record<string, string>
   body: DynamicField<string>
+  proxy?: string
 }
 
 export default ForwarderConfigHttpModel
@@ -14,4 +15,5 @@ export const factory = (): ForwarderConfigHttpModel => ({
   url: '',
   headers: undefined,
   body: '@expr:toJSON(log)',
+  proxy: '',
 })

--- a/website/docs/technical/forwarders/webhook.md
+++ b/website/docs/technical/forwarders/webhook.md
@@ -15,6 +15,7 @@ erDiagram
 
   Configuration {
     str url "The target URL"
+    str proxy "Use a proxy server to send the request (if specified)"
     HttpHeader[] headers "Additional HTTP headers to send"
     str body[1] "The body of a log message"
   }


### PR DESCRIPTION
## Decision Record

 - Closes #1264.

## Changes

- [x]  :sparkles: Add optional Proxy URL to HTTP (Webhook) Forwarder
- [x] :lipstick: Add the proxy field to the HTTP Forwarder Editor in the webui
- [x] :memo: Update documentation

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
