### PR TITLE
:pushpin: :lock: overrides dompurify version to 3.4.0

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -2153,9 +2153,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -42,5 +42,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vite-plugin-compression2": "^2.5.3"
+  },
+  "overrides": {
+    "dompurify": "3.4.0"
   }
 }


### PR DESCRIPTION
## Decision Record

Monaco Editor depends on `dompurify=3.2.7` which contains many CVEs. We override that indirect dependency to the patched version `3.4.0`.

## Changes

 - [x] :pushpin: :lock: overrides dompurify version to 3.4.0

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
