### PR TITLE
✨ Implement comprehensive dark mode theming

### DIFF
--- a/web/app/src/components/ButtonNewRole/component.tsx
+++ b/web/app/src/components/ButtonNewRole/component.tsx
@@ -28,7 +28,6 @@ const ButtonNewRole = ({ onRoleCreated }: ButtonNewRoleProps) => {
     <Button
       id="btn:admin.roles.create"
       variant="contained"
-      color="secondary"
       size="small"
       onClick={() => handleClick()}
     >

--- a/web/app/src/components/ButtonNewRole/component.tsx
+++ b/web/app/src/components/ButtonNewRole/component.tsx
@@ -29,6 +29,7 @@ const ButtonNewRole = ({ onRoleCreated }: ButtonNewRoleProps) => {
       id="btn:admin.roles.create"
       variant="contained"
       size="small"
+      color="secondary"
       onClick={() => handleClick()}
     >
       <AddIcon />

--- a/web/app/src/components/ButtonNewToken/component.tsx
+++ b/web/app/src/components/ButtonNewToken/component.tsx
@@ -28,7 +28,6 @@ const ButtonNewToken = ({ onTokenCreated }: ButtonNewTokenProps) => {
     <Button
       id="btn:account.tokens.create"
       variant="contained"
-      color="secondary"
       size="small"
       disabled={loading}
       onClick={() => handleClick()}

--- a/web/app/src/components/ButtonNewToken/component.tsx
+++ b/web/app/src/components/ButtonNewToken/component.tsx
@@ -29,6 +29,7 @@ const ButtonNewToken = ({ onTokenCreated }: ButtonNewTokenProps) => {
       id="btn:account.tokens.create"
       variant="contained"
       size="small"
+      color="secondary"
       disabled={loading}
       onClick={() => handleClick()}
     >

--- a/web/app/src/components/ButtonNewUser/component.tsx
+++ b/web/app/src/components/ButtonNewUser/component.tsx
@@ -28,7 +28,6 @@ const ButtonNewUser = ({ roles, onUserCreated }: ButtonNewUserProps) => {
     <Button
       id="btn:admin.users.create"
       variant="contained"
-      color="secondary"
       size="small"
       onClick={() => handleClick()}
     >

--- a/web/app/src/components/ButtonNewUser/component.tsx
+++ b/web/app/src/components/ButtonNewUser/component.tsx
@@ -29,6 +29,7 @@ const ButtonNewUser = ({ roles, onUserCreated }: ButtonNewUserProps) => {
       id="btn:admin.users.create"
       variant="contained"
       size="small"
+      color="secondary"
       onClick={() => handleClick()}
     >
       <AddIcon />

--- a/web/app/src/components/LogChart/component.tsx
+++ b/web/app/src/components/LogChart/component.tsx
@@ -1,3 +1,4 @@
+import { useColorMode } from '@/theme'
 import type { ApexOptions } from 'apexcharts'
 
 import { useMemo } from 'react'
@@ -8,21 +9,21 @@ import { aggregateLogs } from '@/lib/timeserie'
 import { LogChartContainer } from './styles'
 import { LogChartProps } from './types'
 
-const CHART_OPTIONS: ApexOptions = {
-  chart: {
-    animations: {
-      enabled: false,
-    },
-  },
-  dataLabels: {
-    enabled: false,
-  },
-  xaxis: {
-    type: 'datetime',
-  },
-}
-
 const LogChart = ({ rowData, from, to }: LogChartProps) => {
+  const { mode } = useColorMode()
+
+  const options: ApexOptions = useMemo(
+    () => ({
+      chart: {
+        animations: { enabled: false },
+        foreColor: mode === 'dark' ? '#ffffff' : undefined,
+      },
+      dataLabels: { enabled: false },
+      xaxis: { type: 'datetime' },
+    }),
+    [mode]
+  )
+
   const series = useMemo(
     () => [
       {
@@ -36,7 +37,7 @@ const LogChart = ({ rowData, from, to }: LogChartProps) => {
   return (
     <LogChartContainer>
       <ApexChart
-        options={CHART_OPTIONS}
+        options={options}
         series={series}
         type="bar"
         width="100%"

--- a/web/app/src/components/PageFooter/component.tsx
+++ b/web/app/src/components/PageFooter/component.tsx
@@ -1,12 +1,38 @@
+import { useColorMode } from '@/theme'
+
+import IconButton from '@mui/material/IconButton'
+
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import LightModeIcon from '@mui/icons-material/LightMode'
+
 import { useFeatureFlags } from '@/lib/hooks/featureflags'
 
 import { PageFooterContainer, PageFooterText } from './styles'
 
 const PageFooter = () => {
   const { demoMode } = useFeatureFlags()
+  const { mode, toggle } = useColorMode()
 
   return (
     <PageFooterContainer>
+      <IconButton
+        id="btn:footer.toggle-color-mode"
+        size="small"
+        onClick={toggle}
+        aria-label={
+          mode === 'light' ? 'Switch to dark mode' : 'Switch to light mode'
+        }
+      >
+        {mode === 'light' ? (
+          <DarkModeIcon fontSize="small" />
+        ) : (
+          <LightModeIcon fontSize="small" />
+        )}
+      </IconButton>
+      <PageFooterText variant="text">
+        {mode === 'light' ? 'Dark mode' : 'Light mode'}
+      </PageFooterText>
+
       {demoMode && (
         <PageFooterText variant="text">Demo Mode Enabled</PageFooterText>
       )}

--- a/web/app/src/components/PageFooter/styles.ts
+++ b/web/app/src/components/PageFooter/styles.ts
@@ -2,6 +2,8 @@ import { Typography, styled } from '@mui/material'
 
 export const PageFooterContainer = styled('footer')`
   display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(1)};
   padding: ${({ theme }) => theme.spacing(1.5)};
   background-color: ${({ theme }) => theme.tokens.colors.borderLight};
 

--- a/web/app/src/components/PipelineEditorFlow/styles.tsx
+++ b/web/app/src/components/PipelineEditorFlow/styles.tsx
@@ -3,6 +3,9 @@ import { Chip, Paper, styled } from '@mui/material'
 export const FlowRoot = styled(Paper)({
   width: '100%',
   height: '100%',
+  '.react-flow__panel': {
+    backgroundColor: 'transparent',
+  },
 })
 
 export const FlowPanelPaper = styled(Paper)(({ theme }) => ({

--- a/web/app/src/components/PipelineEditorFlow/styles.tsx
+++ b/web/app/src/components/PipelineEditorFlow/styles.tsx
@@ -20,8 +20,9 @@ export const FlowPanelLabel = styled('div')(({ theme }) => ({
   alignItems: 'center',
   fontSize: '0.75rem',
   fontWeight: 600,
-  backgroundColor: theme.palette.grey[100],
-  borderRight: `1px solid ${theme.palette.grey[200]}`,
+  backgroundColor: theme.tokens.colors.cardHeaderBkg,
+  color: theme.tokens.colors.primaryContrast,
+  borderRight: `1px solid ${theme.tokens.colors.borderLight}`,
   padding: theme.spacing(1),
 }))
 

--- a/web/app/src/components/PipelineEditorNodeList/component.tsx
+++ b/web/app/src/components/PipelineEditorNodeList/component.tsx
@@ -1,3 +1,5 @@
+import { useColorMode } from '@/theme'
+
 import { ReactElement, ReactNode, useEffect, useState } from 'react'
 
 import CircularProgress from '@mui/material/CircularProgress'
@@ -54,9 +56,13 @@ const PipelineEditorNodeList = (props: PipelineEditorNodeListProps) => {
     }
   }, [error])
 
+  const { mode } = useColorMode()
+
   const baseColorMap = colors[props.itemColor]
-  const bgColorIndex = 50 as keyof typeof baseColorMap
-  const bdColorIndex = 500 as keyof typeof baseColorMap
+  const bgColorIndex = (mode === 'dark' ? 900 : 50) as keyof typeof baseColorMap
+  const bdColorIndex = (
+    mode === 'dark' ? 300 : 500
+  ) as keyof typeof baseColorMap
   const backgroundColor = baseColorMap[bgColorIndex]
   const borderColor = baseColorMap[bdColorIndex]
 

--- a/web/app/src/components/PipelineEditorNodeList/styles.tsx
+++ b/web/app/src/components/PipelineEditorNodeList/styles.tsx
@@ -12,7 +12,8 @@ export const NodeListHeader = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  backgroundColor: theme.palette.grey[100],
+  backgroundColor: theme.tokens.colors.cardHeaderBkg,
+  color: theme.tokens.colors.primaryContrast,
   boxShadow: theme.shadows[4],
 }))
 

--- a/web/app/src/components/PipelineNodeForwarder/styles.tsx
+++ b/web/app/src/components/PipelineNodeForwarder/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodeForwarderBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/PipelineNodePipeline/styles.tsx
+++ b/web/app/src/components/PipelineNodePipeline/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodePipelineBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/PipelineNodeRouter/styles.tsx
+++ b/web/app/src/components/PipelineNodeRouter/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodeRouterBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/PipelineNodeSource/styles.tsx
+++ b/web/app/src/components/PipelineNodeSource/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodeSourceBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/PipelineNodeSwitch/styles.tsx
+++ b/web/app/src/components/PipelineNodeSwitch/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodeSwitchBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/PipelineNodeTransformer/styles.tsx
+++ b/web/app/src/components/PipelineNodeTransformer/styles.tsx
@@ -17,7 +17,7 @@ export const NodeRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   gap: theme.spacing(1),
-  backgroundColor: theme.tokens.colors.white,
+  backgroundColor: theme.palette.background.paper,
   border: `4px solid ${theme.tokens.colors.nodeTransformerBorder}`,
   boxShadow: theme.tokens.shadows.nodeElevated,
   transition: theme.tokens.transitions.shadow,

--- a/web/app/src/components/RoleTable/component.tsx
+++ b/web/app/src/components/RoleTable/component.tsx
@@ -117,8 +117,8 @@ const RoleTable = ({ roles }: RoleTableProps) => {
         },
         suppressMovable: true,
         sortable: false,
-        minWidth: 80,
-        width: 80,
+        minWidth: 100,
+        width: 100,
       },
     ],
     [permissions.can_edit_acls, onDelete]

--- a/web/app/src/components/StreamEditor/styles.tsx
+++ b/web/app/src/components/StreamEditor/styles.tsx
@@ -26,7 +26,8 @@ export const StreamEditorPanel = styled(Paper)({
 
 export const StreamEditorPanelHeader = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1.5),
-  backgroundColor: theme.palette.grey[100],
+  backgroundColor: theme.tokens.colors.cardHeaderBkg,
+  color: theme.tokens.colors.primaryContrast,
   boxShadow: theme.shadows[1],
   textAlign: 'center',
   '& .MuiTypography-root': { fontWeight: 700 },

--- a/web/app/src/components/TransformerEditor/styles.tsx
+++ b/web/app/src/components/TransformerEditor/styles.tsx
@@ -8,6 +8,8 @@ export const EditorRoot = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   width: '100%',
   height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
   gap: theme.spacing(1),
 }))
 
@@ -20,10 +22,12 @@ export const EditorSide = styled(Box)(({ theme }) => ({
   flex: '0 0 calc(33.333% - 0.25rem)',
   minWidth: 0,
   height: '100%',
+  minHeight: 0,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
   gap: theme.spacing(1),
+  overflow: 'hidden',
 }))
 
 export const EditorPaper = styled(Paper)({

--- a/web/app/src/components/VrlCodeEditor/component.tsx
+++ b/web/app/src/components/VrlCodeEditor/component.tsx
@@ -1,9 +1,12 @@
+import { useColorMode } from '@/theme'
+
 import { useEffect, useState } from 'react'
 
 import Editor, { useMonaco } from '@monaco-editor/react'
 
 import {
   vrlLanguageDefinition,
+  vrlThemeDarkDefinition,
   vrlThemeDefinition,
 } from '@/lib/vrl-highlighter'
 
@@ -12,6 +15,7 @@ import { VrlCodeEditorProps } from './types'
 const VrlCodeEditor = ({ id, code, onCodeChange }: VrlCodeEditorProps) => {
   const [value, setValue] = useState(code)
   const monaco = useMonaco()
+  const { mode } = useColorMode()
 
   useEffect(() => {
     setValue(code)
@@ -21,12 +25,16 @@ const VrlCodeEditor = ({ id, code, onCodeChange }: VrlCodeEditorProps) => {
     if (!monaco) return
 
     monaco.languages.register({ id: 'vrl' })
-    monaco.editor.defineTheme('vrl-theme', vrlThemeDefinition as any)
+    monaco.editor.defineTheme('vrl-theme-light', vrlThemeDefinition as any)
+    monaco.editor.defineTheme('vrl-theme-dark', vrlThemeDarkDefinition as any)
     monaco.languages.setMonarchTokensProvider(
       'vrl',
       vrlLanguageDefinition as any
     )
-  }, [monaco])
+    monaco.editor.setTheme(
+      mode === 'dark' ? 'vrl-theme-dark' : 'vrl-theme-light'
+    )
+  }, [monaco, mode])
 
   const onChange = (val?: string) => {
     setValue(val ?? '')
@@ -38,7 +46,7 @@ const VrlCodeEditor = ({ id, code, onCodeChange }: VrlCodeEditorProps) => {
       wrapperProps={{ id: id ?? '' }}
       defaultValue={value}
       defaultLanguage="vrl"
-      theme="vrl-theme"
+      theme={mode === 'dark' ? 'vrl-theme-dark' : 'vrl-theme-light'}
       onChange={onChange}
       options={{ minimap: { enabled: false } }}
     />

--- a/web/app/src/lib/vrl-highlighter.ts
+++ b/web/app/src/lib/vrl-highlighter.ts
@@ -660,3 +660,13 @@ export let vrlThemeDefinition = {
     'editor.selectionHighlightBorder': '#fafbfc',
   },
 }
+
+export let vrlThemeDarkDefinition = {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [],
+  colors: {
+    'editor.background': '#252535',
+    'editor.lineHighlightBackground': '#2d2d3e',
+  },
+}

--- a/web/app/src/theme/ThemeRegistry.tsx
+++ b/web/app/src/theme/ThemeRegistry.tsx
@@ -43,7 +43,7 @@ export default function ThemeRegistry({ children }: ThemeRegistryProps) {
   const [mode, setMode] = useState<ColorMode>(() => {
     const saved = localStorage.getItem('colorMode')
     if (saved === 'dark' || saved === 'light') return saved
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
+    return globalThis.matchMedia('(prefers-color-scheme: dark)').matches
       ? 'dark'
       : 'light'
   })

--- a/web/app/src/theme/ThemeRegistry.tsx
+++ b/web/app/src/theme/ThemeRegistry.tsx
@@ -1,6 +1,12 @@
 import { CacheProvider } from '@emotion/react'
 
-import { type ReactNode, useMemo } from 'react'
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
 
 import CssBaseline from '@mui/material/CssBaseline'
 import GlobalStyles from '@mui/material/GlobalStyles'
@@ -8,22 +14,58 @@ import { ThemeProvider } from '@mui/material/styles'
 
 import { createEmotionCache } from './emotionCache'
 import globalStyles from './globalStyles'
-import theme from './theme'
+import { createAppTheme } from './theme'
 
 interface ThemeRegistryProps {
   readonly children: ReactNode
 }
 
+type ColorMode = 'light' | 'dark'
+
+interface ColorModeContextValue {
+  mode: ColorMode
+  toggle: () => void
+}
+
+export const ColorModeContext = createContext<ColorModeContextValue>({
+  mode: 'light',
+  toggle: () => {},
+})
+
+export function useColorMode() {
+  return useContext(ColorModeContext)
+}
+
 export default function ThemeRegistry({ children }: ThemeRegistryProps) {
   const cache = useMemo(() => createEmotionCache(), [])
 
+  const [mode, setMode] = useState<ColorMode>(() => {
+    const saved = localStorage.getItem('colorMode')
+    if (saved === 'dark' || saved === 'light') return saved
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  })
+
+  const toggle = () => {
+    setMode((prev) => {
+      const next: ColorMode = prev === 'light' ? 'dark' : 'light'
+      localStorage.setItem('colorMode', next)
+      return next
+    })
+  }
+
+  const theme = useMemo(() => createAppTheme(mode), [mode])
+
   return (
-    <CacheProvider value={cache}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <GlobalStyles styles={globalStyles} />
-        {children}
-      </ThemeProvider>
-    </CacheProvider>
+    <ColorModeContext.Provider value={{ mode, toggle }}>
+      <CacheProvider value={cache}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <GlobalStyles styles={globalStyles} />
+          {children}
+        </ThemeProvider>
+      </CacheProvider>
+    </ColorModeContext.Provider>
   )
 }

--- a/web/app/src/theme/ThemeRegistry.tsx
+++ b/web/app/src/theme/ThemeRegistry.tsx
@@ -3,6 +3,7 @@ import { CacheProvider } from '@emotion/react'
 import {
   type ReactNode,
   createContext,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -47,18 +48,19 @@ export default function ThemeRegistry({ children }: ThemeRegistryProps) {
       : 'light'
   })
 
-  const toggle = () => {
+  const toggle = useCallback(() => {
     setMode((prev) => {
       const next: ColorMode = prev === 'light' ? 'dark' : 'light'
       localStorage.setItem('colorMode', next)
       return next
     })
-  }
+  }, [])
 
   const theme = useMemo(() => createAppTheme(mode), [mode])
+  const colorModeValue = useMemo(() => ({ mode, toggle }), [mode, toggle])
 
   return (
-    <ColorModeContext.Provider value={{ mode, toggle }}>
+    <ColorModeContext.Provider value={colorModeValue}>
       <CacheProvider value={cache}>
         <ThemeProvider theme={theme}>
           <CssBaseline />

--- a/web/app/src/theme/globalStyles.ts
+++ b/web/app/src/theme/globalStyles.ts
@@ -30,6 +30,67 @@ const globalStyles: GlobalStylesProps['styles'] = (theme) => ({
   '.flowg-table .flowg-actions-header .ag-header-cell-label': {
     justifyContent: 'center',
   },
+  '.ag-theme-balham': {
+    ...(theme.palette.mode === 'dark' && {
+      '--ag-background-color': '#27324e',
+      '--ag-header-background-color': '#1e284a',
+      '--ag-header-cell-hover-background-color': '#263356',
+      '--ag-odd-row-background-color': '#243050',
+      '--ag-row-hover-color': 'rgba(66, 165, 245, 0.08)',
+      '--ag-selected-row-background-color': 'rgba(66, 165, 245, 0.2)',
+      '--ag-foreground-color': '#cbd5e1',
+      '--ag-header-foreground-color': '#cbd5e1',
+      '--ag-secondary-foreground-color': '#94a3b8',
+      '--ag-border-color': '#2d3a52',
+      '--ag-row-border-color': '#2d3a52',
+      '--ag-range-selection-border-color': '#42a5f5',
+      '--ag-cell-horizontal-border': 'none',
+    }),
+  },
+  '.ag-theme-material': {
+    ...(theme.palette.mode === 'dark' && {
+      '--ag-background-color': '#27324e',
+      '--ag-header-background-color': '#1e284a',
+      '--ag-header-cell-hover-background-color': '#263356',
+      '--ag-odd-row-background-color': '#243050',
+      '--ag-row-hover-color': 'rgba(66, 165, 245, 0.08)',
+      '--ag-selected-row-background-color': 'rgba(66, 165, 245, 0.2)',
+      '--ag-foreground-color': '#cbd5e1',
+      '--ag-header-foreground-color': '#cbd5e1',
+      '--ag-secondary-foreground-color': '#94a3b8',
+      '--ag-border-color': '#2d3a52',
+      '--ag-row-border-color': '#2d3a52',
+      '--ag-range-selection-border-color': '#42a5f5',
+      '--ag-cell-horizontal-border': 'none',
+    }),
+  },
+  ...(theme.palette.mode === 'dark' && {
+    '.react-flow__controls': {
+      backgroundColor: '#27324e',
+      border: '1px solid #2d3a52',
+      boxShadow: 'none',
+    },
+    '.react-flow__controls-button': {
+      backgroundColor: '#27324e',
+      borderBottom: '1px solid #2d3a52',
+      color: '#cbd5e1',
+      fill: '#cbd5e1',
+      '&:hover': {
+        backgroundColor: '#1e3a8a',
+      },
+    },
+    [`.ag-header-group-cell:not(.ag-column-resizing) + .ag-header-group-cell:not(.ag-column-hover):not(.ag-header-cell-moving):hover,
+      .ag-header-group-cell:not(.ag-column-resizing) + .ag-header-group-cell:not(.ag-column-hover).ag-column-resizing,
+      .ag-header-cell:not(.ag-column-resizing) + .ag-header-cell:not(.ag-column-hover):not(.ag-header-cell-moving):hover,
+      .ag-header-cell:not(.ag-column-resizing) + .ag-header-cell:not(.ag-column-hover).ag-column-resizing,
+      .ag-header-group-cell:first-of-type:not(.ag-header-cell-moving):hover,
+      .ag-header-group-cell:first-of-type.ag-column-resizing,
+      .ag-header-cell:not(.ag-column-hover):first-of-type:not(.ag-header-cell-moving):hover,
+      .ag-header-cell:not(.ag-column-hover):first-of-type.ag-column-resizing`]:
+      {
+        backgroundColor: 'var(--ag-header-cell-hover-background-color)',
+      },
+  }),
 })
 
 export default globalStyles

--- a/web/app/src/theme/index.ts
+++ b/web/app/src/theme/index.ts
@@ -1,3 +1,3 @@
-export { default as ThemeRegistry } from './ThemeRegistry'
+export { default as ThemeRegistry, useColorMode } from './ThemeRegistry'
 export { default as theme } from './theme'
 export { createEmotionCache } from './emotionCache'

--- a/web/app/src/theme/theme.ts
+++ b/web/app/src/theme/theme.ts
@@ -3,6 +3,7 @@ import { colors as muiColors } from '@mui/material'
 import { createTheme } from '@mui/material/styles'
 
 import { type TokensType, tokens } from './tokens'
+import { darkColors, lightColors } from './tokens/colors'
 
 declare module '@mui/material/styles' {
   interface Theme {
@@ -40,98 +41,141 @@ declare module '@mui/material/MenuItem' {
   }
 }
 
-const theme = createTheme({
-  tokens,
-  shape: {
-    borderRadius: 0,
-  },
-  palette: {
-    primary: {
-      main: muiColors.blue[800],
+export function createAppTheme(mode: 'light' | 'dark') {
+  const colorTokens = mode === 'dark' ? darkColors : lightColors
+  const themeTokens: TokensType = { ...tokens, colors: colorTokens }
+
+  return createTheme({
+    tokens: themeTokens,
+    shape: {
+      borderRadius: 0,
     },
-    secondary: {
-      main: muiColors.teal[400],
-    },
-  },
-  typography: {
-    allVariants: { color: tokens.colors.black },
-    titleLg: { fontSize: tokens.typography.titleLg, letterSpacing: 'normal' },
-    titleMd: { fontSize: tokens.typography.titleMd, letterSpacing: 'normal' },
-    titleSm: { fontSize: tokens.typography.titleSm, letterSpacing: 'normal' },
-    text: { fontSize: tokens.typography.text, letterSpacing: 'normal' },
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          textTransform: 'uppercase',
-          letterSpacing: 0,
-        },
-        contained: {},
-        outlined: {},
-        text: {},
+    palette: {
+      mode,
+      primary: {
+        main: mode === 'dark' ? muiColors.blue[400] : muiColors.blue[800],
       },
-    },
-    MuiInputLabel: {
-      styleOverrides: {
-        root: {
-          color: 'rgba(0, 0, 0, 0.6)',
-        },
+      secondary: {
+        main: '#42a5f5',
       },
+      ...(mode === 'dark' && {
+        background: {
+          default: '#1e1e2e',
+          paper: '#27324e',
+        },
+      }),
     },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          height: 'fit-content',
+    typography: {
+      allVariants: { color: colorTokens.labelText },
+      titleLg: { fontSize: tokens.typography.titleLg, letterSpacing: 'normal' },
+      titleMd: { fontSize: tokens.typography.titleMd, letterSpacing: 'normal' },
+      titleSm: { fontSize: tokens.typography.titleSm, letterSpacing: 'normal' },
+      text: { fontSize: tokens.typography.text, letterSpacing: 'normal' },
+    },
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            textTransform: 'uppercase',
+            letterSpacing: 0,
+          },
+          contained: {},
+          outlined: {},
+          text: {},
         },
       },
-    },
-    MuiCardHeader: {
-      styleOverrides: {
-        root: {
-          padding: '12px 16px',
-          minHeight: '56px',
-        },
-        content: {
-          overflow: 'hidden',
-        },
-        title: {
-          color: 'inherit',
-        },
-        subheader: {
-          color: 'inherit',
+      MuiInputLabel: {
+        styleOverrides: {
+          root: {
+            color:
+              mode === 'dark'
+                ? 'rgba(255, 255, 255, 0.7)'
+                : 'rgba(0, 0, 0, 0.6)',
+          },
         },
       },
-    },
-    MuiMenuItem: {
-      styleOverrides: {
-        root: {
-          textTransform: 'uppercase',
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            height: 'fit-content',
+          },
         },
       },
-      variants: [
-        {
-          props: { variant: 'navLink' },
-          style: ({ theme }) => ({
-            color: theme.palette.secondary.main,
-            gap: 8,
-            '& .MuiSvgIcon-root': {
+      MuiCardHeader: {
+        styleOverrides: {
+          root: {
+            padding: '12px 16px',
+            minHeight: '56px',
+          },
+          content: {
+            overflow: 'hidden',
+          },
+          title: {
+            color: 'inherit',
+          },
+          subheader: {
+            color: 'inherit',
+          },
+        },
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: {
+            textTransform: 'uppercase',
+          },
+        },
+        variants: [
+          {
+            props: { variant: 'navLink' },
+            style: ({ theme }) => ({
               color: theme.palette.secondary.main,
-            },
-          }),
+              gap: 8,
+              '& .MuiSvgIcon-root': {
+                color: theme.palette.secondary.main,
+              },
+            }),
+          },
+        ],
+      },
+      MuiList: {
+        styleOverrides: {
+          root: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          },
         },
-      ],
-    },
-    MuiList: {
-      styleOverrides: {
-        root: {
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 8,
+      },
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: colorTokens.navbarBg,
+          },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            ...(mode === 'dark' && {
+              backgroundImage: 'none',
+            }),
+          },
+        },
+      },
+      MuiMenu: {
+        styleOverrides: {
+          paper: {
+            ...(mode === 'dark' && {
+              backgroundColor: '#27324e',
+              backgroundImage: 'none',
+            }),
+          },
         },
       },
     },
-  },
-})
+  })
+}
+
+const theme = createAppTheme('light')
 
 export default theme

--- a/web/app/src/theme/theme.ts
+++ b/web/app/src/theme/theme.ts
@@ -56,7 +56,7 @@ export function createAppTheme(mode: 'light' | 'dark') {
         main: mode === 'dark' ? muiColors.blue[400] : muiColors.blue[800],
       },
       secondary: {
-        main: '#42a5f5',
+        main: mode === 'dark' ? '#4db6ac' : '#26a69a',
       },
       ...(mode === 'dark' && {
         background: {
@@ -83,6 +83,12 @@ export function createAppTheme(mode: 'light' | 'dark') {
           outlined: {},
           text: {},
         },
+        variants: [
+          {
+            props: { variant: 'contained', color: 'secondary' },
+            style: { color: '#ffffff' },
+          },
+        ],
       },
       MuiInputLabel: {
         styleOverrides: {

--- a/web/app/src/theme/tokens/colors.ts
+++ b/web/app/src/theme/tokens/colors.ts
@@ -46,7 +46,7 @@ export type ColorsType = {
   nodeSourceBorder: string
 }
 
-export const colors: ColorsType = {
+export const lightColors: ColorsType = {
   // Base
   white: '#ffffff',
   black: '#000000',
@@ -93,5 +93,55 @@ export const colors: ColorsType = {
   nodeSourceBg: '#f97316',
   nodeSourceBorder: '#c2410c',
 }
+
+export const darkColors: ColorsType = {
+  // Base
+  white: '#ffffff',
+  black: '#000000',
+
+  // App layout
+  bodyBg: '#1e1e2e',
+  primary: '#3b82f6',
+  primaryContrast: '#ffffff',
+  toolbarInputBorder: 'rgba(255, 255, 255, 0.23)',
+  cardHeaderBkg: '#1565c0',
+  toolbarBkg: '#1565c0',
+  editorToolbarBkg: '#1565c0',
+  navbarBg: '#073162',
+
+  // Surfaces / neutrals
+  codeBg: '#252535',
+  mutedText: '#94a3b8',
+  borderLight: '#2d3a52',
+  disabledBg: '#252535',
+  selectedBg: '#1e3a8a',
+  selectedBorder: '#3b82f6',
+  labelText: '#cbd5e1',
+
+  // Status
+  statusError: '#f87171',
+  statusSuccess: '#4ade80',
+  shadowOverlay: '#00000088',
+
+  // Switch node chip
+  switchChipBg: '#450a0a',
+  switchChipBorder: '#dc2626',
+
+  // Pipeline nodes
+  nodeRouterBg: '#7e22ce',
+  nodeRouterBorder: '#a855f7',
+  nodeSwitchBg: '#dc2626',
+  nodeSwitchBorder: '#f87171',
+  nodePipelineBg: '#ca8a04',
+  nodePipelineBorder: '#fde047',
+  nodeTransformerBg: '#1d4ed8',
+  nodeTransformerBorder: '#60a5fa',
+  nodeForwarderBg: '#15803d',
+  nodeForwarderBorder: '#4ade80',
+  nodeSourceBg: '#ea580c',
+  nodeSourceBorder: '#fb923c',
+}
+
+export const colors = lightColors
 
 export default colors

--- a/web/app/src/views/PipelineDetailView/styles.tsx
+++ b/web/app/src/views/PipelineDetailView/styles.tsx
@@ -71,7 +71,6 @@ export const PipelineDetailViewLeft = styled('div')(({ theme }) => ({
 export const PipelineDetailViewCenter = styled('div')({
   flex: 1,
   height: '100%',
-  minHeight: 600,
 })
 
 export const PipelineDetailViewRight = styled('div')(({ theme }) => ({

--- a/web/app/src/views/TransformerDetailView/styles.tsx
+++ b/web/app/src/views/TransformerDetailView/styles.tsx
@@ -61,6 +61,8 @@ export const TransformerDetailViewSidebar = styled('div')(({ theme }) => ({
 export const TransformerDetailViewEditor = styled('div')(({ theme }) => ({
   flex: 1,
   height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
   flexDirection: 'column',
   [theme.breakpoints.up('md')]: {
     flexDirection: 'row',


### PR DESCRIPTION
## Decision Record

Closes #513

Adds dark mode support across the full UI. The existing token system (`lightColors` / `darkColors`) was already partially in place — this PR completes it by fixing every component that was still using hardcoded light values.

## Changes

- [x] :sparkles: Theme-aware ApexCharts axis labels via `chart.foreColor`
- [x] :sparkles: Theme-aware Monaco editor (`vrl-theme-dark` based on `vs-dark`)
- [x] :sparkles: Dark mode overrides for AG Grid (`ag-theme-balham` + `ag-theme-material`)
- [x] :sparkles: Pipeline node bodies: hardcoded `white` → `palette.background.paper`
- [x] :sparkles: Panel/sidebar headers: `palette.grey[100]` → `tokens.colors.cardHeaderBkg`
- [x] :sparkles: Pipeline node chips: dynamic MUI color indices (`[900]`/`[300]`) in dark mode
- [x] :sparkles: ReactFlow controls (zoom) dark mode via global CSS overrides
- [x] :bug: Transformer editor output no longer overflows the viewport (`overflow: hidden` + `minHeight: 0`)

## License Agreement

- [x] I guarantee that I have the rights on the code submitted in this PR
- [x] I accept that this contribution will be released under the terms of the MIT License