### PR TITLE
🐛 Preserve scroll position in log viewer watch mode

### DIFF
--- a/web/app/src/components/LogChart/component.tsx
+++ b/web/app/src/components/LogChart/component.tsx
@@ -20,6 +20,7 @@ const LogChart = ({ rowData, from, to }: LogChartProps) => {
       },
       dataLabels: { enabled: false },
       xaxis: { type: 'datetime' },
+      tooltip: { theme: mode, x: { format: 'dd MMM HH:mm:ss' } },
     }),
     [mode]
   )

--- a/web/app/src/components/LogTable/component.tsx
+++ b/web/app/src/components/LogTable/component.tsx
@@ -8,6 +8,7 @@ import { LogTableContainer, LogTableDetailPre, LogTableDrawer } from './styles'
 import { LogTableHandle, LogTableProps } from './types'
 
 const LogTable = forwardRef<LogTableHandle, LogTableProps>((props, ref) => {
+  const containerRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<AgGridReact<LogEntryModel>>(null)
   const [selectedRow, setSelectedRow] = useState<LogEntryModel | undefined>(
     undefined
@@ -20,29 +21,30 @@ const LogTable = forwardRef<LogTableHandle, LogTableProps>((props, ref) => {
         return
       }
 
-      const scrollTop = api.getVerticalPixelRange().top
+      const viewport = containerRef.current?.querySelector<HTMLElement>(
+        '.ag-body-vertical-scroll-viewport'
+      )
+      const scrollTop = viewport?.scrollTop ?? 0
       const atTop = scrollTop <= 1
+      const rowHeight = api.getDisplayedRowAtIndex(0)?.rowHeight ?? 0
 
       api.applyTransaction({ add: rows })
 
-      if (!atTop) {
-        const rowHeight = api.getDisplayedRowAtIndex(0)?.rowHeight ?? 0
-        if (rowHeight > 0) {
-          const firstVisibleIndex = Math.round(scrollTop / rowHeight)
-          api.ensureIndexVisible(firstVisibleIndex + rows.length, 'top')
-        }
+      if (viewport && !atTop && rowHeight > 0) {
+        viewport.scrollTop = scrollTop + rows.length * rowHeight
       }
     },
   }))
 
   return (
-    <LogTableContainer className="ag-theme-balham">
+    <LogTableContainer ref={containerRef} className="ag-theme-balham">
       <AgGridReact<LogEntryModel>
         ref={gridRef}
         rowData={props.rowData}
         columnDefs={props.columnDefs}
         suppressFieldDotNotation
         enableCellTextSelection
+        animateRows={false}
         autoSizeStrategy={{ type: 'fitCellContents' }}
         onRowDoubleClicked={(e) => {
           setSelectedRow(e.data)

--- a/web/app/src/components/LogTable/component.tsx
+++ b/web/app/src/components/LogTable/component.tsx
@@ -1,20 +1,44 @@
-import { useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { AgGridReact } from 'ag-grid-react'
 
 import LogEntryModel from '@/lib/models/LogEntryModel'
 
 import { LogTableContainer, LogTableDetailPre, LogTableDrawer } from './styles'
-import { LogTableProps } from './types'
+import { LogTableHandle, LogTableProps } from './types'
 
-const LogTable = (props: LogTableProps) => {
+const LogTable = forwardRef<LogTableHandle, LogTableProps>((props, ref) => {
+  const gridRef = useRef<AgGridReact<LogEntryModel>>(null)
   const [selectedRow, setSelectedRow] = useState<LogEntryModel | undefined>(
     undefined
   )
 
+  useImperativeHandle(ref, () => ({
+    appendRows: (rows) => {
+      const api = gridRef.current?.api
+      if (!api) {
+        return
+      }
+
+      const scrollTop = api.getVerticalPixelRange().top
+      const atTop = scrollTop <= 1
+
+      api.applyTransaction({ add: rows })
+
+      if (!atTop) {
+        const rowHeight = api.getDisplayedRowAtIndex(0)?.rowHeight ?? 0
+        if (rowHeight > 0) {
+          const firstVisibleIndex = Math.round(scrollTop / rowHeight)
+          api.ensureIndexVisible(firstVisibleIndex + rows.length, 'top')
+        }
+      }
+    },
+  }))
+
   return (
     <LogTableContainer className="ag-theme-balham">
       <AgGridReact<LogEntryModel>
+        ref={gridRef}
         rowData={props.rowData}
         columnDefs={props.columnDefs}
         suppressFieldDotNotation
@@ -35,6 +59,6 @@ const LogTable = (props: LogTableProps) => {
       </LogTableDrawer>
     </LogTableContainer>
   )
-}
+})
 
 export default LogTable

--- a/web/app/src/components/LogTable/types.ts
+++ b/web/app/src/components/LogTable/types.ts
@@ -6,3 +6,7 @@ export type LogTableProps = Readonly<{
   rowData: LogEntryModel[]
   columnDefs: ColDef<LogEntryModel>[]
 }>
+
+export type LogTableHandle = {
+  appendRows: (rows: LogEntryModel[]) => void
+}

--- a/web/app/src/views/StreamDetailView/component.tsx
+++ b/web/app/src/views/StreamDetailView/component.tsx
@@ -92,6 +92,7 @@ const StreamDetailView = () => {
   const logTableRef = useRef<LogTableHandle>(null)
 
   const [rowData, setRowData] = useState<LogEntryModel[]>([])
+  const [chartData, setChartData] = useState<LogEntryModel[]>([])
   const [columnDefs, setColumnDefs] = useState<ColDef<LogEntryModel>[]>([
     timestampColumnDef(),
     ...fields.map(fieldToColumnDef),
@@ -107,6 +108,7 @@ const StreamDetailView = () => {
         selectedIndices
       )
       setRowData(logs)
+      setChartData(logs)
       setTimeWindow({ from, to })
       setWatcher({ enabled: live, filter })
     },
@@ -179,6 +181,7 @@ const StreamDetailView = () => {
 
         if (newRows.length > 0) {
           logTableRef.current?.appendRows(newRows)
+          setChartData((prev) => [...prev, ...newRows])
         }
 
         setColumnDefs(incomingState.columnDefs)
@@ -211,7 +214,7 @@ const StreamDetailView = () => {
           <LogQueryPanel loading={loading} onFetchRequested={fetchLogs} />
           <Divider />
           <LogChart
-            rowData={rowData}
+            rowData={chartData}
             from={timeWindow.from}
             to={timeWindow.to}
           />

--- a/web/app/src/views/StreamDetailView/component.tsx
+++ b/web/app/src/views/StreamDetailView/component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { LoaderFunction, useLoaderData } from 'react-router'
 
 import Divider from '@mui/material/Divider'
@@ -19,6 +19,7 @@ import { loginRequired } from '@/lib/decorators/loaders'
 import LogChart from '@/components/LogChart/component'
 import LogQueryPanel from '@/components/LogQueryPanel/component'
 import LogTable from '@/components/LogTable/component'
+import { LogTableHandle } from '@/components/LogTable/types'
 import SideNavList from '@/components/SideNavList/component'
 import StreamIndexSelector from '@/components/StreamIndexSelector/component'
 
@@ -88,6 +89,8 @@ const StreamDetailView = () => {
     to: new Date(),
   })
 
+  const logTableRef = useRef<LogTableHandle>(null)
+
   const [rowData, setRowData] = useState<LogEntryModel[]>([])
   const [columnDefs, setColumnDefs] = useState<ColDef<LogEntryModel>[]>([
     timestampColumnDef(),
@@ -127,6 +130,8 @@ const StreamDetailView = () => {
         columnDefs,
       }
 
+      const knownFields = new Set(fields)
+
       bus.control.addEventListener('error', (event) => {
         const evt = event as CustomEvent
         handleLiveError(evt.detail)
@@ -145,20 +150,21 @@ const StreamDetailView = () => {
         }
         incomingState.rowData.push(logEntry)
 
-        const allFields = [...fields]
-
+        let fieldsChanged = false
         for (const field of Object.keys(logEntry.fields)) {
-          if (!allFields.includes(field)) {
-            allFields.push(field)
+          if (!knownFields.has(field)) {
+            knownFields.add(field)
+            fieldsChanged = true
           }
         }
 
-        allFields.sort((a, b) => a.localeCompare(b))
-
-        incomingState.columnDefs = [
-          timestampColumnDef(),
-          ...allFields.map(fieldToColumnDef),
-        ]
+        if (fieldsChanged) {
+          const allFields = [...knownFields].sort((a, b) => a.localeCompare(b))
+          incomingState.columnDefs = [
+            timestampColumnDef(),
+            ...allFields.map(fieldToColumnDef),
+          ]
+        }
       })
 
       bus.messages.addEventListener('exception', (event) => {
@@ -168,15 +174,18 @@ const StreamDetailView = () => {
       })
 
       const token = setInterval(() => {
-        setRowData((prev) => {
-          return [...prev, ...incomingState.rowData]
-        })
+        const newRows = incomingState.rowData
+        incomingState.rowData = []
+
+        if (newRows.length > 0) {
+          logTableRef.current?.appendRows(newRows)
+        }
+
         setColumnDefs(incomingState.columnDefs)
         setTimeWindow((prev) => ({
           from: prev.from,
           to: new Date(),
         }))
-        incomingState.rowData = []
       }, 1000)
 
       return () => {
@@ -208,7 +217,7 @@ const StreamDetailView = () => {
           />
         </Paper>
 
-        <LogTable rowData={rowData} columnDefs={columnDefs} />
+        <LogTable ref={logTableRef} rowData={rowData} columnDefs={columnDefs} />
       </StreamDetailViewContent>
 
       {Object.keys(indices).length > 0 && (


### PR DESCRIPTION
## Decision Record

Closes #865.

When new data arrives in Watch mode, the log table was scrolling back to the top on every update. The scroll position is now preserved.

## Changes

- [x] :bug: Preserve scroll position in the log table when new data arrives in Watch mode

## License Agreement
- [x] I guarantee that I have the rights on the code submitted in this PR
- [x] I accept that this contribution will be released under the terms of the MIT License