### PR TITLE
💄 Redesign DynamicField component

### DIFF
--- a/web/app/src/components/DynamicFieldControl/component.tsx
+++ b/web/app/src/components/DynamicFieldControl/component.tsx
@@ -1,84 +1,148 @@
 import { useMemo, useState } from 'react'
 
-import InputAdornment from '@mui/material/InputAdornment'
+import Divider from '@mui/material/Divider'
+import FormControl from '@mui/material/FormControl'
+import FormHelperText from '@mui/material/FormHelperText'
+import InputLabel from '@mui/material/InputLabel'
 import MenuItem from '@mui/material/MenuItem'
-import Select from '@mui/material/Select'
-import TextField from '@mui/material/TextField'
 
 import CodeIcon from '@mui/icons-material/Code'
 import InputIcon from '@mui/icons-material/Input'
 
-import { DynamicFieldControlProps, EditMode } from './types'
+import {
+  DynamicFieldGroupBorder,
+  DynamicFieldGroupRoot,
+  DynamicFieldInput,
+  DynamicFieldModeSelect,
+  DynamicFieldValueSelect,
+} from './styles'
+import { BorderState, DynamicFieldControlProps, EditMode } from './types'
 
 const DynamicFieldControl = <T extends string>(
   props: DynamicFieldControlProps<T>
 ) => {
-  const { value, onChange, select, ...textFieldProps } = props
+  const {
+    value,
+    onChange,
+    select,
+    children,
+    error = false,
+    disabled = false,
+    fullWidth,
+    label,
+    required,
+    id,
+    helperText,
+    multiline,
+    rows,
+    minRows,
+    maxRows,
+    placeholder,
+    type,
+    autoFocus,
+    sx,
+    className,
+  } = props
+
   const [editMode, setEditMode] = useState<EditMode>(
     value.startsWith('@expr:') ? 'dynamic' : 'static'
   )
+  const [focused, setFocused] = useState(false)
 
-  const displayValue = useMemo(() => {
-    if (editMode === 'dynamic') {
-      return value.slice(6)
-    } else {
-      return value as T
-    }
-  }, [editMode, value])
+  const displayValue = useMemo(
+    () => (editMode === 'dynamic' ? value.slice(6) : (value as T)),
+    [editMode, value]
+  )
 
-  const updateValue = (newDisplayValue: string) => {
-    if (editMode === 'dynamic') {
-      onChange(`@expr:${newDisplayValue}`)
-    } else {
-      onChange(newDisplayValue as T)
-    }
+  const shrunk = true
+  const borderState: BorderState = { focused, error, disabled, shrunk }
+  const isSelect = select && editMode === 'static'
+
+  const updateValue = (newVal: string) => {
+    onChange(editMode === 'dynamic' ? `@expr:${newVal}` : (newVal as T))
   }
 
   const switchEditMode = (mode: EditMode) => {
-    setEditMode((prevMode) => {
-      if (prevMode !== mode) {
-        if (mode === 'static') {
-          onChange('' as T)
-        } else if (mode === 'dynamic') {
-          onChange(`@expr:`)
-        }
+    setEditMode((prev) => {
+      if (prev !== mode) {
+        onChange(mode === 'dynamic' ? `@expr:` : ('' as T))
       }
-
       return mode
     })
   }
 
   return (
-    <TextField
-      {...textFieldProps}
-      select={select && editMode === 'static'}
-      value={displayValue}
-      onChange={(e) => {
-        updateValue(e.target.value)
-      }}
-      slotProps={{
-        input: {
-          startAdornment: (
-            <InputAdornment position="start">
-              <Select<EditMode>
-                value={editMode}
-                onChange={(e) => {
-                  switchEditMode(e.target.value as EditMode)
-                }}
-                size="small"
-              >
-                <MenuItem value="static">
-                  <InputIcon fontSize="small" />
-                </MenuItem>
-                <MenuItem value="dynamic">
-                  <CodeIcon fontSize="small" />
-                </MenuItem>
-              </Select>
-            </InputAdornment>
-          ),
-        },
-      }}
-    />
+    <FormControl
+      error={error}
+      disabled={disabled}
+      fullWidth={fullWidth}
+      focused={focused}
+      sx={sx}
+      className={className}
+    >
+      <InputLabel htmlFor={id} shrink={shrunk} required={required}>
+        {label}
+      </InputLabel>
+
+      <DynamicFieldGroupRoot>
+        <DynamicFieldGroupBorder ownerState={borderState} aria-hidden="true">
+          <legend>
+            <span>{label}</span>
+          </legend>
+        </DynamicFieldGroupBorder>
+
+        <DynamicFieldModeSelect
+          value={editMode}
+          onChange={(e) => switchEditMode(e.target.value as EditMode)}
+          onOpen={() => setFocused(true)}
+          onClose={() => setFocused(false)}
+          disabled={disabled}
+          inputProps={{ 'aria-label': 'field mode' }}
+        >
+          <MenuItem value="static">
+            <InputIcon fontSize="small" />
+          </MenuItem>
+          <MenuItem value="dynamic">
+            <CodeIcon fontSize="small" />
+          </MenuItem>
+        </DynamicFieldModeSelect>
+
+        <Divider orientation="vertical" flexItem />
+
+        {isSelect ? (
+          <DynamicFieldValueSelect
+            id={id}
+            value={displayValue}
+            onChange={(e) => updateValue(e.target.value as string)}
+            onOpen={() => setFocused(true)}
+            onClose={() => setFocused(false)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            disabled={disabled}
+          >
+            {children}
+          </DynamicFieldValueSelect>
+        ) : (
+          <DynamicFieldInput
+            id={id}
+            value={displayValue}
+            onChange={(e) => updateValue(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            disabled={disabled}
+            multiline={multiline}
+            rows={rows}
+            minRows={minRows}
+            maxRows={maxRows}
+            placeholder={placeholder}
+            type={type}
+            autoFocus={autoFocus}
+          />
+        )}
+      </DynamicFieldGroupRoot>
+
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </FormControl>
   )
 }
 

--- a/web/app/src/components/DynamicFieldControl/styles.tsx
+++ b/web/app/src/components/DynamicFieldControl/styles.tsx
@@ -1,0 +1,89 @@
+import InputBase from '@mui/material/InputBase'
+import Select from '@mui/material/Select'
+import { alpha, styled } from '@mui/material/styles'
+
+import { BorderState } from './types'
+
+export const DynamicFieldGroupBorder = styled('fieldset')<{
+  ownerState: BorderState
+}>(({ theme, ownerState }) => ({
+  margin: 0,
+  padding: '0 8px',
+  position: 'absolute',
+  inset: '-5px 0 0',
+  border: `${ownerState.focused ? 2 : 1}px solid ${
+    ownerState.error
+      ? theme.palette.error.main
+      : ownerState.focused
+        ? theme.palette.primary.main
+        : ownerState.disabled
+          ? alpha(theme.palette.text.primary, 0.26)
+          : alpha(theme.palette.text.primary, 0.23)
+  }`,
+  borderRadius: `${theme.shape.borderRadius}px`,
+  pointerEvents: 'none',
+
+  '& legend': {
+    display: 'block',
+    float: 'unset',
+    width: 'auto',
+    padding: 0,
+    height: 11,
+    fontSize: '0.75em',
+    visibility: 'hidden',
+    overflow: 'hidden',
+    maxWidth: ownerState.shrunk ? '100%' : '0.01px',
+    transition: 'max-width 100ms cubic-bezier(0.0, 0, 0.2, 1) 50ms',
+    whiteSpace: 'nowrap',
+
+    '& > span': {
+      paddingLeft: '5px',
+      paddingRight: '5px',
+      display: 'inline-block',
+      opacity: 0,
+      visibility: 'visible',
+    },
+  },
+}))
+
+export const DynamicFieldGroupRoot = styled('div')({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'stretch',
+})
+
+const borderlessSelectSx = {
+  '& .MuiOutlinedInput-notchedOutline': { border: 'none' },
+  '&:hover .MuiOutlinedInput-notchedOutline': { border: 'none' },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { border: 'none' },
+} as const
+
+export const DynamicFieldModeSelect = styled(Select)(({ theme }) => ({
+  ...borderlessSelectSx,
+  '& .MuiSelect-select': {
+    display: 'flex',
+    alignItems: 'center',
+    paddingLeft: theme.spacing(1.5),
+    paddingRight: `${theme.spacing(3.5)} !important`,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+}))
+
+export const DynamicFieldInput = styled(InputBase)(({ theme }) => ({
+  flex: 1,
+  '& .MuiInputBase-input': {
+    padding: theme.spacing(1, 1.5),
+  },
+  '& .MuiInputBase-inputMultiline': {
+    padding: 0,
+  },
+}))
+
+export const DynamicFieldValueSelect = styled(Select)(({ theme }) => ({
+  ...borderlessSelectSx,
+  flex: 1,
+  '& .MuiSelect-select': {
+    padding: theme.spacing(1, 1.5),
+  },
+}))

--- a/web/app/src/components/DynamicFieldControl/types.ts
+++ b/web/app/src/components/DynamicFieldControl/types.ts
@@ -11,3 +11,10 @@ export type DynamicFieldControlProps<T extends string> = Omit<
 }
 
 export type EditMode = 'static' | 'dynamic'
+
+export type BorderState = {
+  focused: boolean
+  error: boolean
+  disabled: boolean
+  shrunk: boolean
+}


### PR DESCRIPTION
## Decision Record

Closes #1336.

The DynamicField component embedded the mode selector inside the input field as a MUI adornment.The DynamicField component embedded the mode selector inside the input field as a MUI adornment. It has been redesigned following the Node-RED pattern: the selector now sits to the left of the input as a standalone element.

## Changes

- [x] :lipstick: Redesign `DynamicField` component with selector on the left of the input field

## License Agreement
- [x] I guarantee that I have the rights on the code submitted in this PR
- [x] I accept that this contribution will be released under the terms of the MIT License