### PR TITLE
:card_file_box: Add viewer role to bootstrap roles

### DIFF
--- a/internal/storage/bootstrap/auth.go
+++ b/internal/storage/bootstrap/auth.go
@@ -45,6 +45,17 @@ func DefaultRolesAndUsers(ctx context.Context, authStorage storage.AuthStorage, 
 		if err := authStorage.SaveRole(ctx, adminRole); err != nil {
 			return fmt.Errorf("failed to bootstrap admin role: %w", err)
 		}
+
+		viewerRole := models.Role{
+			Name: "viewer",
+			Scopes: []models.Scope{
+				models.SCOPE_READ_STREAMS,
+			},
+		}
+
+		if err := authStorage.SaveRole(ctx, viewerRole); err != nil {
+			return fmt.Errorf("failed to bootstrap viewer role: %w", err)
+		}
 	}
 
 	users, err := authStorage.ListUsers(ctx)

--- a/internal/storage/bootstrap/auth_test.go
+++ b/internal/storage/bootstrap/auth_test.go
@@ -47,12 +47,36 @@ func TestDefaultRolesAndUsers(t *testing.T) {
 		t.Fatalf("failed to list roles: %v", err)
 	}
 
-	if len(roles) != 1 {
-		t.Fatalf("expected 1 role, got %d", len(roles))
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %d", len(roles))
 	}
 
-	if roles[0].Name != "admin" {
-		t.Fatalf("expected role name to be admin, got %s", roles[0].Name)
+	var adminRole *models.Role
+	var viewerRole *models.Role
+
+	for i := range roles {
+		switch roles[i].Name {
+		case "admin":
+			adminRole = &roles[i]
+		case "viewer":
+			viewerRole = &roles[i]
+		}
+	}
+
+	if adminRole == nil {
+		t.Fatal("expected admin role to exist")
+	}
+
+	if viewerRole == nil {
+		t.Fatal("expected viewer role to exist")
+	}
+
+	if !viewerRole.HasScope(models.SCOPE_READ_STREAMS) {
+		t.Fatal("expected viewer role to have scope read_streams")
+	}
+
+	if viewerRole.HasScope(models.SCOPE_WRITE_STREAMS) {
+		t.Fatal("expected viewer role to NOT have scope write_streams")
 	}
 
 	expected := []models.Scope{
@@ -65,8 +89,8 @@ func TestDefaultRolesAndUsers(t *testing.T) {
 	}
 
 	for _, scope := range expected {
-		if !roles[0].HasScope(scope) {
-			t.Fatalf("expected role to have scope %s", scope)
+		if !adminRole.HasScope(scope) {
+			t.Fatalf("expected admin role to have scope %s", scope)
 		}
 	}
 }

--- a/tests/specs/api/acl_roles.hurl
+++ b/tests/specs/api/acl_roles.hurl
@@ -11,8 +11,9 @@ Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
-jsonpath "$.roles" count == 1
+jsonpath "$.roles" count == 2
 jsonpath "$.roles[*].name" contains "admin"
+jsonpath "$.roles[*].name" contains "viewer"
 
 # -----------------------------------------------------------------------------
 # TEST:
@@ -42,7 +43,7 @@ Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
-jsonpath "$.roles" count == 2
+jsonpath "$.roles" count == 3
 jsonpath "$.roles[*].name" contains "test"
 
 PUT http://localhost:5080/api/v1/users/guest
@@ -96,5 +97,5 @@ Authorization: Bearer {{admin_token}}
 HTTP 200
 [Asserts]
 jsonpath "$.success" == true
-jsonpath "$.roles" count == 1
+jsonpath "$.roles" count == 2
 jsonpath "$.roles[*].name" not contains "test"


### PR DESCRIPTION
## Decision Record

Add a new `viewer` role with the `read_streams` scope during database bootstrap, so that a read-only role is available for users who only need to view logs.

Fixes #1370.

## Changes

- [x] :card_file_box: Add `viewer` role with `SCOPE_READ_STREAMS` in `DefaultRolesAndUsers()` in `internal/app/bootstrap/auth.go`
- [x] :white_check_mark: Update unit test to expect 2 roles (admin + viewer) in `internal/app/bootstrap/auth_test.go`
- [x] :white_check_mark: Update API E2E tests for new role count in `tests/specs/api/acl_roles.hurl`

## License Agreement

- [x] I guarantee that I have the rights on the code submitted in this PR
- [x] I accept that this contribution will be released under the terms of the MIT License