### PR TITLE
:card_file_box: add AuthProvider model for OIDC and SAML (#1373)

### DIFF
--- a/internal/models/auth_provider.go
+++ b/internal/models/auth_provider.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type AuthProvider struct {
+	Name        string             `json:"name" required:"true"`
+	DisplayName string             `json:"display_name" required:"true"`
+	Config      AuthProviderConfig `json:"config" required:"true"`
+}
+
+type AuthProviderConfig struct {
+	Oidc *OidcAuthProvider `json:"-"`
+	Saml *SamlAuthProvider `json:"-"`
+}
+
+// JSONSchemaOneOf advertises every provider variant so the generated OpenAPI
+// schema models Config as a "oneOf".
+func (AuthProviderConfig) JSONSchemaOneOf() []any {
+	return []any{
+		OidcAuthProvider{},
+		SamlAuthProvider{},
+	}
+}
+
+func (cfg *AuthProviderConfig) MarshalJSON() ([]byte, error) {
+	switch {
+	case cfg.Oidc != nil:
+		return json.Marshal(&cfg.Oidc)
+
+	case cfg.Saml != nil:
+		return json.Marshal(&cfg.Saml)
+
+	default:
+		return nil, fmt.Errorf("unsupported auth provider type")
+	}
+}
+
+func (cfg *AuthProviderConfig) UnmarshalJSON(data []byte) error {
+	cfg.Oidc = nil
+	cfg.Saml = nil
+
+	var typeInfo struct {
+		Type string `json:"type" required:"true"`
+	}
+
+	if err := json.Unmarshal(data, &typeInfo); err != nil {
+		return fmt.Errorf("failed to unmarshal auth provider type: %w", err)
+	}
+
+	switch typeInfo.Type {
+	case "oidc":
+		return json.Unmarshal(data, &cfg.Oidc)
+
+	case "saml":
+		return json.Unmarshal(data, &cfg.Saml)
+
+	default:
+		return fmt.Errorf("unsupported auth provider type: %s", typeInfo.Type)
+	}
+}

--- a/internal/models/auth_provider.go
+++ b/internal/models/auth_provider.go
@@ -5,23 +5,28 @@ import (
 	"fmt"
 )
 
+// AuthProvider is the current authentication provider model for delegated
+// authentication. The concrete provider lives in Config, which is a tagged
+// union of one backend type.
 type AuthProvider struct {
 	Name        string             `json:"name" required:"true"`
 	DisplayName string             `json:"display_name" required:"true"`
 	Config      AuthProviderConfig `json:"config" required:"true"`
 }
 
+// AuthProviderConfig is a tagged union: exactly one field is non-nil, selecting
+// the authentication provider backend.
 type AuthProviderConfig struct {
-	Oidc *OidcAuthProvider `json:"-"`
-	Saml *SamlAuthProvider `json:"-"`
+	Oidc *AuthProviderOidc `json:"-"`
+	Saml *AuthProviderSaml `json:"-"`
 }
 
 // JSONSchemaOneOf advertises every provider variant so the generated OpenAPI
 // schema models Config as a "oneOf".
 func (AuthProviderConfig) JSONSchemaOneOf() []any {
 	return []any{
-		OidcAuthProvider{},
-		SamlAuthProvider{},
+		AuthProviderOidc{},
+		AuthProviderSaml{},
 	}
 }
 

--- a/internal/models/auth_provider_oidc.go
+++ b/internal/models/auth_provider_oidc.go
@@ -1,6 +1,8 @@
 package models
 
-type OidcAuthProvider struct {
+// AuthProviderOidc contains the configuration for an OpenID Connect
+// authentication provider.
+type AuthProviderOidc struct {
 	Type         string `json:"type" enum:"oidc" required:"true"`
 	Issuer       string `json:"issuer" required:"true" format:"uri"`
 	ClientID     string `json:"client_id" required:"true"`

--- a/internal/models/auth_provider_oidc.go
+++ b/internal/models/auth_provider_oidc.go
@@ -1,0 +1,8 @@
+package models
+
+type OidcAuthProvider struct {
+	Type         string `json:"type" enum:"oidc" required:"true"`
+	Issuer       string `json:"issuer" required:"true" format:"uri"`
+	ClientID     string `json:"client_id" required:"true"`
+	ClientSecret string `json:"client_secret" required:"true"`
+}

--- a/internal/models/auth_provider_saml.go
+++ b/internal/models/auth_provider_saml.go
@@ -1,6 +1,8 @@
 package models
 
-type SamlAuthProvider struct {
+// AuthProviderSaml contains the configuration for a SAML authentication
+// provider.
+type AuthProviderSaml struct {
 	Type           string `json:"type" enum:"saml" required:"true"`
 	IdpMetadataURL string `json:"idp_metadata_url" required:"true" format:"uri"`
 }

--- a/internal/models/auth_provider_saml.go
+++ b/internal/models/auth_provider_saml.go
@@ -1,0 +1,6 @@
+package models
+
+type SamlAuthProvider struct {
+	Type           string `json:"type" enum:"saml" required:"true"`
+	IdpMetadataURL string `json:"idp_metadata_url" required:"true" format:"uri"`
+}

--- a/internal/models/auth_provider_test.go
+++ b/internal/models/auth_provider_test.go
@@ -11,7 +11,7 @@ func TestAuthProvider_RoundTrip_Oidc(t *testing.T) {
 		Name:        "my-oidc",
 		DisplayName: "My OIDC Provider",
 		Config: AuthProviderConfig{
-			Oidc: &OidcAuthProvider{
+			Oidc: &AuthProviderOidc{
 				Type:         "oidc",
 				Issuer:       "https://accounts.example.com",
 				ClientID:     "client-123",
@@ -40,7 +40,7 @@ func TestAuthProvider_RoundTrip_Saml(t *testing.T) {
 		Name:        "my-saml",
 		DisplayName: "My SAML Provider",
 		Config: AuthProviderConfig{
-			Saml: &SamlAuthProvider{
+			Saml: &AuthProviderSaml{
 				Type:           "saml",
 				IdpMetadataURL: "https://idp.example.com/metadata",
 			},

--- a/internal/models/auth_provider_test.go
+++ b/internal/models/auth_provider_test.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestAuthProvider_RoundTrip_Oidc(t *testing.T) {
+	original := AuthProvider{
+		Name:        "my-oidc",
+		DisplayName: "My OIDC Provider",
+		Config: AuthProviderConfig{
+			Oidc: &OidcAuthProvider{
+				Type:         "oidc",
+				Issuer:       "https://accounts.example.com",
+				ClientID:     "client-123",
+				ClientSecret: "secret-456",
+			},
+		},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("failed to marshal AuthProvider: %v", err)
+	}
+
+	var decoded AuthProvider
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal AuthProvider: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("round-trip mismatch:\n  original = %+v\n  decoded  = %+v", original, decoded)
+	}
+}
+
+func TestAuthProvider_RoundTrip_Saml(t *testing.T) {
+	original := AuthProvider{
+		Name:        "my-saml",
+		DisplayName: "My SAML Provider",
+		Config: AuthProviderConfig{
+			Saml: &SamlAuthProvider{
+				Type:           "saml",
+				IdpMetadataURL: "https://idp.example.com/metadata",
+			},
+		},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("failed to marshal AuthProvider: %v", err)
+	}
+
+	var decoded AuthProvider
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal AuthProvider: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("round-trip mismatch:\n  original = %+v\n  decoded  = %+v", original, decoded)
+	}
+}
+
+func TestAuthProviderConfig_Marshal_NoVariant(t *testing.T) {
+	provider := AuthProvider{Name: "broken", DisplayName: "No variant"}
+	if _, err := json.Marshal(&provider); err == nil {
+		t.Fatal("expected an error marshalling an AuthProvider with no variant, got nil")
+	}
+}


### PR DESCRIPTION
Adds the AuthProvider model for delegated authentication, following the same
encapsulating pattern as the Forwarder configs.

- AuthProvider holds name, display_name, and an optional variant
  (*OidcAuthProvider or *SamlAuthProvider).
- Custom JSON marshalling flattens the active variant with a `type`
  discriminator, mirroring ForwarderConfigV2.
- Added round-trip tests for the OIDC and SAML variants.

Part of the Delegated Authentication milestone; next is the storage CRUD (#1374).

Happy to adjust the JSON shape (e.g. nest the variant under a `config` key
like ForwarderV2) if you'd prefer that layout  let me know.

Closes #1373