### PR TITLE
:construction_worker: :recycle: switch to `pull_request`, thus removing oras and GHCR as cache layer

### DIFF
--- a/.github/actions/setup-testsuite/action.yml
+++ b/.github/actions/setup-testsuite/action.yml
@@ -5,12 +5,6 @@ inputs:
   ref:
     description: Git reference (commit, branch or tag)
     required: true
-  ghactor:
-    description: GitHub Actor
-    required: true
-  ghtoken:
-    description: GitHub Token
-    required: true
 runs:
   using: composite
   steps:
@@ -23,24 +17,18 @@ runs:
       uses: gacts/install-hurl@8c80c69c281b4b618858de1e1a9ce931e9e61c97
       with:
         version: '7.1.0'
-        github-token: ${{ inputs.ghtoken }}
+        github-token: ${{ github.token }}
 
     - name: setup@env
       shell: bash
       working-directory: ./tests
       run: pdm install
 
-    - name: login@docker
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+    - name: download@image
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
-        registry: ghcr.io
-        username: ${{ inputs.ghactor }}
-        password: ${{ inputs.ghtoken }}
+        name: docker-image-${{ inputs.ref }}-linux-amd64
 
-    - name: download@artifacts
+    - name: load@image
       shell: bash
-      env:
-        ARTIFACT_ID: ${{ inputs.ref }}-linux-amd64
-        ARTIFACT_BASENAME: ghcr.io/link-society/flowg/ci-artifacts
-      run: |
-        docker pull ${ARTIFACT_BASENAME}/docker:${ARTIFACT_ID}
+      run: docker load -i image.tar

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -31,65 +31,32 @@ env:
 jobs:
   build:
     runs-on: ${{ inputs.gh-runner }}
-    permissions:
-      packages: write
 
     steps:
-      - name: setup@oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3
-
-      - name: login@oras
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          printf '%s' "${GITHUB_TOKEN}" | oras login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-
-      - name: need-binaries@oras
-        id: need-binaries
-        run: |
-          if oras repo tags ${ARTIFACT_BASENAME}/binaries 2>/dev/null | grep -qx "${ARTIFACT_ID}"
-          then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: need-doc-cli@oras
-        id: need-doc-cli
-        run: |
-          if oras repo tags ${ARTIFACT_BASENAME}/doc-cli 2>/dev/null | grep -qx "${ARTIFACT_ID}"
-          then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: need-doc-openapi@oras
-        id: need-doc-openapi
-        run: |
-          if oras repo tags ${ARTIFACT_BASENAME}/doc-openapi 2>/dev/null | grep -qx "${ARTIFACT_ID}"
-          then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: checkout@scm
-        if: steps.need-binaries.outputs.exists == 'false' || steps.need-doc-cli.outputs.exists == 'false' || steps.need-doc-openapi.outputs.exists == 'false'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref }}
 
+      - name: cache@build
+        id: cache
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        with:
+          key: binaries-${{ env.ARTIFACT_ID }}
+          path: |
+            bin
+            website/docs/technical/cli
+            website/src/openapi.json
+
       - name: setup@buildchain
-        if: steps.need-binaries.outputs.exists == 'false' || steps.need-doc-cli.outputs.exists == 'false' || steps.need-doc-openapi.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-buildchain
         with:
           ghtoken: ${{ secrets.GITHUB_TOKEN }}
           rstarget: ${{ inputs.rust-target }}
 
       - name: build@binary
-        if: steps.need-binaries.outputs.exists == 'false' || steps.need-doc-cli.outputs.exists == 'false' || steps.need-doc-openapi.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: task build:all doc:gen:cli doc:gen:openapi
         env:
           GOOS: ${{ inputs.goos }}
@@ -98,27 +65,30 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "26.0"
 
       - name: compress@binary
-        if: inputs.goos != 'darwin' && (steps.need-binaries.outputs.exists == 'false' || steps.need-doc-cli.outputs.exists == 'false' || steps.need-doc-openapi.outputs.exists == 'false')
+        if: inputs.goos != 'darwin' && steps.cache.outputs.cache-hit != 'true'
         uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368
         with:
           files: bin/*
 
-      - name: upload-binaries@oras
-        if: steps.need-binaries.outputs.exists == 'false'
-        run: |
-          oras push ${ARTIFACT_BASENAME}/binaries:${ARTIFACT_ID} \
-            bin/* LICENSE.txt
+      - name: upload-binaries@artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: binaries-${{ env.ARTIFACT_ID }}
+          path: |
+            bin
+            LICENSE.txt
+          retention-days: 1
 
-      - name: upload-doc-cli
-        if: steps.need-doc-cli.outputs.exists == 'false'
-        run: |
-          oras push ${ARTIFACT_BASENAME}/doc-cli:${ARTIFACT_ID} \
-            website/docs/technical/cli/flowg-client/*.md \
-            website/docs/technical/cli/flowg-health/*.md \
-            website/docs/technical/cli/flowg-server/*.md
+      - name: upload-doc-cli@artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: doc-cli-${{ env.ARTIFACT_ID }}
+          path: website/docs/technical/cli
+          retention-days: 1
 
-      - name: upload-doc-openapi
-        if: steps.need-doc-openapi.outputs.exists == 'false'
-        run: |
-          oras push ${ARTIFACT_BASENAME}/doc-openapi:${ARTIFACT_ID} \
-            website/src/openapi.json
+      - name: upload-doc-openapi@artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: doc-openapi-${{ env.ARTIFACT_ID }}
+          path: website/src/openapi.json
+          retention-days: 1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,50 +27,27 @@ env:
 jobs:
   build:
     runs-on: ${{ inputs.gh-runner }}
-    permissions:
-      packages: write
 
     steps:
-      - name: setup@oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3
-
-      - name: login@oras
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          printf '%s' "${GITHUB_TOKEN}" | oras login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-
-      - name: need-docker@oras
-        id: need-docker
-        run: |
-          if oras repo tags ${ARTIFACT_BASENAME}/docker 2>/dev/null | grep -qx "${ARTIFACT_ID}"
-          then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+      - name: cache@image
+        id: cache
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        with:
+          path: image.tar
+          key: docker-image-${{ env.ARTIFACT_ID }}
 
       - name: checkout@scm
-        if: steps.need-docker.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref }}
 
       - name: setup@docker
-        if: steps.need-docker.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
-      - name: login@docker
-        if: steps.need-docker.outputs.exists == 'false'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: build@docker
-        if: steps.need-docker.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
@@ -79,6 +56,19 @@ jobs:
             UPX_ARCH=${{ inputs.arch }}
             UPX_OS=${{ inputs.os }}
           tags: ${{ env.ARTIFACT_BASENAME }}/docker:${{ env.ARTIFACT_ID }}
-          push: true
+          push: false
+          load: true
           cache-from: type=gha,scope=flowg-${{ inputs.os }}-${{ inputs.arch }}
           cache-to: type=gha,mode=max,scope=flowg-${{ inputs.os }}-${{ inputs.arch }}
+
+      - name: save@image
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: docker save "${ARTIFACT_BASENAME}/docker:${ARTIFACT_ID}" -o image.tar
+
+      - name: upload@artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: docker-image-${{ env.ARTIFACT_ID }}
+          path: image.tar
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,5 +1,5 @@
 ---
-name: build-docker
+name: build-website
 
 on:
   workflow_call:
@@ -15,56 +15,47 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
 
     steps:
-      - name: setup@oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3
-
-      - name: login@oras
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          printf '%s' "${GITHUB_TOKEN}" | oras login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-
-      - name: need-website@oras
-        id: need-website
-        run: |
-          if oras repo tags ${ARTIFACT_BASENAME}/website 2>/dev/null | grep -qx "${ARTIFACT_ID}"
-          then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: checkout@scm
-        if: steps.need-website.outputs.exists == 'false'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref }}
 
+      - name: cache@build
+        id: cache
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        with:
+          key: website-${{ env.ARTIFACT_ID }}
+          path: website/build
+
       - name: setup@buildchain
-        if: steps.need-website.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-buildchain
         with:
           ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: download@oras
-        if: steps.need-website.outputs.exists == 'false'
-        env:
-          DEP_ARTIFACT_ID: ${{ inputs.ref }}-linux-amd64
-        run: |
-          oras pull ${ARTIFACT_BASENAME}/doc-cli:${DEP_ARTIFACT_ID}
-          oras pull ${ARTIFACT_BASENAME}/doc-openapi:${DEP_ARTIFACT_ID}
+      - name: download-doc-cli@artifact
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: doc-cli-${{ inputs.ref }}-linux-amd64
+          path: website/docs/technical/cli
+
+      - name: download-doc-openapi@artifact
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: doc-openapi-${{ inputs.ref }}-linux-amd64
+          path: website/src
 
       - name: build@website
-        if: steps.need-website.outputs.exists == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: task www:build
 
-      - name: upload@oras
-        if: steps.need-website.outputs.exists == 'false'
-        run: |
-          oras push ${ARTIFACT_BASENAME}/website:${ARTIFACT_ID} \
-            website/build
+      - name: upload@artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: website-${{ env.ARTIFACT_ID }}
+          path: website/build
+          retention-days: 1

--- a/.github/workflows/ci-pr-app.yml
+++ b/.github/workflows/ci-pr-app.yml
@@ -2,7 +2,7 @@
 name: ci-pr-app
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/ci-pr-website.yml
+++ b/.github/workflows/ci-pr-website.yml
@@ -2,7 +2,7 @@
 name: ci-pr-website
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,13 +10,11 @@ on:
 
 env:
   ARTIFACT_ID: ${{ inputs.ref }}
-  ARTIFACT_BASENAME: ghcr.io/link-society/flowg/ci-artifacts
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       pages: write
       id-token: write
 
@@ -25,19 +23,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: setup@oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3
-
-      - name: login@oras
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          printf '%s' "${GITHUB_TOKEN}" | oras login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-
-      - name: download@oras
-        run: |
-          oras pull ${ARTIFACT_BASENAME}/website:${ARTIFACT_ID}
+      - name: download@artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: website-${{ env.ARTIFACT_ID }}
+          path: ./website/build
 
       - name: upload@artifacts
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -21,29 +21,18 @@ on:
 
 env:
   ARTIFACT_ID: ${{ inputs.ref }}-${{ inputs.goos }}-${{ inputs.goarch }}
-  ARTIFACT_BASENAME: ghcr.io/link-society/flowg/ci-artifacts
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       contents: write
 
     steps:
-      - name: setup@oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3
-
-      - name: login@oras
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          printf '%s' "${GITHUB_TOKEN}" | oras login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-
-      - name: download@oras
-        run: |
-          oras pull ${ARTIFACT_BASENAME}/binaries:${ARTIFACT_ID}
+      - name: download@artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: binaries-${{ env.ARTIFACT_ID }}
 
       - name: upload@assets
         run: |

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -39,16 +39,15 @@ env:
 jobs:
   publish:
     runs-on: ${{ inputs.gh-runner }}
-    permissions:
-      packages: read
 
     steps:
-      - name: login-ghcr@docker
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+      - name: download@artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: docker-image-${{ env.ARTIFACT_ID }}
+
+      - name: load@image
+        run: docker load -i image.tar
 
       - name: login-dockerhub@docker
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -62,7 +61,6 @@ jobs:
           DOCKERHUB_TAG_LATEST: latest${{ inputs.docker-image-tag-suffix }}
           DOCKERHUB_TAG_VERSION: ${{ inputs.version }}${{ inputs.docker-image-tag-suffix }}
         run: |
-          docker pull ${ARTIFACT_BASENAME}/docker:${ARTIFACT_ID}
           docker tag ${ARTIFACT_BASENAME}/docker:${ARTIFACT_ID} ${DOCKERHUB_REPO}:${DOCKERHUB_TAG_LATEST}
           docker tag ${ARTIFACT_BASENAME}/docker:${ARTIFACT_ID} ${DOCKERHUB_REPO}:${DOCKERHUB_TAG_VERSION}
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,6 @@ jobs:
   api:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       contents: write
       checks: write
       pull-requests: write
@@ -31,8 +30,6 @@ jobs:
         uses: ./.github/actions/setup-testsuite
         with:
           ref: ${{ inputs.ref }}
-          ghactor: ${{ github.actor }}
-          ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run@testsuite
         uses: ./.github/actions/run-hurl-testsuite
@@ -46,7 +43,6 @@ jobs:
   web:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       contents: write
       checks: write
       pull-requests: write
@@ -62,8 +58,6 @@ jobs:
         uses: ./.github/actions/setup-testsuite
         with:
           ref: ${{ inputs.ref }}
-          ghactor: ${{ github.actor }}
-          ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run@testsuite
         uses: ./.github/actions/run-robotframework-testsuite
@@ -77,7 +71,6 @@ jobs:
   k8s:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       contents: write
       checks: write
       pull-requests: write
@@ -93,8 +86,6 @@ jobs:
         uses: ./.github/actions/setup-testsuite
         with:
           ref: ${{ inputs.ref }}
-          ghactor: ${{ github.actor }}
-          ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup@k8s
         uses: ./.github/actions/setup-k8s


### PR DESCRIPTION
## Decision Record

This PR refactors our CI workflow.

We replace `pull_request_target` with `pull_request` so fork PRs run with a read-only token and get GitHub's native "require approval for outside collaborators" gate, solving the privilege-escalation risk that made the old setup dangerous.

Oras (with GHCR) was only used to pass build outputs between jobs. The actions `actions/upload-artifact` and `actions/download-artifact` do the same without needing a registry or write permissions (which fork tokens don't have anyway).

Finally, `actions/cache` (plus the existing buildx `type=gha` layer cache) can be used to skip rebuilds on unchanged refs.

## Changes

 - [x] :lock: Use `pull_request` instead of `pull_request_target`
 - [x] :fire: Remove oras/GHCR everywhere
 - [x] :package: Hand off builds via `actions/upload-artifact` and `actions/download-artifact`.
 - [x] :zap: Cache builds with `actions/cache`.
 - [x] :closed_lock_with_key: Drop unused packages: permissions and inputs.

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
