### PR TITLE
:recycle: Avoid test dependencies in final executable

### DIFF
--- a/api/middlewares/elastic.go
+++ b/api/middlewares/elastic.go
@@ -36,7 +36,7 @@ type ElasticDeps struct {
 
 func init() {
 	routing.RegisterMiddleware(
-		newElasticHandler,
+		NewElasticHandler,
 		"/api/v1/middlewares/elastic/",
 	)
 }
@@ -96,10 +96,10 @@ func elasticAuth(deps ElasticDeps, next http.Handler) http.Handler {
 	})
 }
 
-// newElasticHandler serves the subset of the Elasticsearch API that log
+// NewElasticHandler serves the subset of the Elasticsearch API that log
 // shippers exercise: checking that an index (a FlowG pipeline) exists, and
 // indexing a document (running a log record through that pipeline).
-func newElasticHandler(deps ElasticDeps) http.Handler {
+func NewElasticHandler(deps ElasticDeps) http.Handler {
 	logger := slog.Default().With(slog.String("channel", "input.middleware.elastic"))
 	mux := http.NewServeMux()
 

--- a/api/middlewares/elastic_test.go
+++ b/api/middlewares/elastic_test.go
@@ -1,4 +1,4 @@
-package middlewares
+package middlewares_test
 
 import (
 	"testing"
@@ -15,6 +15,8 @@ import (
 	"link-society.com/flowg/internal/engines/pipelines"
 	"link-society.com/flowg/internal/models"
 	"link-society.com/flowg/internal/storage"
+
+	"link-society.com/flowg/api/middlewares"
 )
 
 func TestElasticEndpoint(t *testing.T) {
@@ -22,7 +24,7 @@ func TestElasticEndpoint(t *testing.T) {
 	mockConfigStorage := storage.NewMockConfigStorage().(*storage.MockConfigStorage)
 	mockPipelineRunner := pipelines.NewMockRunner().(*pipelines.MockRunner)
 
-	deps := ElasticDeps{
+	deps := middlewares.ElasticDeps{
 		AuthStorage:    mockAuthStorage,
 		ConfigStorage:  mockConfigStorage,
 		PipelineRunner: mockPipelineRunner,
@@ -47,7 +49,7 @@ func TestElasticEndpoint(t *testing.T) {
 	mockPipelineRunner.On("Run", mock.Anything, "test", pipelines.DIRECT_ENTRYPOINT, mock.Anything).
 		Return(nil)
 
-	handler := newElasticHandler(deps)
+	handler := middlewares.NewElasticHandler(deps)
 
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/internal/models/auth_provider_test.go
+++ b/internal/models/auth_provider_test.go
@@ -1,17 +1,20 @@
-package models
+package models_test
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
+
+	"encoding/json"
+
+	"link-society.com/flowg/internal/models"
 )
 
 func TestAuthProvider_RoundTrip_Oidc(t *testing.T) {
-	original := AuthProvider{
+	original := models.AuthProvider{
 		Name:        "my-oidc",
 		DisplayName: "My OIDC Provider",
-		Config: AuthProviderConfig{
-			Oidc: &AuthProviderOidc{
+		Config: models.AuthProviderConfig{
+			Oidc: &models.AuthProviderOidc{
 				Type:         "oidc",
 				Issuer:       "https://accounts.example.com",
 				ClientID:     "client-123",
@@ -25,7 +28,7 @@ func TestAuthProvider_RoundTrip_Oidc(t *testing.T) {
 		t.Fatalf("failed to marshal AuthProvider: %v", err)
 	}
 
-	var decoded AuthProvider
+	var decoded models.AuthProvider
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("failed to unmarshal AuthProvider: %v", err)
 	}
@@ -36,11 +39,11 @@ func TestAuthProvider_RoundTrip_Oidc(t *testing.T) {
 }
 
 func TestAuthProvider_RoundTrip_Saml(t *testing.T) {
-	original := AuthProvider{
+	original := models.AuthProvider{
 		Name:        "my-saml",
 		DisplayName: "My SAML Provider",
-		Config: AuthProviderConfig{
-			Saml: &AuthProviderSaml{
+		Config: models.AuthProviderConfig{
+			Saml: &models.AuthProviderSaml{
 				Type:           "saml",
 				IdpMetadataURL: "https://idp.example.com/metadata",
 			},
@@ -52,7 +55,7 @@ func TestAuthProvider_RoundTrip_Saml(t *testing.T) {
 		t.Fatalf("failed to marshal AuthProvider: %v", err)
 	}
 
-	var decoded AuthProvider
+	var decoded models.AuthProvider
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("failed to unmarshal AuthProvider: %v", err)
 	}
@@ -63,7 +66,7 @@ func TestAuthProvider_RoundTrip_Saml(t *testing.T) {
 }
 
 func TestAuthProviderConfig_Marshal_NoVariant(t *testing.T) {
-	provider := AuthProvider{Name: "broken", DisplayName: "No variant"}
+	provider := models.AuthProvider{Name: "broken", DisplayName: "No variant"}
 	if _, err := json.Marshal(&provider); err == nil {
 		t.Fatal("expected an error marshalling an AuthProvider with no variant, got nil")
 	}

--- a/internal/models/flow_convert.go
+++ b/internal/models/flow_convert.go
@@ -82,7 +82,7 @@ func flowGraphFromV2ToV2m1(objV2 *FlowGraphV2) (*FlowGraphV2, error) {
 	for _, nodeV2 := range objV2.Nodes {
 		if nodeV2.Type == "switch" {
 			if condition, exists := nodeV2.Data["condition"]; exists {
-				translated, err := convertFilterdslToExprlang(condition)
+				translated, err := ConvertFilterdslToExprlang(condition)
 				if err != nil {
 					return nil, err
 				}
@@ -145,10 +145,10 @@ func flowGraphFromV1ToV2(objV1 *FlowGraphV1) *FlowGraphV2 {
 	return objV2
 }
 
-// convertFilterdslToExprlang rewrites a legacy filter-DSL expression into an
+// ConvertFilterdslToExprlang rewrites a legacy filter-DSL expression into an
 // equivalent expr-lang one, the only structural change being the single "="
 // equality operator becoming "==".
-func convertFilterdslToExprlang(input string) (string, error) {
+func ConvertFilterdslToExprlang(input string) (string, error) {
 	tokens, err := lexer.Lex(file.NewSource(input))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse expression: %v", err)

--- a/internal/models/flow_convert_test.go
+++ b/internal/models/flow_convert_test.go
@@ -1,7 +1,9 @@
-package models
+package models_test
 
 import (
 	"testing"
+
+	"link-society.com/flowg/internal/models"
 )
 
 func TestConvert_FilterDSL_to_ExprLang(t *testing.T) {
@@ -25,7 +27,7 @@ func TestConvert_FilterDSL_to_ExprLang(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := convertFilterdslToExprlang(tc.input)
+			got, err := models.ConvertFilterdslToExprlang(tc.input)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/storage/backends/badger/concrete/config/system_cofiguration_test.go
+++ b/internal/storage/backends/badger/concrete/config/system_cofiguration_test.go
@@ -1,4 +1,4 @@
-package config
+package config_test
 
 import (
 	"testing"
@@ -7,19 +7,21 @@ import (
 	"go.uber.org/fx/fxtest"
 
 	"link-society.com/flowg/internal/storage"
+
+	"link-society.com/flowg/internal/storage/backends/badger/concrete/config"
 )
 
 func TestReadSystemConfig(t *testing.T) {
 	ctx := t.Context()
 
-	confOpts := DefaultOptions()
+	confOpts := config.DefaultOptions()
 	confOpts.InMemory = true
 
 	var confStorage storage.ConfigStorage
 
 	app := fxtest.New(
 		t,
-		NewStorage(confOpts),
+		config.NewStorage(confOpts),
 		fx.Populate(&confStorage),
 		fx.NopLogger,
 	)


### PR DESCRIPTION
## Decision Record

When writing unit tests, we should always use:

```go
package foo_test
```

This will avoid embedding test dependencies in the final executable.

## Changes

 - [x] :recycle: Avoid test dependencies in final executable
 - [x] :recycle: Make some function public so they are accessible by the unit tests

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
