### PR TITLE
:bug: :wrench: vite config overwrote feature flags and mount path

### DIFF
--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -32,10 +32,20 @@ export default defineConfig({
     },
     {
       name: 'go-template-substitution',
-      transformIndexHtml(html) {
-        return html
-          .replace(/\{\{\s*\.MountPath\s*\}\}/g, '')
-          .replace(/\{\{\s*\.FeatureFlags\.DemoMode\s*\}\}/g, 'false')
+      transformIndexHtml: {
+        order: 'pre',
+        handler(html, ctx) {
+          // Only substitute Go template placeholders when running the Vite dev
+          // server. During a production build the placeholders must be left
+          // intact so the Go backend can inject the real values at runtime.
+          if (!ctx.server) {
+            return html
+          }
+
+          return html
+            .replace(/\{\{\s*\.MountPath\s*\}\}/g, '')
+            .replace(/\{\{\s*\.FeatureFlags\.DemoMode\s*\}\}/g, 'false')
+        },
       },
     },
   ],


### PR DESCRIPTION
## Decision Record

To improve developer experience, we added support for the Vite dev server, avoiding a rebuild of FlowG for every tiny change in the web application.

However, this broke the mount path and demo feature flag, as it was always rewritten.

## Changes

 - [x] :bug: :wrench: Substitue Go template directives only when running `vite dev`

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
