### PR TITLE
:card_file_box: Add default roles field to System Configuration

### DIFF
--- a/cmd/flowg-client/cmd/cmd_systemconfig_update.go
+++ b/cmd/flowg-client/cmd/cmd_systemconfig_update.go
@@ -20,6 +20,7 @@ func NewSystemConfigUpdateCommand() *cobra.Command {
 	type options struct {
 		SyslogAllowedOrigins []string
 		SyslogAllowAll       bool
+		DefaultRoles         []string
 	}
 
 	opts := &options{}
@@ -66,6 +67,10 @@ func NewSystemConfigUpdateCommand() *cobra.Command {
 				data.Configuration.SyslogAllowedOrigins = []string{}
 			}
 
+			if cmd.Flags().Changed("default-role") {
+				data.Configuration.DefaultRoles = opts.DefaultRoles
+			}
+
 			payload, err := json.Marshal(data.Configuration)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "ERROR: Could not encode request body: %v\n", err)
@@ -108,6 +113,13 @@ func NewSystemConfigUpdateCommand() *cobra.Command {
 		"syslog-allow-all",
 		false,
 		"Allow all origins for syslog (overrides --syslog-allowed-origin)",
+	)
+
+	cmd.Flags().StringArrayVar(
+		&opts.DefaultRoles,
+		"default-role",
+		[]string{},
+		"List of default roles assigned to new users",
 	)
 
 	return cmd

--- a/internal/app/server/bootstrap.go
+++ b/internal/app/server/bootstrap.go
@@ -28,23 +28,23 @@ type bootstrapHandler struct {
 	resetPassword string
 }
 
-// Run applies all bootstrap steps in order: default system configuration,
-// default roles and users, default pipeline, and the optional user-password
-// reset. It is invoked from the module's OnStart lifecycle hook.
+// Run applies all bootstrap steps in order: default roles and users,
+// default system configuration, default pipeline, and the optional
+// user-password reset. It is invoked from the module's OnStart lifecycle hook.
 func (h *bootstrapHandler) Run(ctx context.Context) error {
-	err := bootstrap.DefaultSystemConfig(ctx, h.configStorage, bootstrap.BootstrapSystemOptions{
-		InitialSyslogAllowedOrigins: h.initialSyslogAllowedOrigins,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to bootstrap default system config: %w", err)
-	}
-
-	err = bootstrap.DefaultRolesAndUsers(ctx, h.authStorage, bootstrap.BootstrapAuthOptions{
+	err := bootstrap.DefaultRolesAndUsers(ctx, h.authStorage, bootstrap.BootstrapAuthOptions{
 		InitialUser:     h.initialUser,
 		InitialPassword: h.initialPassword,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap default roles and users: %w", err)
+	}
+
+	err = bootstrap.DefaultSystemConfig(ctx, h.configStorage, bootstrap.BootstrapSystemOptions{
+		InitialSyslogAllowedOrigins: h.initialSyslogAllowedOrigins,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to bootstrap default system config: %w", err)
 	}
 
 	err = bootstrap.DefaultPipeline(ctx, h.configStorage)

--- a/internal/models/system_configuration.go
+++ b/internal/models/system_configuration.go
@@ -2,6 +2,8 @@ package models
 
 // SystemConfiguration holds the global, server-wide settings. SyslogAllowedOrigins
 // restricts which source IPs or CIDR ranges may push logs to the syslog endpoint.
+// DefaultRoles defines the default roles assigned to new users.
 type SystemConfiguration struct {
 	SyslogAllowedOrigins []string `json:"syslog_allowed_origins"`
+	DefaultRoles         []string `json:"default_roles"`
 }

--- a/internal/storage/backends/badger/concrete/config/system_cofiguration_test.go
+++ b/internal/storage/backends/badger/concrete/config/system_cofiguration_test.go
@@ -83,4 +83,32 @@ func TestReadSystemConfig(t *testing.T) {
 	if systemConfig.SyslogAllowedOrigins[0] != "192.168.1.1" {
 		t.Fatal("systemConfig.AllowedOrigins[0] != 192.168.1.1")
 	}
+
+	systemConfig.DefaultRoles = []string{"viewer", "admin"}
+
+	if err := confStorage.WriteSystemConfig(ctx, systemConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	systemConfig, err = confStorage.ReadSystemConfig(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if systemConfig == nil {
+		t.Fatal("systemConfig is nil")
+	}
+
+	if len(systemConfig.DefaultRoles) != 2 {
+		t.Fatalf("len(DefaultRoles) = %d != 2", len(systemConfig.DefaultRoles))
+	}
+
+	if systemConfig.DefaultRoles[0] != "viewer" {
+		t.Fatal("systemConfig.DefaultRoles[0] != viewer")
+	}
+
+	if systemConfig.DefaultRoles[1] != "admin" {
+		t.Fatal("systemConfig.DefaultRoles[1] != admin")
+	}
 }

--- a/internal/storage/bootstrap/system.go
+++ b/internal/storage/bootstrap/system.go
@@ -21,6 +21,7 @@ func DefaultSystemConfig(ctx context.Context, configStorage storage.ConfigStorag
 	if !hasConfig {
 		defaultConfig := &models.SystemConfiguration{
 			SyslogAllowedOrigins: opts.InitialSyslogAllowedOrigins,
+			DefaultRoles:         []string{"viewer"},
 		}
 
 		if err := configStorage.WriteSystemConfig(ctx, defaultConfig); err != nil {

--- a/internal/storage/bootstrap/system_test.go
+++ b/internal/storage/bootstrap/system_test.go
@@ -51,4 +51,12 @@ func TestDefaultSystemConfig(t *testing.T) {
 	if systemConfig.SyslogAllowedOrigins[0] != "127.0.0.1" {
 		t.Fatalf("expected allowed origin to be 127.0.0.1, got %s", systemConfig.SyslogAllowedOrigins[0])
 	}
+
+	if len(systemConfig.DefaultRoles) != 1 {
+		t.Fatalf("expected 1 default role, got %d", len(systemConfig.DefaultRoles))
+	}
+
+	if systemConfig.DefaultRoles[0] != "viewer" {
+		t.Fatalf("expected default role to be viewer, got %s", systemConfig.DefaultRoles[0])
+	}
 }

--- a/tests/specs/api/system_configuration.hurl
+++ b/tests/specs/api/system_configuration.hurl
@@ -12,6 +12,8 @@ HTTP 200
 [Asserts]
 jsonpath "$.success" == true
 jsonpath "$.configuration.syslog_allowed_origins" count == 0
+jsonpath "$.configuration.default_roles" count == 1
+jsonpath "$.configuration.default_roles[0]" == "viewer"
 
 # -----------------------------------------------------------------------------
 # TEST:
@@ -23,6 +25,10 @@ Content-Type: application/json
 {
   "syslog_allowed_origins": [
     "192.168.1.1"
+  ],
+  "default_roles": [
+    "viewer",
+    "admin"
   ]
 }
 HTTP 200
@@ -40,3 +46,6 @@ HTTP 200
 jsonpath "$.success" == true
 jsonpath "$.configuration.syslog_allowed_origins" count == 1
 jsonpath "$.configuration.syslog_allowed_origins[0]" == "192.168.1.1"
+jsonpath "$.configuration.default_roles" count == 2
+jsonpath "$.configuration.default_roles[0]" == "viewer"
+jsonpath "$.configuration.default_roles[1]" == "admin"

--- a/web/app/src/components/ButtonNewUser/component.tsx
+++ b/web/app/src/components/ButtonNewUser/component.tsx
@@ -12,12 +12,12 @@ import DialogNewUser from '@/components/DialogNewUser/component'
 
 import { ButtonNewUserProps } from './types'
 
-const ButtonNewUser = ({ roles, onUserCreated }: ButtonNewUserProps) => {
+const ButtonNewUser = ({ roles, defaultRoles, onUserCreated }: ButtonNewUserProps) => {
   const dialogs = useDialogs()
   const notify = useNotify()
 
   const [handleClick] = useApiOperation(async () => {
-    const user = (await dialogs.open(DialogNewUser, roles)) as UserModel | null
+    const user = (await dialogs.open(DialogNewUser, { roles, defaultRoles })) as UserModel | null
     if (user !== null) {
       onUserCreated(user)
       notify.success('User created')

--- a/web/app/src/components/ButtonNewUser/component.tsx
+++ b/web/app/src/components/ButtonNewUser/component.tsx
@@ -12,12 +12,19 @@ import DialogNewUser from '@/components/DialogNewUser/component'
 
 import { ButtonNewUserProps } from './types'
 
-const ButtonNewUser = ({ roles, defaultRoles, onUserCreated }: ButtonNewUserProps) => {
+const ButtonNewUser = ({
+  roles,
+  defaultRoles,
+  onUserCreated,
+}: ButtonNewUserProps) => {
   const dialogs = useDialogs()
   const notify = useNotify()
 
   const [handleClick] = useApiOperation(async () => {
-    const user = (await dialogs.open(DialogNewUser, { roles, defaultRoles })) as UserModel | null
+    const user = (await dialogs.open(DialogNewUser, {
+      roles,
+      defaultRoles,
+    })) as UserModel | null
     if (user !== null) {
       onUserCreated(user)
       notify.success('User created')

--- a/web/app/src/components/ButtonNewUser/types.ts
+++ b/web/app/src/components/ButtonNewUser/types.ts
@@ -2,5 +2,6 @@ import UserModel from '@/lib/models/UserModel'
 
 export type ButtonNewUserProps = Readonly<{
   roles: string[]
+  defaultRoles: string[]
   onUserCreated: (user: UserModel) => void
 }>

--- a/web/app/src/components/DialogNewUser/component.tsx
+++ b/web/app/src/components/DialogNewUser/component.tsx
@@ -30,7 +30,10 @@ const DialogNewUser = ({
   open,
   payload,
   onClose,
-}: DialogProps<{ roles: string[]; defaultRoles: string[] }, UserModel | null>) => {
+}: DialogProps<
+  { roles: string[]; defaultRoles: string[] },
+  UserModel | null
+>) => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [roles, setRoles] = useState<string[]>(payload.defaultRoles)

--- a/web/app/src/components/DialogNewUser/component.tsx
+++ b/web/app/src/components/DialogNewUser/component.tsx
@@ -30,10 +30,10 @@ const DialogNewUser = ({
   open,
   payload,
   onClose,
-}: DialogProps<string[], UserModel | null>) => {
+}: DialogProps<{ roles: string[]; defaultRoles: string[] }, UserModel | null>) => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
-  const [roles, setRoles] = useState<string[]>([])
+  const [roles, setRoles] = useState<string[]>(payload.defaultRoles)
 
   const [onSubmit, loading] = useApiOperation(async () => {
     const user = {
@@ -95,7 +95,8 @@ const DialogNewUser = ({
           <FieldStack id="field:admin.users.modal.roles">
             <FieldLabel variant="text">Roles:</FieldLabel>
             <InputTransferList<string>
-              choices={payload}
+              choices={payload.roles}
+              selected={payload.defaultRoles}
               getItemId={(v) => v}
               renderItem={(v) => (
                 <Tooltip title={v} placement="right-start">

--- a/web/app/src/components/InputTransferList/component.tsx
+++ b/web/app/src/components/InputTransferList/component.tsx
@@ -42,8 +42,11 @@ const intersection = <T,>(
 
 const InputTransferList = <T,>(props: InputTransferListProps<T>) => {
   const [checked, setChecked] = useState<T[]>([])
-  const [left, setLeft] = useState<T[]>(props.choices)
-  const [right, setRight] = useState<T[]>([])
+  const initialLeft = props.selected
+    ? not(props.choices, props.selected, props.getItemId)
+    : props.choices
+  const [left, setLeft] = useState<T[]>(initialLeft)
+  const [right, setRight] = useState<T[]>(props.selected ?? [])
 
   useEffect(() => props.onChoiceUpdate(right), [right])
 

--- a/web/app/src/components/InputTransferList/types.ts
+++ b/web/app/src/components/InputTransferList/types.ts
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 export type InputTransferListProps<T> = Readonly<{
   choices: T[]
+  selected?: T[]
   getItemId: (item: T) => string
   renderItem: (item: T) => ReactNode
   onChoiceUpdate: (choices: readonly T[]) => void

--- a/web/app/src/components/UserTable/component.tsx
+++ b/web/app/src/components/UserTable/component.tsx
@@ -39,7 +39,7 @@ const RolesCell = (props: RolesCellProps) => (
   </RolesCellRoot>
 )
 
-const UserTable = ({ roles, users }: UserTableProps) => {
+const UserTable = ({ roles, users, defaultRoles }: UserTableProps) => {
   const { permissions } = useProfile()
   const notify = useNotify()
 
@@ -120,7 +120,7 @@ const UserTable = ({ roles, users }: UserTableProps) => {
               <Typography variant="titleSm">Users</Typography>
             </UserTableCardHeaderTitleText>
             {permissions.can_edit_acls && (
-              <ButtonNewUser roles={roles} onUserCreated={onNewUser} />
+              <ButtonNewUser roles={roles} defaultRoles={defaultRoles} onUserCreated={onNewUser} />
             )}
           </UserTableCardHeaderTitle>
         }

--- a/web/app/src/components/UserTable/component.tsx
+++ b/web/app/src/components/UserTable/component.tsx
@@ -120,7 +120,11 @@ const UserTable = ({ roles, users, defaultRoles }: UserTableProps) => {
               <Typography variant="titleSm">Users</Typography>
             </UserTableCardHeaderTitleText>
             {permissions.can_edit_acls && (
-              <ButtonNewUser roles={roles} defaultRoles={defaultRoles} onUserCreated={onNewUser} />
+              <ButtonNewUser
+                roles={roles}
+                defaultRoles={defaultRoles}
+                onUserCreated={onNewUser}
+              />
             )}
           </UserTableCardHeaderTitle>
         }

--- a/web/app/src/components/UserTable/types.ts
+++ b/web/app/src/components/UserTable/types.ts
@@ -3,4 +3,5 @@ import UserModel from '@/lib/models/UserModel'
 export type UserTableProps = Readonly<{
   roles: string[]
   users: UserModel[]
+  defaultRoles: string[]
 }>

--- a/web/app/src/lib/models/SystemConfigurationModel.ts
+++ b/web/app/src/lib/models/SystemConfigurationModel.ts
@@ -1,5 +1,6 @@
 type SystemConfigurationModel = {
   syslog_allowed_origins: string[]
+  default_roles: string[]
 }
 
 export default SystemConfigurationModel

--- a/web/app/src/views/AdminView/component.tsx
+++ b/web/app/src/views/AdminView/component.tsx
@@ -1,6 +1,7 @@
 import { LoaderFunction, useLoaderData } from 'react-router'
 
 import * as aclApi from '@/lib/api/operations/acls'
+import { getSystemConfiguration } from '@/lib/api/operations/config'
 
 import { loginRequired } from '@/lib/decorators/loaders'
 
@@ -12,17 +13,18 @@ import { LoaderData } from './types'
 
 export const loader: LoaderFunction = loginRequired(
   async (): Promise<LoaderData> => {
-    const [roles, users] = await Promise.all([
+    const [roles, users, systemConfig] = await Promise.all([
       aclApi.listRoles(),
       aclApi.listUsers(),
+      getSystemConfiguration(),
     ])
 
-    return { roles, users }
+    return { roles, users, defaultRoles: systemConfig.default_roles ?? [] }
   }
 )
 
 const AdminView = () => {
-  const { roles, users } = useLoaderData() as LoaderData
+  const { roles, users, defaultRoles } = useLoaderData() as LoaderData
 
   return (
     <AdminViewContainer variant="page">
@@ -30,7 +32,7 @@ const AdminView = () => {
         <RoleTable roles={roles} />
       </AdminViewPanel>
       <AdminViewPanel>
-        <UserTable roles={roles.map((role) => role.name)} users={users} />
+        <UserTable roles={roles.map((role) => role.name)} users={users} defaultRoles={defaultRoles} />
       </AdminViewPanel>
     </AdminViewContainer>
   )

--- a/web/app/src/views/AdminView/component.tsx
+++ b/web/app/src/views/AdminView/component.tsx
@@ -32,7 +32,11 @@ const AdminView = () => {
         <RoleTable roles={roles} />
       </AdminViewPanel>
       <AdminViewPanel>
-        <UserTable roles={roles.map((role) => role.name)} users={users} defaultRoles={defaultRoles} />
+        <UserTable
+          roles={roles.map((role) => role.name)}
+          users={users}
+          defaultRoles={defaultRoles}
+        />
       </AdminViewPanel>
     </AdminViewContainer>
   )

--- a/web/app/src/views/AdminView/types.ts
+++ b/web/app/src/views/AdminView/types.ts
@@ -4,4 +4,5 @@ import UserModel from '@/lib/models/UserModel'
 export type LoaderData = {
   roles: RoleModel[]
   users: UserModel[]
+  defaultRoles: string[]
 }

--- a/web/app/src/views/SystemConfiguration/component.tsx
+++ b/web/app/src/views/SystemConfiguration/component.tsx
@@ -64,6 +64,23 @@ const SystemConfiguration = () => {
           </SystemConfigurationCardContent>
         </SystemConfigurationCard>
 
+        <SystemConfigurationCard>
+          <SystemConfigurationCardHeader>
+            <SystemConfigurationCardTitle variant="titleSm">
+              Default Roles for New Users
+            </SystemConfigurationCardTitle>
+          </SystemConfigurationCardHeader>
+          <SystemConfigurationCardContent>
+            <ListEdit
+              id="editor.config.default_roles"
+              list={config.default_roles ?? []}
+              setList={(list) =>
+                setConfig({ ...config, default_roles: list })
+              }
+            />
+          </SystemConfigurationCardContent>
+        </SystemConfigurationCard>
+
         <Button
           variant="contained"
           color="secondary"

--- a/web/app/src/views/SystemConfiguration/component.tsx
+++ b/web/app/src/views/SystemConfiguration/component.tsx
@@ -74,9 +74,7 @@ const SystemConfiguration = () => {
             <ListEdit
               id="editor.config.default_roles"
               list={config.default_roles ?? []}
-              setList={(list) =>
-                setConfig({ ...config, default_roles: list })
-              }
+              setList={(list) => setConfig({ ...config, default_roles: list })}
             />
           </SystemConfigurationCardContent>
         </SystemConfigurationCard>


### PR DESCRIPTION
Closes #1371

## Summary

Adds a `DefaultRoles` field to the `SystemConfiguration` model so that administrators can configure which roles are automatically assigned to new users. The default value is `["viewer"]` during bootstrap.

## Changes

- :sparkles: **Backend**
    - **Model** — Added `DefaultRoles []string` field to `SystemConfiguration`
    - **Bootstrap** — Default config now writes `DefaultRoles: ["viewer"]` on first boot
    - **Bootstrap order** — `DefaultRolesAndUsers` now runs before `DefaultSystemConfig` (so the `viewer` role exists before the config references it)
    - **CLI** — Added `--default-role` flag to `flowg-client systemconfig update`
    - **Tests** — Round-trip test in the config backend; bootstrap test verifies `["viewer"]` default
- :sparkles: **Frontend**
    - **System configuration page** — New "Default Roles for New Users" card using the same `ListEdit` pattern as the existing "Allowed Syslog Origins" card
    - **Create user dialog** — Pre-fills the role transfer list with the configured default roles
    - **InputTransferList** — Added optional `selected` prop for initializing the right pane with pre-selected items
- :sparkles: **API**
    - No changes needed — the API uses a type alias (`UpdateSystemConfigurationRequest = models.SystemConfiguration`), so the new field flows through automatically
   
<img width="1671" height="1519" alt="PR-FlowG" src="https://github.com/user-attachments/assets/6099d567-eeb8-47f5-a3af-02cdd7e5dbd2" />

## Decision Record

- No validation at write time (roles are plain string labels)
- Empty default roles list = no pre-selected roles for new users (no fallback)
- Same `SCOPE_WRITE_SYSTEM_CONFIGURATION` scope
- Web UI and CLI both support configuring the field

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License