### PR TITLE
:boom: :lock: :zap: Better password and token hashing

### DIFF
--- a/internal/storage/backends/badger/concrete/auth/token_test.go
+++ b/internal/storage/backends/badger/concrete/auth/token_test.go
@@ -1,0 +1,107 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/cmd/flowg-server/logging"
+	"link-society.com/flowg/internal/models"
+
+	badgerauth "link-society.com/flowg/internal/storage/backends/badger/concrete/auth"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+func newAuthStorage(t *testing.T) (context.Context, storage.AuthStorage) {
+	t.Helper()
+	logging.Discard()
+
+	opts := badgerauth.DefaultOptions()
+	opts.InMemory = true
+
+	var authStorage storage.AuthStorage
+
+	app := fxtest.New(
+		t,
+		badgerauth.NewStorage(opts),
+		fx.Populate(&authStorage),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+
+	return t.Context(), authStorage
+}
+
+// TestTokenLifecycle exercises PAT creation, O(1) verification, revocation, and
+// the reverse-index cleanup on both DeleteToken and DeleteUser.
+func TestTokenLifecycle(t *testing.T) {
+	ctx, authStorage := newAuthStorage(t)
+
+	if err := authStorage.SaveUser(ctx, models.User{Name: "alice", Roles: []string{}}, "s3cret"); err != nil {
+		t.Fatalf("failed to save user: %v", err)
+	}
+
+	token, tokenUUID, err := authStorage.CreateToken(ctx, "alice")
+	if err != nil {
+		t.Fatalf("failed to create token: %v", err)
+	}
+
+	// A valid token resolves to its owner.
+	user, err := authStorage.VerifyToken(ctx, token)
+	if err != nil {
+		t.Fatalf("failed to verify token: %v", err)
+	}
+	if user == nil || user.Name != "alice" {
+		t.Fatalf("expected token to resolve to alice, got %+v", user)
+	}
+
+	// An unknown token resolves to nothing, without error.
+	unknown, err := authStorage.VerifyToken(ctx, "pat_unknown")
+	if err != nil {
+		t.Fatalf("unexpected error verifying unknown token: %v", err)
+	}
+	if unknown != nil {
+		t.Fatalf("expected unknown token to resolve to nil, got %+v", unknown)
+	}
+
+	// The token shows up in its owner's list.
+	uuids, err := authStorage.ListTokens(ctx, "alice")
+	if err != nil {
+		t.Fatalf("failed to list tokens: %v", err)
+	}
+	if len(uuids) != 1 || uuids[0] != tokenUUID {
+		t.Fatalf("expected [%s], got %v", tokenUUID, uuids)
+	}
+
+	// Revoking the token makes it (and its index entry) unusable.
+	if err := authStorage.DeleteToken(ctx, "alice", tokenUUID); err != nil {
+		t.Fatalf("failed to delete token: %v", err)
+	}
+	revoked, err := authStorage.VerifyToken(ctx, token)
+	if err != nil {
+		t.Fatalf("failed to verify revoked token: %v", err)
+	}
+	if revoked != nil {
+		t.Fatalf("expected revoked token to resolve to nil, got %+v", revoked)
+	}
+
+	// Deleting the user must also drop the reverse index of their tokens, so a
+	// still-held token can never resolve to the deleted account.
+	token2, _, err := authStorage.CreateToken(ctx, "alice")
+	if err != nil {
+		t.Fatalf("failed to create second token: %v", err)
+	}
+	if err := authStorage.DeleteUser(ctx, "alice"); err != nil {
+		t.Fatalf("failed to delete user: %v", err)
+	}
+	orphan, err := authStorage.VerifyToken(ctx, token2)
+	if err != nil {
+		t.Fatalf("failed to verify token of deleted user: %v", err)
+	}
+	if orphan != nil {
+		t.Fatalf("expected token of deleted user to resolve to nil, got %+v", orphan)
+	}
+}

--- a/internal/storage/databases/auth/transactions/README.md
+++ b/internal/storage/databases/auth/transactions/README.md
@@ -14,7 +14,7 @@ collection of keys that exist under a given prefix.
 ### Users
 
 - `index:user:<name>` — existence marker used to enumerate users.
-- `user:<name>:password` — bcrypt hash of the user's password.
+- `user:<name>:password` — Argon2id hash of the user's password.
 - `user:<name>:role:<role>` — one key per role assigned to the user.
 
 ### Roles
@@ -24,10 +24,13 @@ collection of keys that exist under a given prefix.
 
 ### Personal access tokens
 
-- `pat:<name>:<uuid>` — one key per token; its value is the bcrypt hash of the
-  token. The plaintext is returned to the caller only once, at creation, so
-  verification re-hashes the presented token and compares it against the stored
-  hashes.
+- `pat:<name>:<uuid>` — one key per token; its value is the SHA-256 hash of the
+  token. A fast hash is enough because the token is a long random secret, not a
+  low-entropy password.
+- `index:pat:<sha256(token)>` — reverse index mapping a token's hash back to its
+  owning `<name>`. The plaintext is returned to the caller only once, at
+  creation; verification hashes the presented token and resolves the owner with a
+  single O(1) lookup on this index (no per-token scan).
 
 ## Notes
 

--- a/internal/storage/databases/auth/transactions/tokens.go
+++ b/internal/storage/databases/auth/transactions/tokens.go
@@ -13,20 +13,18 @@ import (
 )
 
 // CreateToken issues a fresh PAT for an existing user. It confirms the user
-// exists through their "index:user:<username>" marker, then stores the token
-// hash under a new "pat:<username>:<uuid>" key and returns the plaintext token
-// (shown to the caller this one time only) along with its UUID.
+// exists through their "index:user:<username>" marker, stores the token's
+// SHA-256 hash under "pat:<username>:<uuid>", and records a reverse index
+// "index:pat:<hash>" -> username so the token can be resolved in O(1). It
+// returns the plaintext token (shown to the caller this one time only) along
+// with its UUID.
 func CreateToken(txn kv.MutationTx, username string) (string, string, error) {
 	token, err := secret.NewSecret("pat", 32)
 	if err != nil {
 		return "", "", err
 	}
 
-	tokenHash, err := hash.HashPassword(token)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to hash token for user %q: %w", username, err)
-	}
-
+	tokenHash := hash.HashToken(token)
 	tokenUuid := uuid.New().String()
 
 	userKey := kv.Key{"index", "user", username}
@@ -39,47 +37,33 @@ func CreateToken(txn kv.MutationTx, username string) (string, string, error) {
 	}
 
 	tokenKey := kv.Key{"pat", username, tokenUuid}
-	err = txn.Set(tokenKey, []byte(tokenHash))
-	if err != nil {
+	if err := txn.Set(tokenKey, []byte(tokenHash)); err != nil {
 		return "", "", fmt.Errorf("failed to write token for user %q: %w", username, err)
+	}
+
+	indexKey := kv.Key{"index", "pat", tokenHash}
+	if err := txn.Set(indexKey, []byte(username)); err != nil {
+		return "", "", fmt.Errorf("failed to index token for user %q: %w", username, err)
 	}
 
 	return token, tokenUuid, nil
 }
 
-// VerifyToken resolves a plaintext token back to its owning user. Tokens are
-// not addressable by their value, so it scans every "pat:" key and bcrypt-
-// compares the candidate against each stored hash; on a match it returns the
-// owning user (the username is the key segment between the "pat:" prefix and the
-// trailing UUID).
+// VerifyToken resolves a plaintext token back to its owning user in O(1): it
+// hashes the token and looks up "index:pat:<hash>". A missing entry means the
+// token is unknown (and no fallback to a legacy per-token scan is attempted).
 func VerifyToken(txn kv.QueryTx, token string) (*models.User, error) {
-	var username string
-	found := false
+	indexKey := kv.Key{"index", "pat", hash.HashToken(token)}
 
-	for kv := range txn.IterPairs(kv.Key{"pat"}, kv.KeyRange{}) {
-		key := kv.Key()
-		val := kv.Value()
-
-		associatedUser := key[len(key)-2]
-
-		tokenHash := string(val)
-		isValid, err := hash.VerifyPassword(token, tokenHash)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify token: %w", err)
-		}
-
-		if isValid {
-			username = associatedUser
-			found = true
-			break
-		}
+	val, err := txn.Get(indexKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify token: %w", err)
 	}
-
-	if !found {
+	if val == nil {
 		return nil, nil
 	}
 
-	return FetchUser(txn, username)
+	return FetchUser(txn, string(val))
 }
 
 // ListTokens returns the UUIDs of every PAT owned by a user by scanning the
@@ -94,11 +78,24 @@ func ListTokens(txn kv.QueryTx, username string) []string {
 	return tokenUUIDs
 }
 
-// DeleteToken removes a single PAT, identified by its UUID, from a user.
+// DeleteToken removes a single PAT, identified by its UUID, from a user, along
+// with its "index:pat:<hash>" reverse-index entry.
 func DeleteToken(txn kv.MutationTx, username string, tokenUUID string) error {
-	key := kv.Key{"pat", username, tokenUUID}
-	err := txn.Clear(key)
+	tokenKey := kv.Key{"pat", username, tokenUUID}
+
+	tokenHash, err := txn.Get(tokenKey)
 	if err != nil {
+		return fmt.Errorf("failed to read token %q for user %q: %w", tokenUUID, username, err)
+	}
+
+	if tokenHash != nil {
+		indexKey := kv.Key{"index", "pat", string(tokenHash)}
+		if err := txn.Clear(indexKey); err != nil {
+			return fmt.Errorf("failed to clear token index %q for user %q: %w", tokenUUID, username, err)
+		}
+	}
+
+	if err := txn.Clear(tokenKey); err != nil {
 		return fmt.Errorf("failed to clear token %q for user %q: %w", tokenUUID, username, err)
 	}
 

--- a/internal/storage/databases/auth/transactions/users.go
+++ b/internal/storage/databases/auth/transactions/users.go
@@ -118,8 +118,8 @@ func PatchUserRoles(txn kv.MutationTx, user models.User) error {
 }
 
 // DeleteUser removes everything tied to a user: all "user:<name>:*" keys (roles
-// and password), all of their "pat:<name>:*" tokens, and the
-// "index:user:<name>" marker.
+// and password), all of their "pat:<name>:*" tokens (and each token's
+// "index:pat:<hash>" reverse-index entry), and the "index:user:<name>" marker.
 func DeleteUser(txn kv.MutationTx, name string) error {
 	keys := make([]kv.Key, 0)
 
@@ -127,8 +127,12 @@ func DeleteUser(txn kv.MutationTx, name string) error {
 		keys = append(keys, key)
 	}
 
-	for key := range txn.IterKeys(kv.Key{"pat", name}, kv.KeyRange{}) {
-		keys = append(keys, key)
+	for pair := range txn.IterPairs(kv.Key{"pat", name}, kv.KeyRange{}) {
+		keys = append(keys, pair.Key())
+
+		if tokenHash := pair.Value(); tokenHash != nil {
+			keys = append(keys, kv.Key{"index", "pat", string(tokenHash)})
+		}
 	}
 
 	for _, key := range keys {

--- a/internal/utils/hash/hash_test.go
+++ b/internal/utils/hash/hash_test.go
@@ -22,6 +22,23 @@ func TestHashPassword(t *testing.T) {
 	}
 }
 
+func TestHashToken(t *testing.T) {
+	h := hash.HashToken("pat_abc123")
+
+	// SHA-256 hex is deterministic and 64 characters long.
+	if got := hash.HashToken("pat_abc123"); got != h {
+		t.Fatalf("HashToken() not deterministic: %q != %q", got, h)
+	}
+	if len(h) != 64 {
+		t.Fatalf("HashToken() length = %d; want 64", len(h))
+	}
+
+	// Distinct tokens hash to distinct digests.
+	if hash.HashToken("pat_other") == h {
+		t.Fatal("HashToken() collided for distinct tokens")
+	}
+}
+
 func BenchmarkHashPassword(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, err := hash.HashPassword("password")

--- a/internal/utils/hash/main.go
+++ b/internal/utils/hash/main.go
@@ -1,12 +1,15 @@
 package hash
 
 import (
-	"crypto/rand"
-	"crypto/subtle"
+	"fmt"
 	"strings"
 
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+
 	"encoding/base64"
-	"fmt"
+	"encoding/hex"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -17,6 +20,19 @@ type hashParams struct {
 	parallelism uint8
 	saltLength  uint32
 	keyLength   uint32
+}
+
+// HashToken hashes a high-entropy API token with SHA-256 and returns its hex
+// digest.
+//
+// Unlike a user password, a token is a long random secret, so a fast
+// cryptographic hash is enough: it cannot be brute-forced regardless of the
+// hash's speed, and hashing this way lets a token be looked up directly by its
+// digest. A slow password KDF like Argon2id is neither needed nor desirable on
+// the token-verification hot path.
+func HashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }
 
 // HashPassword hashes a password using the Argon2id algorithm and returns the

--- a/internal/utils/hash/main.go
+++ b/internal/utils/hash/main.go
@@ -39,10 +39,10 @@ func HashToken(token string) string {
 // hash in a specific format.
 func HashPassword(password string) (string, error) {
 	hp := hashParams{
-		memory:      1, // 1 kB
-		iterations:  1,
+		memory:      19456, // 19 MiB — OWASP-recommended Argon2id minimum
+		iterations:  2,
 		parallelism: 1,
-		saltLength:  4,
+		saltLength:  16,
 		keyLength:   32,
 	}
 

--- a/website/docs/design/auth.md
+++ b/website/docs/design/auth.md
@@ -26,10 +26,15 @@ assigns permissions to one or more of the following **scopes**:
 Each user is associated to one or more roles. A user has a required password,
 and can have zero or more personal access tokens.
 
-## Password and Token encryption
+## Password and Token hashing
 
-Any secret is hashed using the [Argon2](https://en.wikipedia.org/wiki/Argon2)
-algorithm.
+User **passwords** are low-entropy, human-chosen secrets, so they are hashed with
+the memory-hard [Argon2id](https://en.wikipedia.org/wiki/Argon2) key-derivation
+function to make offline brute-forcing expensive.
+
+**Personal Access Tokens** are long, randomly-generated high-entropy secrets that
+cannot be feasibly brute-forced regardless of hash speed, so they are hashed with
+a fast `SHA-256`.
 
 ## Storage
 
@@ -78,7 +83,7 @@ Each user will have a key containing the hashed password with the following
 format:
 
 ```
-user:<username>:password = argon2(password)
+user:<username>:password = argon2id(password)
 ```
 
 For example:
@@ -104,11 +109,18 @@ For each Personal Access Token associated to the user, there will be a key with
 the following format:
 
 ```
-pat:<username>:<uuid> = argon2(token)
+pat:<username>:<uuid> = sha256(token)
 ```
 
 For example:
 
 ```
 pat:guest:f6c2424a-bc1f-4030-9e42-7a09b96452a7
+```
+
+Additionally, a reverse index lets a token be resolved to its owner in constant
+time, without scanning every token:
+
+```
+index:pat:<sha256(token)> = <username>
 ```


### PR DESCRIPTION
## Decision Record

We use [Argon2id](https://en.wikipedia.org/wiki/Argon2) to hash passwords. It is a great algorithm to secure low-entropy secrets (such as passwords chosen by humans).

When generating personal access tokens, we generate a high-entropy secret (32 characters for 256 bits, or rather 224 if we only count the 7 bits of ASCII). And we hashed that secret with Argon2id as well. This led to a huge drop in performance when ingesting logs through the API, because Argon2id is slow.

So we had a bad idea... Lower the strength of Argon2id parameters.

The proper way would be to use a fast hashing algorithm for tokens (like SHA-256), and strong parameters for Argon2id for passwords (which are used less frequently).

> :warning: **NB:** This is a BREAKING CHANGE, old tokens won't work anymore.

## Changes

 - [x] :zap: Use SHA-256 to hash personal access tokens
 - [x] :lock: Use OWASP recommended parameters for Argon2id when hashing passwords

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
