### PR TITLE
:passport_control: Add read_auth_providers and write_auth_providers permissions

### DIFF
--- a/internal/models/auth_permissions.go
+++ b/internal/models/auth_permissions.go
@@ -23,6 +23,9 @@ type Permissions struct {
 
 	CanReadSystemConfiguration  bool `json:"can_read_system_configuration" required:"true"`
 	CanWriteSystemConfiguration bool `json:"can_write_system_configuration" required:"true"`
+
+	CanViewAuthProviders bool `json:"can_view_auth_providers" required:"true"`
+	CanEditAuthProviders bool `json:"can_edit_auth_providers" required:"true"`
 }
 
 // PermissionsFromScopes projects a flat list of scopes into the Permissions
@@ -57,6 +60,10 @@ func PermissionsFromScopes(scopes []Scope) Permissions {
 			permissions.CanReadSystemConfiguration = true
 		case SCOPE_WRITE_SYSTEM_CONFIGURATION:
 			permissions.CanWriteSystemConfiguration = true
+		case SCOPE_READ_AUTH_PROVIDERS:
+			permissions.CanViewAuthProviders = true
+		case SCOPE_WRITE_AUTH_PROVIDERS:
+			permissions.CanEditAuthProviders = true
 		}
 	}
 	return permissions

--- a/internal/models/auth_scope.go
+++ b/internal/models/auth_scope.go
@@ -21,6 +21,8 @@ const (
 	SCOPE_SEND_LOGS                  Scope = "send_logs"
 	SCOPE_READ_SYSTEM_CONFIGURATION  Scope = "read_system_configuration"
 	SCOPE_WRITE_SYSTEM_CONFIGURATION Scope = "write_system_configuration"
+	SCOPE_READ_AUTH_PROVIDERS        Scope = "read_auth_providers"
+	SCOPE_WRITE_AUTH_PROVIDERS       Scope = "write_auth_providers"
 )
 
 // ParseScope converts a wire string into a Scope, returning an error for unknown
@@ -53,6 +55,10 @@ func ParseScope(s string) (Scope, error) {
 		return SCOPE_READ_SYSTEM_CONFIGURATION, nil
 	case "write_system_configuration":
 		return SCOPE_WRITE_SYSTEM_CONFIGURATION, nil
+	case "read_auth_providers":
+		return SCOPE_READ_AUTH_PROVIDERS, nil
+	case "write_auth_providers":
+		return SCOPE_WRITE_AUTH_PROVIDERS, nil
 	default:
 		return "", fmt.Errorf("invalid scope: %s", s)
 	}
@@ -74,5 +80,7 @@ func (s Scope) Enum() []any {
 		SCOPE_SEND_LOGS,
 		SCOPE_READ_SYSTEM_CONFIGURATION,
 		SCOPE_WRITE_SYSTEM_CONFIGURATION,
+		SCOPE_READ_AUTH_PROVIDERS,
+		SCOPE_WRITE_AUTH_PROVIDERS,
 	}
 }

--- a/internal/storage/bootstrap/auth.go
+++ b/internal/storage/bootstrap/auth.go
@@ -39,6 +39,8 @@ func DefaultRolesAndUsers(ctx context.Context, authStorage storage.AuthStorage, 
 				models.SCOPE_WRITE_FORWARDERS,
 				models.SCOPE_READ_SYSTEM_CONFIGURATION,
 				models.SCOPE_WRITE_SYSTEM_CONFIGURATION,
+				models.SCOPE_READ_AUTH_PROVIDERS,
+				models.SCOPE_WRITE_AUTH_PROVIDERS,
 			},
 		}
 


### PR DESCRIPTION
## Description

Closes #1375.

This PR adds two new permission scopes to guard the upcoming authentication providers API (tracked in #1377):

- `read_auth_providers`
- `write_auth_providers`

The admin role created during bootstrap (`DefaultRolesAndUsers`) is granted both new scopes, so the bootstrapped `root` user can manage auth providers out of the box.

## Changes

This is a small, additive change limited to **3 files / 17 insertions**:

- `internal/models/auth_scope.go`
  - Add `SCOPE_READ_AUTH_PROVIDERS` and `SCOPE_WRITE_AUTH_PROVIDERS` constants
  - Register both in `ParseScope` and `Scope.Enum()` (the latter feeds OpenAPI schema enum generation)
- `internal/models/auth_permissions.go`
  - Add `CanViewAuthProviders` / `CanEditAuthProviders` fields to the `Permissions` struct (with `required:"true"` tag, consistent with the existing fields)
  - Project the new scopes in `PermissionsFromScopes` (`READ -> CanView`, `WRITE -> CanEdit`)
- `internal/storage/bootstrap/auth.go`
  - Grant both new scopes to the bootstrapped `admin` role

## Out of scope (intentionally)

- No `AuthStorage` interface changes and no backend implementation changes — the new scopes are plain strings and are already handled by `VerifyUserPermission`, so no mock or backend updates are required.
- No API endpoints / frontend changes — these belong to #1377 and the subsequent UI issues.
- No data migration for existing deployments — the bootstrap seeding only runs on an empty database, which matches the existing pattern (e.g. when `read_system_configuration` was introduced).

## Validation

- `go build ./internal/models/... ./internal/storage/bootstrap/... ./api/auth/...` succeeds
- `go test ./internal/models/... ./internal/storage/bootstrap/... ./api/auth/...` — all packages pass
- `gofmt -l` reports no formatting issues on the three changed files
- Existing `TestDefaultRolesAndUsers` uses subset assertions, so it keeps passing with the two extra admin scopes

## Checklist

- [x] Commit message uses Gitmoji text prefix (`:passport_control:`)
- [x] PR targets `main` and is rebased on top of it (single linear commit)
- [x] `Closes #1375` is referenced in the commit message
- [x] No temporary files, build artifacts, or dependency changes are included
