### PR TITLE
:sparkles: Pipeline auto layout

### DIFF
--- a/internal/models/flow_v2.go
+++ b/internal/models/flow_v2.go
@@ -7,7 +7,7 @@ package models
 type FlowGraphV2 struct {
 	MajorVersion int           `json:"version" default:"2"`
 	MinorVersion int           `json:"version.minor" default:"1"`
-	HasLayout    bool          `json:"hasLayout" default:"true"`
+	HasLayout    bool          `json:"hasLayout" default:"false"`
 	Nodes        []*FlowNodeV2 `json:"nodes" required:"true"`
 	Edges        []*FlowEdgeV2 `json:"edges" required:"true"`
 }

--- a/internal/models/flow_v2.go
+++ b/internal/models/flow_v2.go
@@ -7,6 +7,7 @@ package models
 type FlowGraphV2 struct {
 	MajorVersion int           `json:"version" default:"2"`
 	MinorVersion int           `json:"version.minor" default:"1"`
+	HasLayout    bool          `json:"hasLayout" default:"true"`
 	Nodes        []*FlowNodeV2 `json:"nodes" required:"true"`
 	Edges        []*FlowEdgeV2 `json:"edges" required:"true"`
 }

--- a/internal/storage/bootstrap/pipelines.go
+++ b/internal/storage/bootstrap/pipelines.go
@@ -19,14 +19,11 @@ func DefaultPipeline(ctx context.Context, configStorage storage.ConfigStorage) e
 			"default",
 			`{
 				"version": 2,
+				"hasLayout": false,
 				"nodes": [
 					{
 						"id": "__builtin__source_direct",
 						"type": "source",
-						"position": {
-							"x": -45,
-							"y": 0
-						},
 						"data": {
 							"type": "direct"
 						}
@@ -34,10 +31,6 @@ func DefaultPipeline(ctx context.Context, configStorage storage.ConfigStorage) e
 					{
 						"id": "__builtin__source_syslog",
 						"type": "source",
-						"position": {
-							"x": -45,
-							"y": 120
-						},
 						"data": {
 							"type": "syslog"
 						}
@@ -45,10 +38,6 @@ func DefaultPipeline(ctx context.Context, configStorage storage.ConfigStorage) e
 					{
 						"id": "node-37da64b3-6243-4620-b0f2-ba484a71b053",
 						"type": "router",
-						"position": {
-							"x": 345,
-							"y": 60
-						},
 						"data": {
 							"stream": "default"
 						}

--- a/internal/storage/bootstrap/pipelines.go
+++ b/internal/storage/bootstrap/pipelines.go
@@ -19,7 +19,6 @@ func DefaultPipeline(ctx context.Context, configStorage storage.ConfigStorage) e
 			"default",
 			`{
 				"version": 2,
-				"hasLayout": false,
 				"nodes": [
 					{
 						"id": "__builtin__source_direct",

--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/x-date-pickers": "^9.8.0",
         "@xyflow/react": "^12.11.2",
         "ag-grid-react": "^36.0.0",
+        "dagre": "^0.8.5",
         "dayjs": "^1.11.21",
         "event-source-plus": "^0.1.15",
         "react": "^19.2.7",
@@ -27,6 +28,7 @@
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+        "@types/dagre": "^0.7.54",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -203,24 +205,26 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -933,9 +937,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -953,9 +954,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,9 +971,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,9 +988,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,9 +1005,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1033,9 +1022,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,9 +1039,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,9 +1056,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,9 +1236,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,9 +1253,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,9 +1270,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,9 +1287,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1336,9 +1304,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,9 +1321,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,6 +1364,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -1568,6 +1553,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2064,6 +2056,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -2250,6 +2252,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/hasown": {
@@ -2612,6 +2623,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -20,6 +20,7 @@
     "@mui/x-date-pickers": "^9.8.0",
     "@xyflow/react": "^12.11.2",
     "ag-grid-react": "^36.0.0",
+    "dagre": "^0.8.5",
     "dayjs": "^1.11.21",
     "event-source-plus": "^0.1.15",
     "react": "^19.2.7",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@types/dagre": "^0.7.54",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/web/app/src/components/DialogNewPipeline/component.tsx
+++ b/web/app/src/components/DialogNewPipeline/component.tsx
@@ -46,6 +46,7 @@ const DialogNewPipeline = ({
 
   const [onSubmit, loading] = useApiOperation(async () => {
     await configApi.savePipeline(name, {
+      hasLayout: true,
       nodes: defaultSourceNodes,
       edges: [],
     })

--- a/web/app/src/components/PipelineEditorFlow/component.tsx
+++ b/web/app/src/components/PipelineEditorFlow/component.tsx
@@ -93,15 +93,19 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
     []
   )
 
-  const [nodes, setNodes] = useState<Node[]>(
-    flow.nodes.map((node) => {
+  const [nodes, setNodes] = useState<Node[]>(() => {
+    const initialNodes = flow.nodes.map((node) => {
       if (node.type === 'source') {
         node.deletable = false
       }
 
       return node
     })
-  )
+
+    return flow.hasLayout
+      ? initialNodes
+      : getLayoutedNodes(initialNodes, flow.edges)
+  })
 
   const [edges, setEdges] = useState<Edge[]>(flow.edges)
 
@@ -118,7 +122,7 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
         {}
       )
 
-      return initialNodes.map((node: Node) => {
+      const nextNodes = initialNodes.map((node: Node) => {
         const oldNode = oldNodesById[node.id]
         if (oldNode !== undefined && oldNode.measured) {
           node.measured = oldNode.measured
@@ -126,6 +130,10 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
 
         return node
       })
+
+      return flow.hasLayout
+        ? nextNodes
+        : getLayoutedNodes(nextNodes, initialEdges)
     })
     setEdges(initialEdges)
   }, [flow])
@@ -144,7 +152,7 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
   }, [pipelineTrace])
 
   useEffect(() => {
-    onFlowChange({ nodes, edges })
+    onFlowChange({ hasLayout: true, nodes, edges })
   }, [nodes, edges])
 
   const onNodesChange: OnNodesChange = (changes) =>

--- a/web/app/src/components/PipelineEditorFlow/component.tsx
+++ b/web/app/src/components/PipelineEditorFlow/component.tsx
@@ -7,13 +7,16 @@ import React, {
   useMemo,
   useState,
 } from 'react'
+import { flushSync } from 'react-dom'
 
 import Typography from '@mui/material/Typography'
 
+import AccountTreeIcon from '@mui/icons-material/AccountTree'
 import DeviceHubIcon from '@mui/icons-material/DeviceHub'
 
 import {
   Background,
+  ControlButton,
   Controls,
   type Edge,
   type KeyCode,
@@ -40,6 +43,7 @@ import PipelineNodeSource from '@/components/PipelineNodeSource/component'
 import PipelineNodeSwitch from '@/components/PipelineNodeSwitch/component'
 import PipelineNodeTransformer from '@/components/PipelineNodeTransformer/component'
 
+import { getLayoutedNodes } from './layout'
 import {
   FlowPanelChips,
   FlowPanelLabel,
@@ -75,7 +79,7 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
   onFlowChange,
   pipelineTrace,
 }) => {
-  const { screenToFlowPosition } = useReactFlow()
+  const { screenToFlowPosition, fitView } = useReactFlow()
 
   const nodeTypes = useMemo(
     () => ({
@@ -150,6 +154,13 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
     setEdges((eds) => applyEdgeChanges(changes, eds))
 
   const onConnect: OnConnect = (conn) => setEdges((eds) => addEdge(conn, eds))
+
+  const onLayout = useCallback(() => {
+    flushSync(() => {
+      setNodes((nds) => getLayoutedNodes(nds, edges))
+    })
+    fitView()
+  }, [edges, fitView])
 
   const onDragOver: DragEventHandler<HTMLDivElement> = (event) => {
     event.preventDefault()
@@ -232,7 +243,11 @@ export const PipelineEditorFlow: React.FC<PipelineEditorFlowProps> = ({
           {...shortcuts}
         >
           <Background />
-          <Controls />
+          <Controls>
+            <ControlButton onClick={onLayout} title="Auto layout">
+              <AccountTreeIcon />
+            </ControlButton>
+          </Controls>
 
           <Panel position="top-left">
             <FlowPanelPaper variant="outlined">

--- a/web/app/src/components/PipelineEditorFlow/layout.ts
+++ b/web/app/src/components/PipelineEditorFlow/layout.ts
@@ -1,0 +1,48 @@
+import dagre from 'dagre'
+
+import type { Edge, Node } from '@xyflow/react'
+
+const DEFAULT_NODE_WIDTH = 270
+const DEFAULT_NODE_HEIGHT = 100
+
+export type LayoutDirection = 'TB' | 'LR'
+
+export function getLayoutedNodes(
+  nodes: Node[],
+  edges: Edge[],
+  direction: LayoutDirection = 'LR'
+): Node[] {
+  const graph = new dagre.graphlib.Graph()
+  graph.setDefaultEdgeLabel(() => ({}))
+  graph.setGraph({ rankdir: direction, nodesep: 60, ranksep: 80 })
+
+  for (const node of nodes) {
+    graph.setNode(node.id, {
+      width: node.measured?.width ?? DEFAULT_NODE_WIDTH,
+      height: node.measured?.height ?? DEFAULT_NODE_HEIGHT,
+    })
+  }
+
+  for (const edge of edges) {
+    graph.setEdge(edge.source, edge.target)
+  }
+
+  dagre.layout(graph)
+
+  return nodes.map((node) => {
+    const { x: left, y: top } = graph.node(node.id)
+    const width = node.measured?.width ?? DEFAULT_NODE_WIDTH
+    const height = node.measured?.height ?? DEFAULT_NODE_HEIGHT
+
+    const centerX = left + width / 2
+    const centerY = top + height / 2
+
+    return {
+      ...node,
+      position: {
+        x: centerX,
+        y: centerY,
+      },
+    }
+  })
+}

--- a/web/app/src/lib/models/PipelineModel.ts
+++ b/web/app/src/lib/models/PipelineModel.ts
@@ -1,6 +1,7 @@
 import { ReactFlowJsonObject } from '@xyflow/react'
 
 type PipelineModel = {
+  hasLayout: boolean
   nodes: ReactFlowJsonObject['nodes']
   edges: ReactFlowJsonObject['edges']
 }


### PR DESCRIPTION
## Decision Record

When creating pipelines via API, we might use junk positions for nodes, which renders badly in React Flow.

In this PR, we add an auto-layout feature to render properly such pipelines.

## Changes

 - [x] :heavy_plus_sign: Add `dagre` layouting library
 - [x] :card_file_box: Add `hasLayout` property to pipeline model, defaulting to `false`
 - [x] :sparkles: Add auto-layouting of pipelines that have no layout
 - [x] :lipstick: Add button to re-layout pipeline 

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
