### PR TITLE
:memo: Forbid 100% vibecoded PRs in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,22 @@ take the time to edit your PR to make it fit our guidelines.
 They will be rendered by Github, giving a nice visual indicator of the kind of
 change you are submitting, and yet will still be easily "greppable".
 
+### Use of AI
+
+While the use of AI to help write code, documentation and tests is not
+prohibited per-se, low-effort Pull Requests that are 100% vibecoded and do not
+even follow those contributing guidelines will be rejected without discussion.
+
+AI is a tool to help the developper write code and navigate a large codebase, it
+is not meant to replace human thought and reasoning. If no human can understand
+or explain the code, then no human can debug it. It's a can of worm we are not
+willing to open.
+
+In the Pull Request template, there is a section about "License Agreement",
+asking you to make sure you have the rights on the code being submitted. Pull
+Requests that have been 100% vibecoded CANNOT check this box. And we don't want
+to rely on code with an incompatible license.
+
 ## License of your contributions
 
 This project is **Free** and **Open Source**. It is released under the terms of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,9 @@ While the use of AI to help write code, documentation and tests is not
 prohibited per-se, low-effort Pull Requests that are 100% vibecoded and do not
 even follow those contributing guidelines will be rejected without discussion.
 
-AI is a tool to help the developper write code and navigate a large codebase, it
+AI is a tool to help the developer write code and navigate a large codebase, it
 is not meant to replace human thought and reasoning. If no human can understand
-or explain the code, then no human can debug it. It's a can of worm we are not
+or explain the code, then no human can debug it. It's a can of worms we are not
 willing to open.
 
 In the Pull Request template, there is a section about "License Agreement",


### PR DESCRIPTION
## Decision Record

As said in the edited document:

- there is no way a user can claim the rights on the code produced by an LLM
- if humans don't write/understand/know the code, they can't debug it; we don't want that
- low-effort PRs for your portfolio won't be rewarded, your LLM isn't even able to follow the contributing guidelines anyway

## Changes

 - [x] :memo: Add section about the use of AI in the contributing guidelines

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
