### PR TITLE
:loud_sound: Always report root cause of initialization failure

### DIFF
--- a/cmd/flowg-server/cmd/main.go
+++ b/cmd/flowg-server/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/dig"
 	"go.uber.org/fx"
 
 	"link-society.com/flowg/internal/app/featureflags"
@@ -52,11 +53,14 @@ func NewRootCommand() *cobra.Command {
 			featureflags.SetDemoMode(config.DemoMode)
 			metrics.Setup()
 
-			if getEnvBool("DEBUG", false) {
-				fx.New(server.NewServer(opts)).Run()
-			} else {
-				fx.New(fx.NopLogger, server.NewServer(opts)).Run()
+			app := fx.New(fx.NopLogger, server.NewServer(opts))
+			if err := app.Err(); err != nil {
+				fmt.Printf("ERROR: %v\n", dig.RootCause(err))
+				ExitCode = 1
+				return
 			}
+
+			app.Run()
 		},
 	}
 


### PR DESCRIPTION
## Decision Record

We usually silence noisy logs from the `fx` library by using `fx.NopLogger`. However, when a fallible provider returns an error, it is also silenced. Then `flowg-server` exits with code 1 without printing anything.

As a temporary workaround, we did not inject `fx.NopLogger` when the environment variable `DEBUG` was set to a truthy value. This requires re-running the application in debug mode to get the actual error.

But, `fx` does expose the root cause of the failure. So we print it instead.

## Changes

 - [x] :loud_sound: Always report root cause of initialization failure

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
