### PR TITLE
💄 Style Google Cloud Logging forwarder auth JSON editor like MUI

### DIFF
--- a/web/app/src/components/ForwarderEditorGoogleCloudLogging/component.tsx
+++ b/web/app/src/components/ForwarderEditorGoogleCloudLogging/component.tsx
@@ -19,6 +19,8 @@ import {
 
 import {
   ForwarderEditorGoogleCloudLoggingField,
+  ForwarderEditorGoogleCloudLoggingJsonField,
+  ForwarderEditorGoogleCloudLoggingJsonLabel,
   ForwarderEditorGoogleCloudLoggingRoot,
   ForwarderEditorGoogleCloudLoggingRow,
 } from './styles'
@@ -156,19 +158,27 @@ const ForwarderEditorGoogleCloudLogging = ({
       </FormGroup>
 
       {!disable_auth.value && (
-        <>
-          <label>
+        <ForwarderEditorGoogleCloudLoggingJsonField id="input:editor.forwarders.googlelog.auth_json">
+          <ForwarderEditorGoogleCloudLoggingJsonLabel>
             {t('components.forwarderEditorGoogleCloudLogging.authJsonLabel')}
-          </label>
+          </ForwarderEditorGoogleCloudLoggingJsonLabel>
+
           <Editor
             defaultValue={auth_json}
             defaultLanguage="json"
             height="10rem"
             theme={mode === 'dark' ? 'vrl-theme-dark' : 'vrl-theme-light'}
             onChange={setAuthJson}
-            options={{ minimap: { enabled: false } }}
+            options={{
+              minimap: { enabled: false },
+              scrollBeyondLastLine: false,
+              fontSize: 13,
+              ariaLabel: t(
+                'components.forwarderEditorGoogleCloudLogging.authJsonLabel'
+              ),
+            }}
           />
-        </>
+        </ForwarderEditorGoogleCloudLoggingJsonField>
       )}
     </ForwarderEditorGoogleCloudLoggingRoot>
   )

--- a/web/app/src/components/ForwarderEditorGoogleCloudLogging/styles.tsx
+++ b/web/app/src/components/ForwarderEditorGoogleCloudLogging/styles.tsx
@@ -21,3 +21,43 @@ export const ForwarderEditorGoogleCloudLoggingRow = styled('div')(
 export const ForwarderEditorGoogleCloudLoggingField = styled(TextField)({
   flexGrow: 1,
 })
+
+export const ForwarderEditorGoogleCloudLoggingJsonField = styled('fieldset')(
+  ({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    margin: 0,
+    padding: theme.spacing(0.75, 1.5, 1.5),
+    border: `1px solid ${
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.23)'
+        : 'rgba(0, 0, 0, 0.23)'
+    }`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+    transition: theme.transitions.create('border-color'),
+
+    '&:hover': {
+      borderColor: theme.palette.text.primary,
+    },
+
+    '&:focus-within': {
+      borderColor: theme.palette.primary.main,
+
+      '& legend': {
+        color: theme.palette.primary.main,
+      },
+    },
+  })
+)
+
+export const ForwarderEditorGoogleCloudLoggingJsonLabel = styled('legend')(
+  ({ theme }) => ({
+    padding: theme.spacing(0, 0.75),
+    fontSize: '0.75rem',
+    color:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.7)'
+        : 'rgba(0, 0, 0, 0.6)',
+  })
+)


### PR DESCRIPTION
## Decision Record

The auth JSON editor in the Google Cloud Logging forwarder form used a plain text label above an unstyled Monaco editor, visually inconsistent with the other MUI outlined TextFields on the same form (Project ID, Log ID, etc).

Considered wrapping it in a styled container with the label placed above the box, rejected because it doesn't reproduce MUI's "notched outline" look (label embedded in the border), which reads as a different component style next to the real TextFields.

Decided to use a native fieldset/legend pair, styled with the same color tokens the theme already uses for MuiInputLabel and outlined borders (rest/hover/focus states, including primary.main on focus for both the border and the label). This matches the surrounding inputs without pulling in MUI's own Input internals.

Closes #1403.

## Changes

 - [x] :lipstick: Wrap the auth JSON Monaco editor in a fieldset/legend styled to match MUI's outlined TextField (border + label colors, hover/focus states)

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
