### PR TITLE
✨ Harden forms & dialogs

### DIFF
--- a/tests/specs/web/forwarders.robot
+++ b/tests/specs/web/forwarders.robot
@@ -51,5 +51,7 @@ Delete forwarder
     Wait Until Element Is Visible  id=label:forwarders.list-item.test
     Sleep                          1s
     Click Element                  id=btn:forwarders.delete
+    Wait Until Element Is Visible  id=btn:confirm-dialog.confirm
+    Click Element                  id=btn:confirm-dialog.confirm
     Wait Until Page Contains       No forwarder found  timeout=5s
     Close Browser

--- a/tests/specs/web/resources/components/table.resource
+++ b/tests/specs/web/resources/components/table.resource
@@ -8,9 +8,11 @@ Wait Until Row Is Visible
 
 
 Remove Row
-    [Arguments]                ${table}  ${row}
-    Element Should Be Visible  xpath=//div[@id='${table}']//div[@role='row'][@row-id='${row}']
-    Click Element              xpath=//div[@id='${table}']//div[@role='row'][@row-id='${row}']//button[@data-ref='btn:generic.tablerow.actions.delete']
+    [Arguments]                     ${table}  ${row}
+    Element Should Be Visible       xpath=//div[@id='${table}']//div[@role='row'][@row-id='${row}']
+    Click Element                   xpath=//div[@id='${table}']//div[@role='row'][@row-id='${row}']//button[@data-ref='btn:generic.tablerow.actions.delete']
+    Wait Until Element Is Visible   id=btn:confirm-dialog.confirm
+    Click Element                   id=btn:confirm-dialog.confirm
 
 
 Row Should Not Be Visible

--- a/tests/specs/web/resources/logging.resource
+++ b/tests/specs/web/resources/logging.resource
@@ -29,4 +29,6 @@ Purge stream
     Go To                          ${BASE_URL}/web/storage/${stream}
     Wait Until Element Is Visible  id=btn:streams.delete
     Click Element                  id=btn:streams.delete
+    Wait Until Element Is Visible  id=btn:confirm-dialog.confirm
+    Click Element                  id=btn:confirm-dialog.confirm
     Sleep                          1s

--- a/tests/specs/web/storage.robot
+++ b/tests/specs/web/storage.robot
@@ -50,5 +50,7 @@ Delete stream
     Wait Until Element Is Visible  id=label:streams.list-item.test
     Sleep                          1s
     Click Element                  id=btn:streams.delete
+    Wait Until Element Is Visible  id=btn:confirm-dialog.confirm
+    Click Element                  id=btn:confirm-dialog.confirm
     Wait Until Page Contains       No stream found  timeout=5s
     Close Browser

--- a/tests/specs/web/transformers.robot
+++ b/tests/specs/web/transformers.robot
@@ -49,5 +49,7 @@ Delete transformer
     Wait Until Element Is Visible  id=label:transformers.list-item.test
     Sleep                          1s
     Click Element                  id=btn:transformers.delete
+    Wait Until Element Is Visible  id=btn:confirm-dialog.confirm
+    Click Element                  id=btn:confirm-dialog.confirm
     Wait Until Page Contains       No transformer found  timeout=5s
     Close Browser

--- a/web/app/src/components/DialogConfirm/component.tsx
+++ b/web/app/src/components/DialogConfirm/component.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next'
+
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+
+import CancelIcon from '@mui/icons-material/Cancel'
+import CheckIcon from '@mui/icons-material/Check'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+import { DialogProps } from '@/lib/models/Dialog'
+
+import { DialogConfirmPayload } from './types'
+
+const DialogConfirm = ({
+  open,
+  payload,
+  onClose,
+}: DialogProps<DialogConfirmPayload, boolean>) => {
+  const { t } = useTranslation()
+  const { title, message, confirmLabel, danger = false } = payload
+
+  return (
+    <Dialog open={open} onClose={() => onClose(false)} fullWidth maxWidth="xs">
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          id="btn:confirm-dialog.cancel"
+          variant="contained"
+          startIcon={<CancelIcon />}
+          onClick={() => onClose(false)}
+        >
+          {t('common.actions.cancel')}
+        </Button>
+        <Button
+          id="btn:confirm-dialog.confirm"
+          variant="contained"
+          color={danger ? 'error' : 'secondary'}
+          startIcon={danger ? <DeleteIcon /> : <CheckIcon />}
+          onClick={() => onClose(true)}
+          autoFocus
+        >
+          {confirmLabel ?? t('common.actions.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default DialogConfirm

--- a/web/app/src/components/DialogConfirm/component.tsx
+++ b/web/app/src/components/DialogConfirm/component.tsx
@@ -10,6 +10,7 @@ import DialogTitle from '@mui/material/DialogTitle'
 import CancelIcon from '@mui/icons-material/Cancel'
 import CheckIcon from '@mui/icons-material/Check'
 import DeleteIcon from '@mui/icons-material/Delete'
+import UndoIcon from '@mui/icons-material/Undo'
 
 import { DialogProps } from '@/lib/models/Dialog'
 
@@ -21,7 +22,16 @@ const DialogConfirm = ({
   onClose,
 }: DialogProps<DialogConfirmPayload, boolean>) => {
   const { t } = useTranslation()
-  const { title, message, confirmLabel, danger = false } = payload
+  const {
+    title,
+    message,
+    confirmLabel,
+    danger = false,
+    warning = false,
+  } = payload
+
+  const color = danger ? 'error' : warning ? 'warning' : 'secondary'
+  const ConfirmIcon = danger ? DeleteIcon : warning ? UndoIcon : CheckIcon
 
   return (
     <Dialog open={open} onClose={() => onClose(false)} fullWidth maxWidth="xs">
@@ -41,8 +51,8 @@ const DialogConfirm = ({
         <Button
           id="btn:confirm-dialog.confirm"
           variant="contained"
-          color={danger ? 'error' : 'secondary'}
-          startIcon={danger ? <DeleteIcon /> : <CheckIcon />}
+          color={color}
+          startIcon={<ConfirmIcon />}
           onClick={() => onClose(true)}
           autoFocus
         >

--- a/web/app/src/components/DialogConfirm/types.ts
+++ b/web/app/src/components/DialogConfirm/types.ts
@@ -2,5 +2,9 @@ export type DialogConfirmPayload = Readonly<{
   title: string
   message: string
   confirmLabel?: string
+  // `danger` is for irreversible destructive actions (deleting a resource).
+  // `warning` is for lower-stakes but still noteworthy actions (discarding
+  // unsaved local edits, nothing is actually destroyed server-side).
   danger?: boolean
+  warning?: boolean
 }>

--- a/web/app/src/components/DialogConfirm/types.ts
+++ b/web/app/src/components/DialogConfirm/types.ts
@@ -1,0 +1,6 @@
+export type DialogConfirmPayload = Readonly<{
+  title: string
+  message: string
+  confirmLabel?: string
+  danger?: boolean
+}>

--- a/web/app/src/components/DialogForwarderEditor/component.tsx
+++ b/web/app/src/components/DialogForwarderEditor/component.tsx
@@ -15,12 +15,14 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import ForwarderModel from '@/lib/models/ForwarderModel'
 
 import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import ForwarderEditor from '@/components/ForwarderEditor/component'
 
 import {
@@ -48,6 +50,7 @@ const DialogForwarderEditor = ({
 }: DialogForwarderEditorProps) => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const [open, setOpen] = useState(false)
 
@@ -91,6 +94,19 @@ const DialogForwarderEditor = ({
     notify.success(t('pages.forwarders.notifications.saved'))
   }, [forwarderName, forwarder])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    setOpen(false)
+  }
+
   return (
     <>
       <Button
@@ -105,18 +121,14 @@ const DialogForwarderEditor = ({
       <Dialog
         fullScreen
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={handleClose}
         slots={{
           transition: Transition,
         }}
       >
         <DialogAppBar>
           <DialogToolbar>
-            <IconButton
-              edge="start"
-              color="inherit"
-              onClick={() => setOpen(false)}
-            >
+            <IconButton edge="start" color="inherit" onClick={handleClose}>
               <CloseIcon />
             </IconButton>
 

--- a/web/app/src/components/DialogForwarderEditor/component.tsx
+++ b/web/app/src/components/DialogForwarderEditor/component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Button from '@mui/material/Button'
@@ -15,6 +15,7 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import ForwarderModel from '@/lib/models/ForwarderModel'
@@ -52,11 +53,28 @@ const DialogForwarderEditor = ({
 
   const [valid, setValid] = useState(false)
   const [forwarder, setForwarder] = useState<ForwarderModel>(undefined!)
+  const [savedForwarder, setSavedForwarder] = useState<ForwarderModel>(
+    undefined!
+  )
+  const dirty = useDirty(savedForwarder, forwarder)
   const [forwarderPromise, setForwarderPromise] =
     useState<Promise<void> | null>(null)
 
+  // ForwarderEditor's sub-editors normalize their config on mount (filling
+  // in defaults for optional fields), which changes `forwarder` once before
+  // any real user edit. Treat that first change as the dirty baseline.
+  const initializedRef = useRef(false)
+  const handleForwarderChange = (newForwarder: ForwarderModel) => {
+    setForwarder(newForwarder)
+    if (!initializedRef.current) {
+      initializedRef.current = true
+      setSavedForwarder(newForwarder)
+    }
+  }
+
   const [onFetch] = useApiOperation(
     async (name: string) => {
+      initializedRef.current = false
       const forwarder = await configApi.getForwarder(name)
       setForwarder(forwarder)
     },
@@ -69,6 +87,7 @@ const DialogForwarderEditor = ({
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveForwarder(forwarderName, forwarder)
+    setSavedForwarder(forwarder)
     notify.success(t('pages.forwarders.notifications.saved'))
   }, [forwarderName, forwarder])
 
@@ -121,7 +140,7 @@ const DialogForwarderEditor = ({
               color="secondary"
               size="small"
               onClick={onSave}
-              disabled={saveLoading || !valid}
+              disabled={saveLoading || !valid || !dirty}
               startIcon={!saveLoading && <SaveIcon />}
             >
               {saveLoading ? (
@@ -145,7 +164,7 @@ const DialogForwarderEditor = ({
               <AuthenticatedAwait resolve={forwarderPromise}>
                 <ForwarderEditor
                   forwarder={forwarder}
-                  onForwarderChange={setForwarder}
+                  onForwarderChange={handleForwarderChange}
                   onValidationChange={setValid}
                 />
               </AuthenticatedAwait>

--- a/web/app/src/components/DialogNewForwarder/component.tsx
+++ b/web/app/src/components/DialogNewForwarder/component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Button from '@mui/material/Button'
@@ -21,6 +21,8 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useInput } from '@/lib/hooks/input'
 
 import { DialogProps } from '@/lib/models/Dialog'
@@ -33,6 +35,7 @@ import ForwarderModel from '@/lib/models/ForwarderModel'
 
 import * as validators from '@/lib/validators'
 
+import DialogConfirm from '@/components/DialogConfirm/component'
 import ForwarderEditor from '@/components/ForwarderEditor/component'
 
 import { DialogFormBody, TypeOption } from './styles'
@@ -42,6 +45,7 @@ const DialogNewForwarder = ({
   onClose,
 }: DialogProps<void, string | null>) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
 
   const initialType: ForwarderConfigTypes = 'http'
 
@@ -54,6 +58,22 @@ const DialogNewForwarder = ({
   const [forwarder, setForwarder] = useState<ForwarderModel>(() => ({
     config: ForwarderConfigFactory(initialType),
   }))
+  const [savedForwarder, setSavedForwarder] =
+    useState<ForwarderModel>(forwarder)
+  const configDirty = useDirty(savedForwarder, forwarder)
+  const dirty = name.value.trim() !== '' || type !== initialType || configDirty
+
+  // ForwarderEditor's sub-editors normalize their config on mount (filling
+  // in defaults for optional fields), which changes `forwarder` once before
+  // any real user edit. Treat that first change as the dirty baseline.
+  const initializedRef = useRef(false)
+  const handleForwarderChange = (newForwarder: ForwarderModel) => {
+    setForwarder(newForwarder)
+    if (!initializedRef.current) {
+      initializedRef.current = true
+      setSavedForwarder(newForwarder)
+    }
+  }
 
   const [onSubmit, loading] = useApiOperation(async () => {
     await configApi.saveForwarder(name.value, forwarder)
@@ -62,9 +82,25 @@ const DialogNewForwarder = ({
 
   const handleTypeChange = (newType: ForwarderConfigTypes) => {
     setType(newType)
-    setForwarder({
+    const resetForwarder = {
       config: ForwarderConfigFactory(newType),
-    })
+    }
+    setForwarder(resetForwarder)
+    setSavedForwarder(resetForwarder)
+    initializedRef.current = false
+  }
+
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
   }
 
   return (
@@ -72,7 +108,7 @@ const DialogNewForwarder = ({
       maxWidth="lg"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -134,7 +170,7 @@ const DialogNewForwarder = ({
 
           <ForwarderEditor
             forwarder={forwarder}
-            onForwarderChange={setForwarder}
+            onForwarderChange={handleForwarderChange}
             onValidationChange={setConfigValid}
             showType={false}
           />
@@ -145,7 +181,7 @@ const DialogNewForwarder = ({
           id="btn:forwarder.modal.cancel"
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewPipeline/component.tsx
+++ b/web/app/src/components/DialogNewPipeline/component.tsx
@@ -98,7 +98,7 @@ const DialogNewPipeline = ({
           variant="contained"
           color="secondary"
           startIcon={!loading && <SaveIcon />}
-          disabled={loading}
+          disabled={loading || name.trim() === ''}
           type="submit"
         >
           {loading ? (

--- a/web/app/src/components/DialogNewPipeline/component.tsx
+++ b/web/app/src/components/DialogNewPipeline/component.tsx
@@ -17,8 +17,11 @@ import { type Node } from '@xyflow/react'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 
 import { DialogProps } from '@/lib/models/Dialog'
+
+import DialogConfirm from '@/components/DialogConfirm/component'
 
 import { DialogFormBody } from './styles'
 
@@ -44,7 +47,9 @@ const DialogNewPipeline = ({
   onClose,
 }: DialogProps<void, string | null>) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
   const [name, setName] = useState('')
+  const dirty = name.trim() !== ''
 
   const [onSubmit, loading] = useApiOperation(async () => {
     await configApi.savePipeline(name, {
@@ -55,12 +60,25 @@ const DialogNewPipeline = ({
     onClose(name)
   }, [name])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
+  }
+
   return (
     <Dialog
       maxWidth="sm"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -89,7 +107,7 @@ const DialogNewPipeline = ({
         <Button
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewRole/component.tsx
+++ b/web/app/src/components/DialogNewRole/component.tsx
@@ -16,11 +16,13 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as aclApi from '@/lib/api/operations/acls'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 
 import { DialogProps } from '@/lib/models/Dialog'
 import RoleModel from '@/lib/models/RoleModel'
 import { ScopeLabels, Scopes } from '@/lib/models/Scopes'
 
+import DialogConfirm from '@/components/DialogConfirm/component'
 import InputTransferList from '@/components/InputTransferList/component'
 
 import { FieldLabel, FieldStack, FormStack, FormTextField } from './styles'
@@ -30,8 +32,10 @@ const DialogNewRole = ({
   onClose,
 }: DialogProps<void, RoleModel | null>) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
   const [name, setName] = useState('')
   const [scopes, setScopes] = useState<string[]>([])
+  const dirty = name.trim() !== '' || scopes.length > 0
 
   const [onSubmit, loading] = useApiOperation(async () => {
     const role = {
@@ -43,12 +47,25 @@ const DialogNewRole = ({
     onClose(role)
   }, [name, scopes, onClose])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
+  }
+
   return (
     <Dialog
       maxWidth="sm"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -102,7 +119,7 @@ const DialogNewRole = ({
           id="btn:admin.roles.modal.cancel"
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewRole/component.tsx
+++ b/web/app/src/components/DialogNewRole/component.tsx
@@ -112,7 +112,7 @@ const DialogNewRole = ({
           variant="contained"
           color="secondary"
           startIcon={!loading && <SaveIcon />}
-          disabled={loading}
+          disabled={loading || name.trim() === ''}
           type="submit"
         >
           {loading ? (

--- a/web/app/src/components/DialogNewStreamConfig/component.tsx
+++ b/web/app/src/components/DialogNewStreamConfig/component.tsx
@@ -15,8 +15,11 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 
 import { DialogProps } from '@/lib/models/Dialog'
+
+import DialogConfirm from '@/components/DialogConfirm/component'
 
 import { DialogFormBody } from './styles'
 
@@ -25,7 +28,9 @@ const DialogNewStreamConfig = ({
   onClose,
 }: DialogProps<void, string | null>) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
   const [name, setName] = useState('')
+  const dirty = name.trim() !== ''
 
   const [onSubmit, loading] = useApiOperation(async () => {
     await configApi.configureStream(name, {
@@ -36,12 +41,25 @@ const DialogNewStreamConfig = ({
     onClose(name)
   }, [name])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
+  }
+
   return (
     <Dialog
       maxWidth="sm"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -72,7 +90,7 @@ const DialogNewStreamConfig = ({
           id="btn:streams.modal.cancel"
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewStreamConfig/component.tsx
+++ b/web/app/src/components/DialogNewStreamConfig/component.tsx
@@ -82,7 +82,7 @@ const DialogNewStreamConfig = ({
           variant="contained"
           color="secondary"
           startIcon={!loading && <SaveIcon />}
-          disabled={loading}
+          disabled={loading || name.trim() === ''}
           type="submit"
         >
           {loading ? (

--- a/web/app/src/components/DialogNewToken/component.tsx
+++ b/web/app/src/components/DialogNewToken/component.tsx
@@ -28,8 +28,14 @@ const DialogNewToken = ({
 >) => {
   const { t } = useTranslation()
 
+  // This token is shown only once: closing via backdrop click or Escape is
+  // too easy to trigger by accident, so require the explicit "Done" click.
+  // MUI only invokes Dialog's onClose for those two reasons, so a no-op
+  // here blocks both while leaving the "Done" button free to call onClose.
+  const handleClose = () => {}
+
   return (
-    <Dialog maxWidth="sm" fullWidth open={open} onClose={() => onClose()}>
+    <Dialog maxWidth="sm" fullWidth open={open} onClose={handleClose}>
       <DialogTitle>{t('components.dialogNewToken.title')}</DialogTitle>
       <DialogContent>
         <FieldRow>

--- a/web/app/src/components/DialogNewTransformer/component.tsx
+++ b/web/app/src/components/DialogNewTransformer/component.tsx
@@ -15,8 +15,11 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 
 import { DialogProps } from '@/lib/models/Dialog'
+
+import DialogConfirm from '@/components/DialogConfirm/component'
 
 import { DialogFormBody } from './styles'
 
@@ -25,19 +28,34 @@ const DialogNewTransformer = ({
   onClose,
 }: DialogProps<void, string | null>) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
   const [name, setName] = useState('')
+  const dirty = name.trim() !== ''
 
   const [onSubmit, loading] = useApiOperation(async () => {
     await configApi.saveTransformer(name, '')
     onClose(name)
   }, [name])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
+  }
+
   return (
     <Dialog
       maxWidth="sm"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -68,7 +86,7 @@ const DialogNewTransformer = ({
           id="btn:transformers.modal.cancel"
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewTransformer/component.tsx
+++ b/web/app/src/components/DialogNewTransformer/component.tsx
@@ -78,7 +78,7 @@ const DialogNewTransformer = ({
           variant="contained"
           color="secondary"
           startIcon={!loading && <SaveIcon />}
-          disabled={loading}
+          disabled={loading || name.trim() === ''}
           type="submit"
         >
           {loading ? (

--- a/web/app/src/components/DialogNewUser/component.tsx
+++ b/web/app/src/components/DialogNewUser/component.tsx
@@ -19,10 +19,13 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as aclApi from '@/lib/api/operations/acls'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 
 import { DialogProps } from '@/lib/models/Dialog'
 import UserModel from '@/lib/models/UserModel'
 
+import DialogConfirm from '@/components/DialogConfirm/component'
 import InputTransferList from '@/components/InputTransferList/component'
 
 import { FieldLabel, FieldRow, FieldStack, FormStack } from './styles'
@@ -36,9 +39,12 @@ const DialogNewUser = ({
   UserModel | null
 >) => {
   const { t } = useTranslation()
+  const dialogs = useDialogs()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [roles, setRoles] = useState<string[]>(payload.defaultRoles)
+  const rolesDirty = useDirty(payload.defaultRoles, roles)
+  const dirty = username.trim() !== '' || password !== '' || rolesDirty
 
   const [onSubmit, loading] = useApiOperation(async () => {
     const user = {
@@ -50,12 +56,25 @@ const DialogNewUser = ({
     onClose(user)
   }, [username, password, roles, onClose])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    onClose(null)
+  }
+
   return (
     <Dialog
       maxWidth="sm"
       fullWidth
       open={open}
-      onClose={() => onClose(null)}
+      onClose={handleClose}
       slotProps={{
         paper: {
           component: 'form',
@@ -120,7 +139,7 @@ const DialogNewUser = ({
           id="btn:admin.users.modal.cancel"
           variant="contained"
           startIcon={<CancelIcon />}
-          onClick={() => onClose(null)}
+          onClick={handleClose}
           disabled={loading}
         >
           {t('common.actions.cancel')}

--- a/web/app/src/components/DialogNewUser/component.tsx
+++ b/web/app/src/components/DialogNewUser/component.tsx
@@ -130,7 +130,7 @@ const DialogNewUser = ({
           variant="contained"
           color="secondary"
           startIcon={!loading && <SaveIcon />}
-          disabled={loading}
+          disabled={loading || username.trim() === '' || password === ''}
           type="submit"
         >
           {loading ? (

--- a/web/app/src/components/DialogStreamEditor/component.tsx
+++ b/web/app/src/components/DialogStreamEditor/component.tsx
@@ -17,12 +17,14 @@ import * as configApi from '@/lib/api/operations/config'
 import * as logApi from '@/lib/api/operations/logs.ts'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import StreamConfigModel from '@/lib/models/StreamConfigModel'
 
 import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import StreamEditor from '@/components/StreamEditor/component'
 
 import {
@@ -44,6 +46,7 @@ const Transition = React.forwardRef(function Transition(
 const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const [open, setOpen] = useState(false)
 
@@ -81,6 +84,19 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
     notify.success(t('pages.storage.notifications.saved'))
   }, [stream, streamConfig])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    setOpen(false)
+  }
+
   return (
     <>
       <Button
@@ -95,18 +111,14 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
       <Dialog
         fullScreen
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={handleClose}
         slots={{
           transition: Transition,
         }}
       >
         <DialogAppBar>
           <EditorToolbar>
-            <IconButton
-              edge="start"
-              color="inherit"
-              onClick={() => setOpen(false)}
-            >
+            <IconButton edge="start" color="inherit" onClick={handleClose}>
               <CloseIcon />
             </IconButton>
 

--- a/web/app/src/components/DialogStreamEditor/component.tsx
+++ b/web/app/src/components/DialogStreamEditor/component.tsx
@@ -17,6 +17,7 @@ import * as configApi from '@/lib/api/operations/config'
 import * as logApi from '@/lib/api/operations/logs.ts'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import StreamConfigModel from '@/lib/models/StreamConfigModel'
@@ -51,6 +52,9 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
     size: 0,
     ttl: 0,
   })
+  const [savedStreamConfig, setSavedStreamConfig] =
+    useState<StreamConfigModel>(streamConfig)
+  const dirty = useDirty(savedStreamConfig, streamConfig)
   const [streamConfigPromise, setStreamConfigPromise] =
     useState<Promise<void> | null>(null)
   const [usage, setUsage] = useState<number>(0)
@@ -59,6 +63,7 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
     async (stream: string) => {
       const streamConfig = await configApi.getStreamConfig(stream)
       setStreamConfig(streamConfig)
+      setSavedStreamConfig(streamConfig)
 
       const estimated = await logApi.getStreamUsage(stream)
       setUsage(estimated)
@@ -72,6 +77,7 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.configureStream(stream, streamConfig)
+    setSavedStreamConfig(streamConfig)
     notify.success(t('pages.storage.notifications.saved'))
   }, [stream, streamConfig])
 
@@ -136,7 +142,7 @@ const DialogStreamEditor = ({ stream }: DialogStreamEditorProps) => {
               color="secondary"
               size="small"
               onClick={onSave}
-              disabled={saveLoading}
+              disabled={saveLoading || !dirty}
               startIcon={!saveLoading && <SaveIcon />}
             >
               {saveLoading ? (

--- a/web/app/src/components/DialogTransformerEditor/component.tsx
+++ b/web/app/src/components/DialogTransformerEditor/component.tsx
@@ -16,10 +16,12 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import TransformerEditor from '@/components/TransformerEditor/component'
 
 import {
@@ -43,6 +45,7 @@ const DialogTransformerEditor = ({
 }: DialogTransformerEditorProps) => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const [open, setOpen] = useState(false)
 
@@ -71,6 +74,19 @@ const DialogTransformerEditor = ({
     notify.success(t('pages.transformers.notifications.saved'))
   }, [transformer, code])
 
+  const handleClose = async () => {
+    if (dirty) {
+      const confirmed = await dialogs.open(DialogConfirm, {
+        title: t('common.discardConfirm.title'),
+        message: t('common.discardConfirm.message'),
+        confirmLabel: t('common.actions.discard'),
+        warning: true,
+      })
+      if (!confirmed) return
+    }
+    setOpen(false)
+  }
+
   return (
     <>
       <Button
@@ -85,18 +101,14 @@ const DialogTransformerEditor = ({
       <Dialog
         fullScreen
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={handleClose}
         slots={{
           transition: Transition,
         }}
       >
         <DialogAppBar>
           <EditorToolbar>
-            <IconButton
-              edge="start"
-              color="inherit"
-              onClick={() => setOpen(false)}
-            >
+            <IconButton edge="start" color="inherit" onClick={handleClose}>
               <CloseIcon />
             </IconButton>
 

--- a/web/app/src/components/DialogTransformerEditor/component.tsx
+++ b/web/app/src/components/DialogTransformerEditor/component.tsx
@@ -16,6 +16,7 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 
 import AuthenticatedAwait from '@/components/AuthenticatedAwait/component'
@@ -46,6 +47,8 @@ const DialogTransformerEditor = ({
   const [open, setOpen] = useState(false)
 
   const [code, setCode] = useState('')
+  const [savedCode, setSavedCode] = useState('')
+  const dirty = useDirty(savedCode, code)
   const [transformerPromise, setTransformerPromise] =
     useState<Promise<void> | null>(null)
 
@@ -53,6 +56,7 @@ const DialogTransformerEditor = ({
     async (transformer: string) => {
       const script = await configApi.getTransformer(transformer)
       setCode(script)
+      setSavedCode(script)
     },
     [transformer]
   )
@@ -63,6 +67,7 @@ const DialogTransformerEditor = ({
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveTransformer(transformer, code)
+    setSavedCode(code)
     notify.success(t('pages.transformers.notifications.saved'))
   }, [transformer, code])
 
@@ -127,7 +132,7 @@ const DialogTransformerEditor = ({
               color="secondary"
               size="small"
               onClick={onSave}
-              disabled={saveLoading}
+              disabled={saveLoading || !dirty}
               startIcon={!saveLoading && <SaveIcon />}
             >
               {saveLoading ? (

--- a/web/app/src/components/TableActionsCell/component.tsx
+++ b/web/app/src/components/TableActionsCell/component.tsx
@@ -1,11 +1,35 @@
+import { useTranslation } from 'react-i18next'
+
 import Button from '@mui/material/Button'
 
 import DeleteIcon from '@mui/icons-material/Delete'
+
+import { useDialogs } from '@/lib/hooks/dialogs'
+
+import DialogConfirm from '@/components/DialogConfirm/component'
 
 import { CellRoot } from './styles'
 import { TableActionsCellProps } from './types'
 
 function TableActionsCell<T>({ data, onDelete }: TableActionsCellProps<T>) {
+  const { t } = useTranslation()
+  const dialogs = useDialogs()
+
+  const handleDeleteClick = async () => {
+    if (!onDelete || !data) return
+
+    const confirmed = await dialogs.open(DialogConfirm, {
+      title: t('components.tableActionsCell.deleteConfirm.title'),
+      message: t('components.tableActionsCell.deleteConfirm.message'),
+      confirmLabel: t('common.actions.delete'),
+      danger: true,
+    })
+
+    if (confirmed) {
+      onDelete(data)
+    }
+  }
+
   return (
     <CellRoot>
       {onDelete && data && (
@@ -13,7 +37,7 @@ function TableActionsCell<T>({ data, onDelete }: TableActionsCellProps<T>) {
           variant="contained"
           size="small"
           color="error"
-          onClick={() => onDelete(data)}
+          onClick={handleDeleteClick}
           data-ref="btn:generic.tablerow.actions.delete"
         >
           <DeleteIcon />

--- a/web/app/src/lib/hooks/dirty.ts
+++ b/web/app/src/lib/hooks/dirty.ts
@@ -1,0 +1,2 @@
+export const useDirty = <T>(initial: T, current: T): boolean =>
+  JSON.stringify(initial) !== JSON.stringify(current)

--- a/web/app/src/locales/dummy.po
+++ b/web/app/src/locales/dummy.po
@@ -15,6 +15,9 @@ msgstr "Confirm"
 msgid "common.actions.delete"
 msgstr "Delete"
 
+msgid "common.actions.discard"
+msgstr "Discard"
+
 msgid "common.actions.documentation"
 msgstr "Documentation"
 
@@ -29,6 +32,12 @@ msgstr "Save"
 
 msgid "common.actions.test"
 msgstr "Test"
+
+msgid "common.discardConfirm.message"
+msgstr "Your unsaved changes will be lost."
+
+msgid "common.discardConfirm.title"
+msgstr "Discard unsaved changes?"
 
 msgid "common.notifications.testFailed"
 msgstr "Test failed: {{error}}"

--- a/web/app/src/locales/dummy.po
+++ b/web/app/src/locales/dummy.po
@@ -9,6 +9,9 @@ msgstr "Cancel"
 msgid "common.actions.close"
 msgstr "Close"
 
+msgid "common.actions.confirm"
+msgstr "Confirm"
+
 msgid "common.actions.delete"
 msgstr "Delete"
 
@@ -567,6 +570,12 @@ msgstr "Retention time (in seconds)"
 msgid "components.streamEditor.usageLabel"
 msgstr "Estimated storage usage: {{usage}}MB"
 
+msgid "components.tableActionsCell.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "components.tableActionsCell.deleteConfirm.title"
+msgstr "Delete this item?"
+
 msgid "components.timeWindowSelector.absolute"
 msgstr "Absolute"
 
@@ -627,6 +636,12 @@ msgstr "Users"
 msgid "components.usernameDisplay.label"
 msgstr "Username"
 
+msgid "pages.forwarders.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.forwarders.deleteConfirm.title"
+msgstr "Delete this forwarder?"
+
 msgid "pages.forwarders.empty"
 msgstr "No forwarder found, create one"
 
@@ -681,6 +696,12 @@ msgstr "The page you are looking for does not exist or has been moved."
 msgid "pages.notFound.title"
 msgstr "Page not found"
 
+msgid "pages.pipelines.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.pipelines.deleteConfirm.title"
+msgstr "Delete this pipeline?"
+
 msgid "pages.pipelines.empty"
 msgstr "No pipeline found, create one"
 
@@ -692,6 +713,12 @@ msgstr "Pipeline saved"
 
 msgid "pages.pipelines.switchExpressionDocs"
 msgstr "Switch Expression Documentation"
+
+msgid "pages.storage.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.storage.deleteConfirm.title"
+msgstr "Delete this stream?"
 
 msgid "pages.storage.demoModeBanner"
 msgstr "Demo Mode Active, changes will be ignored."
@@ -719,6 +746,12 @@ msgstr "System configuration saved"
 
 msgid "pages.systemConfiguration.title"
 msgstr "System configuration"
+
+msgid "pages.transformers.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.transformers.deleteConfirm.title"
+msgstr "Delete this transformer?"
 
 msgid "pages.transformers.empty"
 msgstr "No transformer found, create one"

--- a/web/app/src/locales/dummy.po
+++ b/web/app/src/locales/dummy.po
@@ -9,6 +9,9 @@ msgstr "Cancel"
 msgid "common.actions.close"
 msgstr "Close"
 
+msgid "common.actions.confirm"
+msgstr "Confirm"
+
 msgid "common.actions.delete"
 msgstr "Delete"
 
@@ -561,6 +564,12 @@ msgstr "Retention time (in seconds)"
 msgid "components.streamEditor.usageLabel"
 msgstr "Estimated storage usage: {{usage}}MB"
 
+msgid "components.tableActionsCell.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "components.tableActionsCell.deleteConfirm.title"
+msgstr "Delete this item?"
+
 msgid "components.timeWindowSelector.absolute"
 msgstr "Absolute"
 
@@ -621,6 +630,12 @@ msgstr "Users"
 msgid "components.usernameDisplay.label"
 msgstr "Username"
 
+msgid "pages.forwarders.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.forwarders.deleteConfirm.title"
+msgstr "Delete this forwarder?"
+
 msgid "pages.forwarders.empty"
 msgstr "No forwarder found, create one"
 
@@ -675,6 +690,12 @@ msgstr "The page you are looking for does not exist or has been moved."
 msgid "pages.notFound.title"
 msgstr "Page not found"
 
+msgid "pages.pipelines.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.pipelines.deleteConfirm.title"
+msgstr "Delete this pipeline?"
+
 msgid "pages.pipelines.empty"
 msgstr "No pipeline found, create one"
 
@@ -686,6 +707,12 @@ msgstr "Pipeline saved"
 
 msgid "pages.pipelines.switchExpressionDocs"
 msgstr "Switch Expression Documentation"
+
+msgid "pages.storage.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.storage.deleteConfirm.title"
+msgstr "Delete this stream?"
 
 msgid "pages.storage.demoModeBanner"
 msgstr "Demo Mode Active, changes will be ignored."
@@ -713,6 +740,12 @@ msgstr "System configuration saved"
 
 msgid "pages.systemConfiguration.title"
 msgstr "System configuration"
+
+msgid "pages.transformers.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.transformers.deleteConfirm.title"
+msgstr "Delete this transformer?"
 
 msgid "pages.transformers.empty"
 msgstr "No transformer found, create one"

--- a/web/app/src/locales/en.po
+++ b/web/app/src/locales/en.po
@@ -15,6 +15,9 @@ msgstr "Confirm"
 msgid "common.actions.delete"
 msgstr "Delete"
 
+msgid "common.actions.discard"
+msgstr "Discard"
+
 msgid "common.actions.documentation"
 msgstr "Documentation"
 
@@ -29,6 +32,12 @@ msgstr "Save"
 
 msgid "common.actions.test"
 msgstr "Test"
+
+msgid "common.discardConfirm.message"
+msgstr "Your unsaved changes will be lost."
+
+msgid "common.discardConfirm.title"
+msgstr "Discard unsaved changes?"
 
 msgid "common.notifications.testFailed"
 msgstr "Test failed: {{error}}"

--- a/web/app/src/locales/en.po
+++ b/web/app/src/locales/en.po
@@ -9,6 +9,9 @@ msgstr "Cancel"
 msgid "common.actions.close"
 msgstr "Close"
 
+msgid "common.actions.confirm"
+msgstr "Confirm"
+
 msgid "common.actions.delete"
 msgstr "Delete"
 
@@ -576,6 +579,12 @@ msgstr "Retention time (in seconds)"
 msgid "components.streamEditor.usageLabel"
 msgstr "Estimated storage usage: {{usage}}MB"
 
+msgid "components.tableActionsCell.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "components.tableActionsCell.deleteConfirm.title"
+msgstr "Delete this item?"
+
 msgid "components.timeWindowSelector.absolute"
 msgstr "Absolute"
 
@@ -636,6 +645,12 @@ msgstr "Users"
 msgid "components.usernameDisplay.label"
 msgstr "Username"
 
+msgid "pages.forwarders.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.forwarders.deleteConfirm.title"
+msgstr "Delete this forwarder?"
+
 msgid "pages.forwarders.empty"
 msgstr "No forwarder found, create one"
 
@@ -690,6 +705,12 @@ msgstr "The page you are looking for does not exist or has been moved."
 msgid "pages.notFound.title"
 msgstr "Page not found"
 
+msgid "pages.pipelines.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.pipelines.deleteConfirm.title"
+msgstr "Delete this pipeline?"
+
 msgid "pages.pipelines.empty"
 msgstr "No pipeline found, create one"
 
@@ -701,6 +722,12 @@ msgstr "Pipeline saved"
 
 msgid "pages.pipelines.switchExpressionDocs"
 msgstr "Switch Expression Documentation"
+
+msgid "pages.storage.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.storage.deleteConfirm.title"
+msgstr "Delete this stream?"
 
 msgid "pages.storage.demoModeBanner"
 msgstr "Demo Mode Active, changes will be ignored."
@@ -728,6 +755,12 @@ msgstr "System configuration saved"
 
 msgid "pages.systemConfiguration.title"
 msgstr "System configuration"
+
+msgid "pages.transformers.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.transformers.deleteConfirm.title"
+msgstr "Delete this transformer?"
 
 msgid "pages.transformers.empty"
 msgstr "No transformer found, create one"

--- a/web/app/src/locales/en.po
+++ b/web/app/src/locales/en.po
@@ -9,6 +9,9 @@ msgstr "Cancel"
 msgid "common.actions.close"
 msgstr "Close"
 
+msgid "common.actions.confirm"
+msgstr "Confirm"
+
 msgid "common.actions.delete"
 msgstr "Delete"
 
@@ -570,6 +573,12 @@ msgstr "Retention time (in seconds)"
 msgid "components.streamEditor.usageLabel"
 msgstr "Estimated storage usage: {{usage}}MB"
 
+msgid "components.tableActionsCell.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "components.tableActionsCell.deleteConfirm.title"
+msgstr "Delete this item?"
+
 msgid "components.timeWindowSelector.absolute"
 msgstr "Absolute"
 
@@ -630,6 +639,12 @@ msgstr "Users"
 msgid "components.usernameDisplay.label"
 msgstr "Username"
 
+msgid "pages.forwarders.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.forwarders.deleteConfirm.title"
+msgstr "Delete this forwarder?"
+
 msgid "pages.forwarders.empty"
 msgstr "No forwarder found, create one"
 
@@ -684,6 +699,12 @@ msgstr "The page you are looking for does not exist or has been moved."
 msgid "pages.notFound.title"
 msgstr "Page not found"
 
+msgid "pages.pipelines.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.pipelines.deleteConfirm.title"
+msgstr "Delete this pipeline?"
+
 msgid "pages.pipelines.empty"
 msgstr "No pipeline found, create one"
 
@@ -695,6 +716,12 @@ msgstr "Pipeline saved"
 
 msgid "pages.pipelines.switchExpressionDocs"
 msgstr "Switch Expression Documentation"
+
+msgid "pages.storage.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.storage.deleteConfirm.title"
+msgstr "Delete this stream?"
 
 msgid "pages.storage.demoModeBanner"
 msgstr "Demo Mode Active, changes will be ignored."
@@ -722,6 +749,12 @@ msgstr "System configuration saved"
 
 msgid "pages.systemConfiguration.title"
 msgstr "System configuration"
+
+msgid "pages.transformers.deleteConfirm.message"
+msgstr "This action cannot be undone."
+
+msgid "pages.transformers.deleteConfirm.title"
+msgstr "Delete this transformer?"
 
 msgid "pages.transformers.empty"
 msgstr "No transformer found, create one"

--- a/web/app/src/views/ForwarderDetailView/component.tsx
+++ b/web/app/src/views/ForwarderDetailView/component.tsx
@@ -20,12 +20,14 @@ import ScienceIcon from '@mui/icons-material/Science'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
 
 import { loginRequired } from '@/lib/decorators/loaders'
 
 import ButtonNewForwarder from '@/components/ButtonNewForwarder/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import ForwarderEditor from '@/components/ForwarderEditor/component'
 import InputKeyValue from '@/components/InputKeyValue/component'
 import SideNavList from '@/components/SideNavList/component'
@@ -71,6 +73,7 @@ export const loader: LoaderFunction = loginRequired(
 const ForwarderDetailView = () => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const { permissions } = useProfile()
   const { forwarders, currentForwarder } = useLoaderData() as LoaderData
@@ -103,6 +106,19 @@ const ForwarderDetailView = () => {
       navigate(buildUrl('/forwarders'))
     })
   }, [currentForwarder])
+
+  const handleDeleteClick = async () => {
+    const confirmed = await dialogs.open(DialogConfirm, {
+      title: t('pages.forwarders.deleteConfirm.title'),
+      message: t('pages.forwarders.deleteConfirm.message'),
+      confirmLabel: t('common.actions.delete'),
+      danger: true,
+    })
+
+    if (confirmed) {
+      onDelete()
+    }
+  }
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveForwarder(currentForwarder.name, forwarder)
@@ -148,7 +164,7 @@ const ForwarderDetailView = () => {
                   variant="contained"
                   color="error"
                   size="small"
-                  onClick={onDelete}
+                  onClick={handleDeleteClick}
                   disabled={deleteLoading}
                   startIcon={!deleteLoading && <DeleteIcon />}
                 >

--- a/web/app/src/views/ForwarderDetailView/component.tsx
+++ b/web/app/src/views/ForwarderDetailView/component.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
@@ -21,8 +21,11 @@ import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
 import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
+
+import ForwarderModel from '@/lib/models/ForwarderModel'
 
 import { loginRequired } from '@/lib/decorators/loaders'
 
@@ -81,6 +84,22 @@ const ForwarderDetailView = () => {
 
   const [forwarder, setForwarder] = useState(currentForwarder.forwarder)
   const [valid, setValid] = useState(false)
+  const [savedForwarder, setSavedForwarder] = useState(
+    currentForwarder.forwarder
+  )
+  const dirty = useDirty(savedForwarder, forwarder)
+
+  // ForwarderEditor's sub-editors normalize their config on mount (filling
+  // in defaults for optional fields), which changes `forwarder` once before
+  // any real user edit. Treat that first change as the dirty baseline.
+  const initializedRef = useRef(false)
+  const handleForwarderChange = (newForwarder: ForwarderModel) => {
+    setForwarder(newForwarder)
+    if (!initializedRef.current) {
+      initializedRef.current = true
+      setSavedForwarder(newForwarder)
+    }
+  }
 
   const [testOpen, setTestOpen] = useState(false)
   const [testRecords, setTestRecords] = useState<[string, string][]>([])
@@ -122,6 +141,7 @@ const ForwarderDetailView = () => {
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveForwarder(currentForwarder.name, forwarder)
+    setSavedForwarder(forwarder)
     notify.success(t('pages.forwarders.notifications.saved'))
   }, [forwarder, currentForwarder])
 
@@ -181,7 +201,7 @@ const ForwarderDetailView = () => {
                   color="secondary"
                   size="small"
                   onClick={onSave}
-                  disabled={saveLoading || !valid}
+                  disabled={saveLoading || !valid || !dirty}
                   startIcon={!saveLoading && <SaveIcon />}
                 >
                   {saveLoading ? (
@@ -208,7 +228,7 @@ const ForwarderDetailView = () => {
             <ForwarderDetailViewEditorPaper>
               <ForwarderEditor
                 forwarder={forwarder}
-                onForwarderChange={setForwarder}
+                onForwarderChange={handleForwarderChange}
                 onValidationChange={setValid}
               />
             </ForwarderDetailViewEditorPaper>

--- a/web/app/src/views/PipelineDetailView/component.tsx
+++ b/web/app/src/views/PipelineDetailView/component.tsx
@@ -22,6 +22,7 @@ import { ReactFlowProvider } from '@xyflow/react'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
 
@@ -30,6 +31,7 @@ import { PipelineTrace } from '@/lib/models/PipelineTrace.ts'
 
 import { loginRequired } from '@/lib/decorators/loaders'
 
+import DialogConfirm from '@/components/DialogConfirm/component'
 import InputKeyValue from '@/components/InputKeyValue/component'
 import PipelineEditorFlow from '@/components/PipelineEditorFlow/component'
 import PipelineEditorNodeListForwarder from '@/components/PipelineEditorNodeListForwarder/component'
@@ -80,6 +82,7 @@ export const loader: LoaderFunction = loginRequired(
 const PipelineDetailView = () => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const { permissions } = useProfile()
   const { currentPipeline } = useLoaderData() as LoaderData
@@ -110,6 +113,19 @@ const PipelineDetailView = () => {
       navigate(buildUrl('/pipelines'))
     })
   }, [currentPipeline])
+
+  const handleDeleteClick = async () => {
+    const confirmed = await dialogs.open(DialogConfirm, {
+      title: t('pages.pipelines.deleteConfirm.title'),
+      message: t('pages.pipelines.deleteConfirm.message'),
+      confirmLabel: t('common.actions.delete'),
+      danger: true,
+    })
+
+    if (confirmed) {
+      onDelete()
+    }
+  }
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     const savedFlow = {
@@ -217,7 +233,7 @@ const PipelineDetailView = () => {
                   variant="contained"
                   color="error"
                   size="small"
-                  onClick={onDelete}
+                  onClick={handleDeleteClick}
                   disabled={deleteLoading}
                   startIcon={!deleteLoading && <DeleteIcon />}
                 >

--- a/web/app/src/views/PipelineDetailView/component.tsx
+++ b/web/app/src/views/PipelineDetailView/component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoaderFunction, useLoaderData, useNavigate } from 'react-router'
 
@@ -23,6 +23,7 @@ import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
 import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
 
@@ -90,9 +91,16 @@ const PipelineDetailView = () => {
 
   const initialFlow = currentPipeline.flow
   const [flow, setFlow] = useState(initialFlow)
+  const [lastSavedFlow, setLastSavedFlow] = useState(initialFlow)
+  const dirty = useDirty(lastSavedFlow, flow)
   const [testOpen, setTestOpen] = useState(false)
   const [testRecords, setTestRecords] = useState<[string, string][]>([])
   const [testResult, setTestResult] = useState<PipelineTrace | null>(null)
+
+  // PipelineEditorFlow normalizes the flow on mount (layout, node metadata,
+  // `hasLayout: true`), which changes it once before any real user edit.
+  // Treat that first change as the dirty baseline.
+  const initializedRef = useRef(false)
 
   const onChange = useCallback(
     (newFlow: PipelineModel) => {
@@ -101,6 +109,11 @@ const PipelineDetailView = () => {
 
       if (serializedOldFlow !== serializedNewFlow) {
         setFlow(newFlow)
+      }
+
+      if (!initializedRef.current) {
+        initializedRef.current = true
+        setLastSavedFlow(newFlow)
       }
     },
     [flow]
@@ -138,6 +151,7 @@ const PipelineDetailView = () => {
     }
 
     await configApi.savePipeline(currentPipeline.name, savedFlow)
+    setLastSavedFlow(flow)
     notify.success(t('pages.pipelines.notifications.saved'))
   }, [flow, currentPipeline])
 
@@ -249,7 +263,7 @@ const PipelineDetailView = () => {
                   color="secondary"
                   size="small"
                   onClick={onSave}
-                  disabled={saveLoading}
+                  disabled={saveLoading || !dirty}
                   startIcon={!saveLoading && <SaveIcon />}
                 >
                   {saveLoading ? (

--- a/web/app/src/views/StorageDetailView/component.tsx
+++ b/web/app/src/views/StorageDetailView/component.tsx
@@ -13,6 +13,7 @@ import * as configApi from '@/lib/api/operations/config'
 import * as logApi from '@/lib/api/operations/logs.ts'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useFeatureFlags } from '@/lib/hooks/featureflags'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
@@ -20,6 +21,7 @@ import { useProfile } from '@/lib/hooks/profile'
 import { loginRequired } from '@/lib/decorators/loaders'
 
 import ButtonNewStreamConfig from '@/components/ButtonNewStreamConfig/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import SideNavList from '@/components/SideNavList/component'
 import StreamEditor from '@/components/StreamEditor/component'
 
@@ -56,6 +58,7 @@ const StorageDetailView = () => {
   const { t } = useTranslation()
   const featureFlags = useFeatureFlags()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const { permissions } = useProfile()
   const { streams, usage, currentStream } = useLoaderData() as LoaderData
@@ -75,6 +78,19 @@ const StorageDetailView = () => {
       navigate(buildUrl('/storage'))
     })
   }, [currentStream])
+
+  const handleDeleteClick = async () => {
+    const confirmed = await dialogs.open(DialogConfirm, {
+      title: t('pages.storage.deleteConfirm.title'),
+      message: t('pages.storage.deleteConfirm.message'),
+      confirmLabel: t('common.actions.delete'),
+      danger: true,
+    })
+
+    if (confirmed) {
+      onDelete()
+    }
+  }
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.configureStream(currentStream, streamConfig)
@@ -112,7 +128,7 @@ const StorageDetailView = () => {
               variant="contained"
               color="error"
               size="small"
-              onClick={onDelete}
+              onClick={handleDeleteClick}
               disabled={deleteLoading}
               startIcon={!deleteLoading && <DeleteIcon />}
             >

--- a/web/app/src/views/StorageDetailView/component.tsx
+++ b/web/app/src/views/StorageDetailView/component.tsx
@@ -14,6 +14,7 @@ import * as logApi from '@/lib/api/operations/logs.ts'
 
 import { useApiOperation } from '@/lib/hooks/api'
 import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useFeatureFlags } from '@/lib/hooks/featureflags'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
@@ -65,6 +66,10 @@ const StorageDetailView = () => {
   const navigate = useNavigate()
 
   const [streamConfig, setStreamConfig] = useState(streams[currentStream])
+  const [savedStreamConfig, setSavedStreamConfig] = useState(
+    streams[currentStream]
+  )
+  const dirty = useDirty(savedStreamConfig, streamConfig)
 
   const onCreate = (name: string) => {
     queueMicrotask(() => {
@@ -94,6 +99,7 @@ const StorageDetailView = () => {
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.configureStream(currentStream, streamConfig)
+    setSavedStreamConfig(streamConfig)
     notify.success(t('pages.storage.notifications.saved'))
   }, [streamConfig, currentStream])
 
@@ -145,7 +151,7 @@ const StorageDetailView = () => {
               color="secondary"
               size="small"
               onClick={onSave}
-              disabled={saveLoading}
+              disabled={saveLoading || !dirty}
               startIcon={!saveLoading && <SaveIcon />}
             >
               {saveLoading ? (

--- a/web/app/src/views/SystemConfiguration/component.tsx
+++ b/web/app/src/views/SystemConfiguration/component.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/api/operations/config.ts'
 
 import { useApiOperation } from '@/lib/hooks/api.ts'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify.ts'
 
 import { loginRequired } from '@/lib/decorators/loaders'
@@ -35,12 +36,15 @@ const SystemConfiguration = () => {
   const receivedConfig = useLoaderData() as LoaderData
 
   const [config, setConfig] = useState(receivedConfig)
+  const [savedConfig, setSavedConfig] = useState(receivedConfig)
+  const dirty = useDirty(savedConfig, config)
 
   const notify = useNotify()
   const [onSave, saveLoading] = useApiOperation(async () => {
     await saveSystemConfiguration(config)
+    setSavedConfig(config)
     notify.success(t('pages.systemConfiguration.notifications.saved'))
-  }, [])
+  }, [config])
 
   return (
     <SystemConfigurationRoot variant="page">
@@ -87,7 +91,7 @@ const SystemConfiguration = () => {
           variant="contained"
           color="secondary"
           onClick={onSave}
-          disabled={saveLoading}
+          disabled={saveLoading || !dirty}
         >
           {t('common.actions.save')}
         </Button>

--- a/web/app/src/views/TransformerDetailView/component.tsx
+++ b/web/app/src/views/TransformerDetailView/component.tsx
@@ -13,6 +13,7 @@ import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
 import { useDialogs } from '@/lib/hooks/dialogs'
+import { useDirty } from '@/lib/hooks/dirty'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
 
@@ -67,6 +68,8 @@ const TransformerDetailView = () => {
   const navigate = useNavigate()
 
   const [code, setCode] = useState(currentTransformer.script)
+  const [savedCode, setSavedCode] = useState(currentTransformer.script)
+  const dirty = useDirty(savedCode, code)
 
   const onCreate = (name: string) => {
     queueMicrotask(() => {
@@ -96,6 +99,7 @@ const TransformerDetailView = () => {
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveTransformer(currentTransformer.name, code)
+    setSavedCode(code)
     notify.success(t('pages.transformers.notifications.saved'))
   }, [code, currentTransformer])
 
@@ -141,7 +145,7 @@ const TransformerDetailView = () => {
               color="secondary"
               size="small"
               onClick={onSave}
-              disabled={saveLoading}
+              disabled={saveLoading || !dirty}
               startIcon={!saveLoading && <SaveIcon />}
             >
               {saveLoading ? (

--- a/web/app/src/views/TransformerDetailView/component.tsx
+++ b/web/app/src/views/TransformerDetailView/component.tsx
@@ -12,12 +12,14 @@ import SaveIcon from '@mui/icons-material/Save'
 import * as configApi from '@/lib/api/operations/config'
 
 import { useApiOperation } from '@/lib/hooks/api'
+import { useDialogs } from '@/lib/hooks/dialogs'
 import { useNotify } from '@/lib/hooks/notify'
 import { useProfile } from '@/lib/hooks/profile'
 
 import { loginRequired } from '@/lib/decorators/loaders'
 
 import ButtonNewTransformer from '@/components/ButtonNewTransformer/component'
+import DialogConfirm from '@/components/DialogConfirm/component'
 import SideNavList from '@/components/SideNavList/component'
 import TransformerEditor from '@/components/TransformerEditor/component'
 
@@ -58,6 +60,7 @@ export const loader: LoaderFunction = loginRequired(
 const TransformerDetailView = () => {
   const { t } = useTranslation()
   const notify = useNotify()
+  const dialogs = useDialogs()
 
   const { permissions } = useProfile()
   const { transformers, currentTransformer } = useLoaderData() as LoaderData
@@ -77,6 +80,19 @@ const TransformerDetailView = () => {
       navigate(buildUrl('/transformers'))
     })
   }, [currentTransformer])
+
+  const handleDeleteClick = async () => {
+    const confirmed = await dialogs.open(DialogConfirm, {
+      title: t('pages.transformers.deleteConfirm.title'),
+      message: t('pages.transformers.deleteConfirm.message'),
+      confirmLabel: t('common.actions.delete'),
+      danger: true,
+    })
+
+    if (confirmed) {
+      onDelete()
+    }
+  }
 
   const [onSave, saveLoading] = useApiOperation(async () => {
     await configApi.saveTransformer(currentTransformer.name, code)
@@ -108,7 +124,7 @@ const TransformerDetailView = () => {
               variant="contained"
               color="error"
               size="small"
-              onClick={onDelete}
+              onClick={handleDeleteClick}
               disabled={deleteLoading}
               startIcon={!deleteLoading && <DeleteIcon />}
             >


### PR DESCRIPTION
## Decision Record

None of the forms/dialogs in the app ask for confirmation before a destructive action — clicking Delete on a forwarder, pipeline, stream, transformer, or a role/token/user row fires the API call immediately, with no way to back out of a misclick.

Considered a native window.confirm() — rejected, it can't be styled to match the app and reads as out of place next to the rest of the MUI UI.

Decided to add a single reusable DialogConfirm component (title/message/confirm label, opened through the existing useDialogs hook) and gate every delete action behind it. TableActionsCell was the one place this could be wired centrally, since it's shared by the Role, Token, and User tables.

This is part 1 of 3 for the "Harden forms & dialogs" initiative (dirty/pristine tracking and Save auto-disable, then Dialog close protection, will follow in separate PRs).

 - Closes #1452.

## Changes

### Confirmation before destructive actions
- [x] :sparkles: Add a reusable DialogConfirm component for destructive-action confirmations
- [x] :sparkles: Require confirmation before deleting a forwarder, pipeline, stream, or transformer
- [x] :sparkles: Require confirmation before deleting a role, token, or user (via TableActionsCell)
- [x] :white_check_mark: Update the forwarders/transformers/storage/account e2e specs to confirm before asserting deletion
- [x] :globe_with_meridians: Add the new common.actions.confirm and *.deleteConfirm.* translation strings

### Save button — no dirty tracking, no auto-disable
- [x] :sparkles: Disable Save when nothing changed or required fields are empty (forwarder, stream, and transformer editor dialogs)

### Dialogs close without protection
- [x] :sparkles: Confirm discarding unsaved changes before closing via backdrop, Escape, or Cancel (forwarder/stream/transformer editors + New Forwarder/Transformer/Stream/Pipeline/Role/User dialogs)
- [x] :sparkles: Require the explicit "Done" click to close the New Token dialog (token is shown only once)
- [x] :sparkles: Add a `warning` severity (orange, undo icon) to DialogConfirm, distinct from `danger`, for non-destructive discard confirmations
- [x] :globe_with_meridians: Add the new common.actions.discard and common.discardConfirm.* translation strings

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
