### PR TITLE
:bug: Fix CloudWatch timestamp units

### DIFF
--- a/internal/engines/forwarders/awscloudwatch.go
+++ b/internal/engines/forwarders/awscloudwatch.go
@@ -53,6 +53,10 @@ func (rt *awsCloudWatchRuntime) Close(context.Context) error {
 	return nil
 }
 
+func awsCloudWatchTimestamp(record *models.LogRecord) int64 {
+	return record.Timestamp.UnixMilli()
+}
+
 func (rt *awsCloudWatchRuntime) Call(ctx context.Context, record *models.LogRecord) error {
 	message, err := json.Marshal(record.Fields)
 	if err != nil {
@@ -61,7 +65,7 @@ func (rt *awsCloudWatchRuntime) Call(ctx context.Context, record *models.LogReco
 
 	event := types.InputLogEvent{
 		Message:   new(string(message)),
-		Timestamp: new(record.Timestamp.Unix()),
+		Timestamp: new(awsCloudWatchTimestamp(record)),
 	}
 
 	_, err = rt.client.PutLogEvents(ctx, &cloudwatchlogs.PutLogEventsInput{

--- a/internal/engines/forwarders/awscloudwatch_test.go
+++ b/internal/engines/forwarders/awscloudwatch_test.go
@@ -1,0 +1,17 @@
+package forwarders
+
+import (
+	"testing"
+	"time"
+
+	"link-society.com/flowg/internal/models"
+)
+
+func TestAwsCloudWatchTimestamp(t *testing.T) {
+	timestamp := time.Date(2026, time.August, 5, 15, 0, 0, 123_000_000, time.UTC)
+	record := &models.LogRecord{Timestamp: timestamp}
+
+	if got := awsCloudWatchTimestamp(record); got != timestamp.UnixMilli() {
+		t.Fatalf("expected timestamp %d, got %d", timestamp.UnixMilli(), got)
+	}
+}


### PR DESCRIPTION
## Decision Record

Fixes #1460.

AWS CloudWatch Logs expects `InputLogEvent.Timestamp` in milliseconds since the Unix epoch, while the forwarder used seconds. Use `time.Time.UnixMilli()` directly so the unit is explicit and sub-second precision is retained.

## Changes

- [x] :bug: Send CloudWatch log event timestamps in milliseconds.
- [x] :white_check_mark: Add a focused regression test for a timestamp with millisecond precision.

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
