### PR TITLE
fix(forwarders): send CloudWatch log timestamps in milliseconds

### DIFF
--- a/internal/engines/forwarders/awscloudwatch.go
+++ b/internal/engines/forwarders/awscloudwatch.go
@@ -61,7 +61,7 @@ func (rt *awsCloudWatchRuntime) Call(ctx context.Context, record *models.LogReco
 
 	event := types.InputLogEvent{
 		Message:   new(string(message)),
-		Timestamp: new(record.Timestamp.Unix()),
+		Timestamp: new(record.Timestamp.UnixMilli()),
 	}
 
 	_, err = rt.client.PutLogEvents(ctx, &cloudwatchlogs.PutLogEventsInput{


### PR DESCRIPTION
## Summary
AWS CloudWatch Logs `PutLogEvents` expects timestamps in **milliseconds**. The AWS CloudWatch forwarder used `Unix()` (seconds), so event times were wrong.

## Changes
- Use `record.Timestamp.UnixMilli()` when building `InputLogEvent.Timestamp`.

Closes #1460