### PR TITLE
:sparkles: Add read_auth_providers and write_auth_providers permissions

### DIFF
--- a/internal/models/auth_permissions.go
+++ b/internal/models/auth_permissions.go
@@ -23,6 +23,9 @@ type Permissions struct {
 
 	CanReadSystemConfiguration  bool `json:"can_read_system_configuration" required:"true"`
 	CanWriteSystemConfiguration bool `json:"can_write_system_configuration" required:"true"`
+
+	CanReadAuthProviders  bool `json:"can_read_auth_providers" required:"true"`
+	CanWriteAuthProviders bool `json:"can_write_auth_providers" required:"true"`
 }
 
 // PermissionsFromScopes projects a flat list of scopes into the Permissions
@@ -57,6 +60,10 @@ func PermissionsFromScopes(scopes []Scope) Permissions {
 			permissions.CanReadSystemConfiguration = true
 		case SCOPE_WRITE_SYSTEM_CONFIGURATION:
 			permissions.CanWriteSystemConfiguration = true
+		case SCOPE_READ_AUTH_PROVIDERS:
+			permissions.CanReadAuthProviders = true
+		case SCOPE_WRITE_AUTH_PROVIDERS:
+			permissions.CanWriteAuthProviders = true
 		}
 	}
 	return permissions

--- a/internal/models/auth_scope.go
+++ b/internal/models/auth_scope.go
@@ -21,6 +21,8 @@ const (
 	SCOPE_SEND_LOGS                  Scope = "send_logs"
 	SCOPE_READ_SYSTEM_CONFIGURATION  Scope = "read_system_configuration"
 	SCOPE_WRITE_SYSTEM_CONFIGURATION Scope = "write_system_configuration"
+	SCOPE_READ_AUTH_PROVIDERS        Scope = "read_auth_providers"
+	SCOPE_WRITE_AUTH_PROVIDERS       Scope = "write_auth_providers"
 )
 
 // ParseScope converts a wire string into a Scope, returning an error for unknown
@@ -53,6 +55,10 @@ func ParseScope(s string) (Scope, error) {
 		return SCOPE_READ_SYSTEM_CONFIGURATION, nil
 	case "write_system_configuration":
 		return SCOPE_WRITE_SYSTEM_CONFIGURATION, nil
+	case "read_auth_providers":
+		return SCOPE_READ_AUTH_PROVIDERS, nil
+	case "write_auth_providers":
+		return SCOPE_WRITE_AUTH_PROVIDERS, nil
 	default:
 		return "", fmt.Errorf("invalid scope: %s", s)
 	}
@@ -74,5 +80,7 @@ func (s Scope) Enum() []any {
 		SCOPE_SEND_LOGS,
 		SCOPE_READ_SYSTEM_CONFIGURATION,
 		SCOPE_WRITE_SYSTEM_CONFIGURATION,
+		SCOPE_READ_AUTH_PROVIDERS,
+		SCOPE_WRITE_AUTH_PROVIDERS,
 	}
 }

--- a/internal/storage/bootstrap/auth.go
+++ b/internal/storage/bootstrap/auth.go
@@ -39,6 +39,8 @@ func DefaultRolesAndUsers(ctx context.Context, authStorage storage.AuthStorage, 
 				models.SCOPE_WRITE_FORWARDERS,
 				models.SCOPE_READ_SYSTEM_CONFIGURATION,
 				models.SCOPE_WRITE_SYSTEM_CONFIGURATION,
+				models.SCOPE_READ_AUTH_PROVIDERS,
+				models.SCOPE_WRITE_AUTH_PROVIDERS,
 			},
 		}
 

--- a/web/app/src/lib/models/PermissionsModel.ts
+++ b/web/app/src/lib/models/PermissionsModel.ts
@@ -18,6 +18,9 @@ type PermissionsModel = {
 
   can_read_system_configuration: boolean
   can_write_system_configuration: boolean
+
+  can_read_auth_providers: boolean
+  can_write_auth_providers: boolean
 }
 
 export default PermissionsModel

--- a/web/app/src/lib/models/Scopes.ts
+++ b/web/app/src/lib/models/Scopes.ts
@@ -12,6 +12,8 @@ export const ScopeLabels = {
   send_logs: 'Send Logs',
   read_system_configuration: 'View System Configuration',
   write_system_configuration: 'View & Edit System Configuration',
+  read_auth_providers: 'View Auth Providers',
+  write_auth_providers: 'View & Edit Auth Providers',
 }
 
 export const Scopes = Object.keys(ScopeLabels)


### PR DESCRIPTION
## Decision Record

Related to #1375 

## Changes

- [x] :sparkles: Add read_auth_providers and write_auth_providers permissions and scopes

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
