### PR TITLE
:sparkles: Add CRUD methods to AuthStorage interface

### DIFF
--- a/internal/storage/databases/auth/storage.go
+++ b/internal/storage/databases/auth/storage.go
@@ -212,3 +212,43 @@ func (s *Storage[QTx, MTx]) DeleteToken(ctx context.Context, username string, to
 		return transactions.DeleteToken(txn, username, tokenUUID)
 	})
 }
+
+// ListAuthProviders implements [storage.AuthStorage].
+func (s *Storage[QTx, MTx]) ListAuthProviders(ctx context.Context) ([]models.AuthProvider, error) {
+	var providers []models.AuthProvider
+
+	err := s.adapter.View(ctx, func(txn QTx) error {
+		var err error
+		providers, err = transactions.ListAuthProviders(txn)
+		return err
+	})
+
+	return providers, err
+}
+
+// DeleteAuthProvider implements [storage.AuthStorage].
+func (s *Storage[QTx, MTx]) FetchAuthProvider(ctx context.Context, providerType string, name string) (models.AuthProvider, error) {
+	var provider models.AuthProvider
+
+	err := s.adapter.View(ctx, func(txn QTx) error {
+		var err error
+		provider, err = transactions.ReadAuthProvider(txn, providerType, name)
+		return err
+	})
+
+	return provider, err
+}
+
+// DeleteAuthProvider implements [storage.AuthStorage].
+func (s *Storage[QTx, MTx]) SaveAuthProvider(ctx context.Context, provider models.AuthProvider) error {
+	return s.adapter.Update(ctx, func(txn MTx) error {
+		return transactions.SaveAuthProvider(txn, provider)
+	})
+}
+
+// DeleteAuthProvider implements [storage.AuthStorage].
+func (s *Storage[QTx, MTx]) DeleteAuthProvider(ctx context.Context, providerType string, name string) error {
+	return s.adapter.Update(ctx, func(txn MTx) error {
+		return transactions.DeleteAuthProvider(txn, providerType, name)
+	})
+}

--- a/internal/storage/databases/auth/transactions/providers.go
+++ b/internal/storage/databases/auth/transactions/providers.go
@@ -1,0 +1,80 @@
+package transactions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/storage/generic/kv"
+)
+
+const PROVIDER = "provider"
+
+// ListAuthProviders returns deserialized array of models.AuthProvider
+func ListAuthProviders(txn kv.QueryTx) ([]models.AuthProvider, error) {
+	var providers []models.AuthProvider
+
+	for key := range txn.IterKeys(kv.Key{PROVIDER}, kv.KeyRange{}) {
+		var provider models.AuthProvider
+		err := json.Unmarshal([]byte(key[len(key)-1]), &provider)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshall auth provider: %w", err)
+		}
+
+		providers = append(providers, provider)
+	}
+
+	return providers, nil
+}
+
+// ReadAuthProvider returns deserialized instance of models.AuthProvider with provided type and name
+func ReadAuthProvider(txn kv.QueryTx, providerType string, name string) (models.AuthProvider, error) {
+	key := kv.Key{PROVIDER, providerType, name}
+
+	marshalled, err := txn.Get(key)
+	if err != nil {
+		return models.AuthProvider{}, fmt.Errorf("failed to find auth provider %q with type %q: %w", name, providerType, err)
+	}
+
+	var provider models.AuthProvider
+	err = json.Unmarshal(marshalled, &provider)
+	if err != nil {
+		return models.AuthProvider{}, fmt.Errorf("failed to unmarshall auth provider %q with type %q: %w", name, providerType, err)
+	}
+
+	return provider, nil
+}
+
+// SaveAuthProvider serializes models.AuthProvider and saves it to the database
+func SaveAuthProvider(txn kv.MutationTx, provider models.AuthProvider) error {
+	var providerType string
+
+	if provider.Config.Oidc != nil {
+		providerType = provider.Config.Oidc.Type
+	}
+
+	if provider.Config.Saml != nil {
+		providerType = provider.Config.Saml.Type
+	}
+
+	key := kv.Key{PROVIDER, providerType, provider.Name}
+
+	marshalled, err := json.Marshal(provider)
+	if err != nil {
+		return fmt.Errorf("failed to marshall auth provider %q with type %q: %w", provider.Name, providerType, err)
+	}
+
+	return txn.Set(key, marshalled)
+}
+
+// DeleteAuthProvider deletes provider from the database
+func DeleteAuthProvider(txn kv.MutationTx, providerType string, name string) error {
+	providerKey := kv.Key{PROVIDER, providerType, name}
+
+	if err := txn.Clear(providerKey); err != nil {
+		return fmt.Errorf("failed to clear auth provider %q: %w", name, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is untested because it requires #1377 do be finished as well in order to write unit tests.

@ShivanshKansal19 wanted to work on #1337 so I'm leaving that part to them.

## Decision Record

 - Closes #1374.

## Changes

 - [x] :sparkles: Add CRUD methods to AuthStorage interface

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
