### PR TITLE
:sparkles:  Add CRUD API endpoints to handle authentication providers

### DIFF
--- a/api/operations/delete_auth_provider.go
+++ b/api/operations/delete_auth_provider.go
@@ -1,0 +1,81 @@
+package operations
+
+import (
+	"context"
+	"log/slog"
+
+	"net/http"
+
+	"go.uber.org/fx"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/api/auth"
+	"link-society.com/flowg/api/logging"
+	"link-society.com/flowg/api/routing"
+	"link-society.com/flowg/api/schemas"
+
+	"link-society.com/flowg/internal/models"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+// DeleteAuthProviderDeps lists the dependencies of [NewDeleteAuthProviderUsecase].
+type DeleteAuthProviderDeps struct {
+	fx.In
+
+	AuthStorage storage.AuthStorage
+}
+
+// NewDeleteAuthProviderUsecase removes an auth provider.
+//
+// Callers must have the write-auth-providers permission. Deleting an absent auth provider is
+// treated as a success.
+func NewDeleteAuthProviderUsecase(deps DeleteAuthProviderDeps) usecase.Interactor {
+	logger := logging.Logger()
+
+	u := usecase.NewInteractor(
+		auth.RequireScopeApiDecorator(
+			deps.AuthStorage,
+			models.SCOPE_WRITE_AUTH_PROVIDERS,
+			func(
+				ctx context.Context,
+				req schemas.DeleteAuthProviderRequest,
+				resp *schemas.DeleteAuthProviderResponse,
+			) error {
+				err := deps.AuthStorage.DeleteAuthProvider(ctx, req.AuthProvider)
+				if err != nil {
+					logger.ErrorContext(
+						ctx,
+						"Failed to delete auth provider",
+						slog.String("auth_provider", req.AuthProvider),
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.Internal)
+				}
+
+				resp.Success = true
+				return nil
+			},
+		),
+	)
+
+	u.SetName("delete_auth_provider")
+	u.SetTitle("Delete Auth Provider")
+	u.SetDescription("Delete Auth Provider")
+	u.SetTags("auth")
+
+	u.SetExpectedErrors(status.PermissionDenied, status.Internal)
+
+	return u
+}
+
+func init() {
+	routing.RegisterOperation(
+		NewDeleteAuthProviderUsecase,
+		http.MethodDelete,
+		"/api/v1/auth-providers/{auth_provider}",
+	)
+}

--- a/api/operations/get_auth_provider.go
+++ b/api/operations/get_auth_provider.go
@@ -1,0 +1,83 @@
+package operations
+
+import (
+	"context"
+	"log/slog"
+
+	"net/http"
+
+	"go.uber.org/fx"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/api/auth"
+	"link-society.com/flowg/api/logging"
+	"link-society.com/flowg/api/routing"
+	"link-society.com/flowg/api/schemas"
+
+	"link-society.com/flowg/internal/models"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+// GetAuthProviderDeps lists the dependencies of [NewGetAuthProviderUsecase].
+type GetAuthProviderDeps struct {
+	fx.In
+
+	AuthStorage storage.AuthStorage
+}
+
+// NewGetAuthProviderUsecase returns a single auth provider along with its details.
+//
+// Callers must have the read-auth-providers permission. Requesting an unknown auth provider yields
+// a not-found error.
+func NewGetAuthProviderUsecase(deps GetAuthProviderDeps) usecase.Interactor {
+	logger := logging.Logger()
+
+	u := usecase.NewInteractor(
+		auth.RequireScopeApiDecorator(
+			deps.AuthStorage,
+			models.SCOPE_READ_AUTH_PROVIDERS,
+			func(
+				ctx context.Context,
+				req schemas.GetAuthProvidersRequest,
+				resp *schemas.GetAuthProvidersResponse,
+			) error {
+				authProvider, err := deps.AuthStorage.FetchAuthProvider(ctx, req.AuthProvider)
+				if err != nil {
+					logger.ErrorContext(
+						ctx,
+						"Failed to get auth provider",
+						slog.String("auth_provider", req.AuthProvider),
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.NotFound)
+				}
+
+				resp.Success = true
+				resp.AuthProvider = authProvider
+
+				return nil
+			},
+		),
+	)
+
+	u.SetName("get_auth_provider")
+	u.SetTitle("Get Auth Provider")
+	u.SetDescription("Get Auth Provider")
+	u.SetTags("auth")
+
+	u.SetExpectedErrors(status.PermissionDenied, status.NotFound)
+
+	return u
+}
+
+func init() {
+	routing.RegisterOperation(
+		NewGetAuthProviderUsecase,
+		http.MethodGet,
+		"/api/v1/auth-providers/{auth_provider}",
+	)
+}

--- a/api/operations/list_auth_providers.go
+++ b/api/operations/list_auth_providers.go
@@ -1,0 +1,81 @@
+package operations
+
+import (
+	"context"
+	"log/slog"
+
+	"net/http"
+
+	"go.uber.org/fx"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/api/logging"
+	"link-society.com/flowg/api/routing"
+	"link-society.com/flowg/api/schemas"
+
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+// ListAuthProvidersDeps lists the dependencies of [NewListAuthProvidersUsecase].
+type ListAuthProvidersDeps struct {
+	fx.In
+
+	AuthStorage storage.AuthStorage
+}
+
+// NewListAuthProvidersUsecase enumerates all available auth providers.
+func NewListAuthProvidersUsecase(deps ListAuthProvidersDeps) usecase.Interactor {
+	logger := logging.Logger()
+
+	u := usecase.NewInteractor(
+		func(
+			ctx context.Context,
+			req schemas.ListAuthProvidersRequest,
+			resp *schemas.ListAuthProvidersResponse,
+		) error {
+			authProviders, err := deps.AuthStorage.ListAuthProviders(ctx)
+			if err != nil {
+				logger.ErrorContext(
+					ctx,
+					"Failed to list auth providers",
+					slog.String("error", err.Error()),
+				)
+
+				resp.Success = false
+				return status.Wrap(err, status.Internal)
+			}
+
+			authProviderInfos := make([]schemas.AuthProviderInfo, len(authProviders))	
+			for i, ap := range authProviders {
+				authProviderInfos[i] = schemas.AuthProviderInfo{
+					Name:        ap.Name,
+					DisplayName: ap.DisplayName,
+				}
+			}
+
+			resp.Success = true
+			resp.AuthProviders = authProviderInfos
+			return nil
+		},
+	)
+
+	u.SetName("list_auth_providers")
+	u.SetTitle("List Auth Providers")
+	u.SetDescription("List available auth providers")
+	u.SetTags("auth")
+
+	u.SetExpectedErrors(status.PermissionDenied, status.Internal)
+
+	return u
+}
+
+func init() {
+	routing.RegisterOperation(
+		NewListAuthProvidersUsecase,
+		http.MethodGet,
+		"/api/v1/auth-providers/",
+		routing.Public(),
+	)
+}

--- a/api/operations/save_auth_provider.go
+++ b/api/operations/save_auth_provider.go
@@ -1,0 +1,82 @@
+package operations
+
+import (
+	"context"
+	"log/slog"
+
+	"net/http"
+
+	"go.uber.org/fx"
+
+	"github.com/swaggest/usecase"
+	"github.com/swaggest/usecase/status"
+
+	"link-society.com/flowg/api/auth"
+	"link-society.com/flowg/api/logging"
+	"link-society.com/flowg/api/routing"
+	"link-society.com/flowg/api/schemas"
+
+	"link-society.com/flowg/internal/models"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+// SaveAuthProviderDeps lists the dependencies of [NewSaveAuthProviderUsecase].
+type SaveAuthProviderDeps struct {
+	fx.In
+
+	AuthStorage storage.AuthStorage
+}
+
+// NewSaveAuthProviderUsecase creates or overwrites an auth provider.
+//
+// Callers must have the write-auth-providers permission.
+func NewSaveAuthProviderUsecase(deps SaveAuthProviderDeps) usecase.Interactor {
+	logger := logging.Logger()
+
+	u := usecase.NewInteractor(
+		auth.RequireScopeApiDecorator(
+			deps.AuthStorage,
+			models.SCOPE_WRITE_AUTH_PROVIDERS,
+			func(
+				ctx context.Context,
+				req schemas.SaveAuthProviderRequest,
+				resp *schemas.SaveAuthProviderResponse,
+			) error {
+				req.Config.Name = req.AuthProvider
+				err := deps.AuthStorage.SaveAuthProvider(ctx, req.Config)
+				if err != nil {
+					logger.ErrorContext(
+						ctx,
+						"Failed to save auth provider",
+						slog.String("auth_provider", req.AuthProvider),
+						slog.String("error", err.Error()),
+					)
+
+					resp.Success = false
+					return status.Wrap(err, status.Internal)
+				}
+
+				resp.Success = true
+
+				return nil
+			},
+		),
+	)
+
+	u.SetName("save_auth_provider")
+	u.SetTitle("Save Auth Provider")
+	u.SetDescription("Save auth provider")
+	u.SetTags("auth")
+
+	u.SetExpectedErrors(status.PermissionDenied, status.Internal)
+
+	return u
+}
+
+func init() {
+	routing.RegisterOperation(
+		NewSaveAuthProviderUsecase,
+		http.MethodPut,
+		"/api/v1/auth-providers/{auth_provider}",
+	)
+}

--- a/api/schemas/delete_auth_provider.go
+++ b/api/schemas/delete_auth_provider.go
@@ -1,0 +1,13 @@
+package schemas
+
+// DeleteAuthProviderRequest identifies the auth provider to remove.
+type DeleteAuthProviderRequest struct {
+	// AuthProvider is the name of the auth provider to delete.
+	AuthProvider string `path:"auth_provider" minLength:"1"`
+}
+
+// DeleteAuthProviderResponse reports the outcome of the deletion.
+type DeleteAuthProviderResponse struct {
+	// Success reports whether the auth provider was removed.
+	Success bool `json:"success"`
+}

--- a/api/schemas/get_auth_provider.go
+++ b/api/schemas/get_auth_provider.go
@@ -1,0 +1,19 @@
+package schemas
+
+import (
+	"link-society.com/flowg/internal/models"
+)
+
+// GetAuthProvidersRequest identifies the auth provider to retrieve.
+type GetAuthProvidersRequest struct {
+	// Name is the name of the auth provider to read.
+	AuthProvider string `path:"auth_provider" minLength:"1"`
+}
+
+// GetAuthProvidersResponse carries the requested auth provider information.
+type GetAuthProvidersResponse struct {
+	// Success reports whether the auth provider was found and returned.
+	Success bool `json:"success"`
+	// AuthProvider is the auth provider and its details.
+	AuthProvider *models.AuthProvider `json:"auth_provider"`
+}

--- a/api/schemas/list_auth_providers.go
+++ b/api/schemas/list_auth_providers.go
@@ -1,0 +1,19 @@
+package schemas
+
+// AuthProviderInfo carries the name and display name of an auth provider.
+type AuthProviderInfo struct {
+	Name string `json:"name" required:"true"`
+	DisplayName string `json:"display_name" required:"true"`
+}
+
+// ListAuthProvidersRequest is empty: listing auth providers takes no parameters.
+type ListAuthProvidersRequest struct{}
+
+// ListAuthProvidersResponse carries the names and display names of the available auth providers.
+type ListAuthProvidersResponse struct {
+	// Success reports whether the listing completed.
+	Success bool `json:"success"`
+	// AuthProviders holds the name and display name of every configured auth provider.
+	AuthProviders []AuthProviderInfo `json:"auth_providers"`
+}
+

--- a/api/schemas/save_auth_provider.go
+++ b/api/schemas/save_auth_provider.go
@@ -1,0 +1,17 @@
+package schemas
+
+import "link-society.com/flowg/internal/models"
+
+// SaveAuthProviderRequest carries the auth provider name and its new definition.
+type SaveAuthProviderRequest struct {
+	// AuthProvider is the name of the auth provider to create or overwrite.
+	AuthProvider string `path:"auth_provider" minLength:"1"`
+	// Config is the auth provider definition to store under that name.
+	Config models.AuthProvider `json:"auth_provider" required:"true"`
+}
+
+// SaveAuthProviderResponse reports the outcome of the save.
+type SaveAuthProviderResponse struct {
+	// Success reports whether the auth provider was persisted.
+	Success bool `json:"success"`
+}

--- a/internal/storage/databases/auth/transactions/providers.go
+++ b/internal/storage/databases/auth/transactions/providers.go
@@ -15,14 +15,15 @@ func ListAuthProviders(txn kv.QueryTx) ([]models.AuthProvider, error) {
 	var providers []models.AuthProvider
 
 	for key := range txn.IterKeys(kv.Key{PROVIDER}, kv.KeyRange{}) {
-		var provider models.AuthProvider
-		err := json.Unmarshal([]byte(key[len(key)-1]), &provider)
-
+		name := key[len(key)-1]
+		provider, err := ReadAuthProvider(txn, name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshall auth provider: %w", err)
+			return nil, fmt.Errorf("failed to list auth providers: %w", err)
 		}
 
-		providers = append(providers, provider)
+		if provider != nil {
+			providers = append(providers, *provider)
+		}
 	}
 
 	return providers, nil
@@ -37,20 +38,20 @@ func ReadAuthProvider(txn kv.QueryTx, name string) (*models.AuthProvider, error)
 		return nil, fmt.Errorf("failed to find auth provider %q: %w", name, err)
 	}
 
-	var provider *models.AuthProvider
-	err = json.Unmarshal(marshalled, provider)
+	var provider models.AuthProvider
+	err = json.Unmarshal(marshalled, &provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall auth provider %q: %w", name, err)
 	}
 
-	return provider, nil
+	return &provider, nil
 }
 
 // SaveAuthProvider serializes models.AuthProvider and saves it to the database
 func SaveAuthProvider(txn kv.MutationTx, provider models.AuthProvider) error {
 	key := kv.Key{PROVIDER, provider.Name}
 
-	marshalled, err := json.Marshal(provider)
+	marshalled, err := json.Marshal(&provider)
 	if err != nil {
 		return fmt.Errorf("failed to marshall auth provider %q: %w", provider.Name, err)
 	}

--- a/tests/specs/api/auth_provider_oicd.hurl
+++ b/tests/specs/api/auth_provider_oicd.hurl
@@ -1,0 +1,55 @@
+###############################################################################
+# DESCRIPTION: Test Oicd auth provider
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Check Create Oicd auth provider
+#  - Verify the Oicd auth provider appears in the list
+#  - Verify the Oicd auth provider can be fetched individually
+#  - Delete the Oicd auth provider
+#  - Verify the Oicd auth provider is deleted
+
+PUT http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "auth_provider": {
+    "name": "test-oidc",
+    "display_name": "Test OIDC Connection",
+    "config": {
+      "type": "oidc",
+      "issuer": "https://example.com",
+      "client_id": "abc",
+      "client_secret": "123"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_providers" count == 1
+jsonpath "$.auth_providers[0].name" == "test-oidc"
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_provider.name" == "test-oidc"
+jsonpath "$.auth_provider.display_name" == "Test OIDC Connection"
+
+DELETE http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 404

--- a/tests/specs/api/auth_provider_saml.hurl
+++ b/tests/specs/api/auth_provider_saml.hurl
@@ -1,0 +1,53 @@
+###############################################################################
+# DESCRIPTION: Test Saml auth provider
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Check Create Saml auth provider
+#  - Verify the Saml auth provider appears in the list
+#  - Verify the Saml auth provider can be fetched individually
+#  - Delete the Saml auth provider
+#  - Verify the Saml auth provider is deleted
+
+PUT http://localhost:5080/api/v1/auth-providers/test-saml
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "auth_provider": {
+    "name": "test-saml",
+    "display_name": "Test SAML Connection",
+    "config": {
+      "type": "saml",
+      "idp_metadata_url": "https://example.com"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_providers" count == 1
+jsonpath "$.auth_providers[0].name" == "test-saml"
+
+GET http://localhost:5080/api/v1/auth-providers/test-saml
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_provider.name" == "test-saml"
+jsonpath "$.auth_provider.display_name" == "Test SAML Connection"
+
+DELETE http://localhost:5080/api/v1/auth-providers/test-saml
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/test-saml
+Authorization: Bearer {{admin_token}}
+HTTP 404

--- a/tests/specs/api/auth_providers.hurl
+++ b/tests/specs/api/auth_providers.hurl
@@ -1,0 +1,98 @@
+###############################################################################
+# DESCRIPTION: Test auth provider management through API
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Verify that no auth providers exist initially
+#  - Verify that trying to get a non-existent auth provider returns 404
+
+GET http://localhost:5080/api/v1/auth-providers/
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_providers" count == 0
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 404
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Check Create auth provider endpoint is authenticated
+#  - Create a auth provider
+#  - Verify the auth provider appears in the list
+#  - Check Read auth provider endpoint is authenticated
+#  - Verify the auth provider can be fetched individually
+
+PUT http://localhost:5080/api/v1/auth-providers/test-oidc
+Content-Type: application/json
+{
+  "auth_provider": {
+    "name": "test-oidc",
+    "display_name": "Test OIDC Connection",
+    "config": {
+      "type": "oidc",
+      "issuer": "https://example.com",
+      "client_id": "abc",
+      "client_secret": "123"
+    }
+  }
+}
+HTTP 401
+
+PUT http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "auth_provider": {
+    "name": "test-oidc",
+    "display_name": "Test OIDC Connection",
+    "config": {
+      "type": "oidc",
+      "issuer": "https://example.com",
+      "client_id": "abc",
+      "client_secret": "123"
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_providers" count == 1
+jsonpath "$.auth_providers[0].name" == "test-oidc"
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+HTTP 401
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.auth_provider.name" == "test-oidc"
+jsonpath "$.auth_provider.display_name" == "Test OIDC Connection"
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Check Delete auth provider endpoint is authenticated
+#  - Delete the auth provider
+#  - Verify the auth provider is deleted
+
+DELETE http://localhost:5080/api/v1/auth-providers/test-oidc
+HTTP 401
+
+DELETE http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+GET http://localhost:5080/api/v1/auth-providers/test-oidc
+Authorization: Bearer {{admin_token}}
+HTTP 404


### PR DESCRIPTION
## Decision Record


 - Closes #1377.

## Changes

- [x] :sparkles: Add CRUD API endpoints to handle authentication providers

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
