### PR TITLE
:recycle: Remove provider type from key of Authentication Provider storage interface

### DIFF
--- a/internal/storage/databases/auth/storage.go
+++ b/internal/storage/databases/auth/storage.go
@@ -227,12 +227,12 @@ func (s *Storage[QTx, MTx]) ListAuthProviders(ctx context.Context) ([]models.Aut
 }
 
 // DeleteAuthProvider implements [storage.AuthStorage].
-func (s *Storage[QTx, MTx]) FetchAuthProvider(ctx context.Context, providerType string, name string) (models.AuthProvider, error) {
-	var provider models.AuthProvider
+func (s *Storage[QTx, MTx]) FetchAuthProvider(ctx context.Context, name string) (*models.AuthProvider, error) {
+	var provider *models.AuthProvider
 
 	err := s.adapter.View(ctx, func(txn QTx) error {
 		var err error
-		provider, err = transactions.ReadAuthProvider(txn, providerType, name)
+		provider, err = transactions.ReadAuthProvider(txn, name)
 		return err
 	})
 
@@ -247,8 +247,8 @@ func (s *Storage[QTx, MTx]) SaveAuthProvider(ctx context.Context, provider model
 }
 
 // DeleteAuthProvider implements [storage.AuthStorage].
-func (s *Storage[QTx, MTx]) DeleteAuthProvider(ctx context.Context, providerType string, name string) error {
+func (s *Storage[QTx, MTx]) DeleteAuthProvider(ctx context.Context, name string) error {
 	return s.adapter.Update(ctx, func(txn MTx) error {
-		return transactions.DeleteAuthProvider(txn, providerType, name)
+		return transactions.DeleteAuthProvider(txn, name)
 	})
 }

--- a/internal/storage/databases/auth/transactions/providers.go
+++ b/internal/storage/databases/auth/transactions/providers.go
@@ -29,18 +29,18 @@ func ListAuthProviders(txn kv.QueryTx) ([]models.AuthProvider, error) {
 }
 
 // ReadAuthProvider returns deserialized instance of models.AuthProvider with provided type and name
-func ReadAuthProvider(txn kv.QueryTx, providerType string, name string) (models.AuthProvider, error) {
-	key := kv.Key{PROVIDER, providerType, name}
+func ReadAuthProvider(txn kv.QueryTx, name string) (*models.AuthProvider, error) {
+	key := kv.Key{PROVIDER, name}
 
 	marshalled, err := txn.Get(key)
 	if err != nil {
-		return models.AuthProvider{}, fmt.Errorf("failed to find auth provider %q with type %q: %w", name, providerType, err)
+		return nil, fmt.Errorf("failed to find auth provider %q: %w", name, err)
 	}
 
-	var provider models.AuthProvider
-	err = json.Unmarshal(marshalled, &provider)
+	var provider *models.AuthProvider
+	err = json.Unmarshal(marshalled, provider)
 	if err != nil {
-		return models.AuthProvider{}, fmt.Errorf("failed to unmarshall auth provider %q with type %q: %w", name, providerType, err)
+		return nil, fmt.Errorf("failed to unmarshall auth provider %q: %w", name, err)
 	}
 
 	return provider, nil
@@ -48,29 +48,19 @@ func ReadAuthProvider(txn kv.QueryTx, providerType string, name string) (models.
 
 // SaveAuthProvider serializes models.AuthProvider and saves it to the database
 func SaveAuthProvider(txn kv.MutationTx, provider models.AuthProvider) error {
-	var providerType string
-
-	if provider.Config.Oidc != nil {
-		providerType = provider.Config.Oidc.Type
-	}
-
-	if provider.Config.Saml != nil {
-		providerType = provider.Config.Saml.Type
-	}
-
-	key := kv.Key{PROVIDER, providerType, provider.Name}
+	key := kv.Key{PROVIDER, provider.Name}
 
 	marshalled, err := json.Marshal(provider)
 	if err != nil {
-		return fmt.Errorf("failed to marshall auth provider %q with type %q: %w", provider.Name, providerType, err)
+		return fmt.Errorf("failed to marshall auth provider %q: %w", provider.Name, err)
 	}
 
 	return txn.Set(key, marshalled)
 }
 
 // DeleteAuthProvider deletes provider from the database
-func DeleteAuthProvider(txn kv.MutationTx, providerType string, name string) error {
-	providerKey := kv.Key{PROVIDER, providerType, name}
+func DeleteAuthProvider(txn kv.MutationTx, name string) error {
+	providerKey := kv.Key{PROVIDER, name}
 
 	if err := txn.Clear(providerKey); err != nil {
 		return fmt.Errorf("failed to clear auth provider %q: %w", name, err)

--- a/internal/storage/interfaces/auth.go
+++ b/internal/storage/interfaces/auth.go
@@ -59,4 +59,14 @@ type AuthStorage interface {
 	// DeleteToken revokes the personal access token identified by tokenUUID for
 	// the named user.
 	DeleteToken(ctx context.Context, username string, tokenUUID string) error
+
+	// ListAuthProviders returns every auth provider known to the store.
+	ListAuthProviders(ctx context.Context) ([]models.AuthProvider, error)
+	// FetchAuthProvider returns the auth provider with the given name, or an
+	// error if it does not exist.
+	FetchAuthProvider(ctx context.Context, name string) (*models.AuthProvider, error)
+	// SaveAuthProvider creates or replaces an auth provider.
+	SaveAuthProvider(ctx context.Context, provider models.AuthProvider) error
+	// DeleteAuthProvider removes the auth provider with the given name.
+	DeleteAuthProvider(ctx context.Context, name string) error
 }

--- a/internal/storage/mocks/auth.go
+++ b/internal/storage/mocks/auth.go
@@ -111,3 +111,23 @@ func (m *MockAuthStorage) DeleteToken(ctx context.Context, username string, toke
 	args := m.Called(ctx, username, tokenUUID)
 	return args.Error(0)
 }
+
+func (m *MockAuthStorage) ListAuthProviders(ctx context.Context) ([]models.AuthProvider, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.AuthProvider), args.Error(1)
+}
+
+func (m *MockAuthStorage) FetchAuthProvider(ctx context.Context, name string) (*models.AuthProvider, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*models.AuthProvider), args.Error(1)
+}
+
+func (m *MockAuthStorage) SaveAuthProvider(ctx context.Context, provider models.AuthProvider) error {
+	args := m.Called(ctx, provider)
+	return args.Error(0)
+}
+
+func (m *MockAuthStorage) DeleteAuthProvider(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}


### PR DESCRIPTION
## Decision Record


 - Closes #1477.

## Changes

 - [x] :recycle: Remove `providerType` from key of Authentication Provider storage interface

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
