### PR TITLE
:recycle: :bug: Propagate side effects cluster-wide

### DIFF
--- a/api/middlewares/elastic.go
+++ b/api/middlewares/elastic.go
@@ -233,7 +233,7 @@ func NewElasticHandler(deps ElasticDeps) http.Handler {
 			flatten("", doc)
 
 			record := models.NewLogRecord(fields)
-			err = deps.PipelineRunner.Run(
+			err = deps.PipelineRunner.Process(
 				r.Context(),
 				index,
 				pipelines.DIRECT_ENTRYPOINT,

--- a/api/middlewares/elastic_test.go
+++ b/api/middlewares/elastic_test.go
@@ -48,7 +48,7 @@ func TestElasticEndpoint(t *testing.T) {
 	mockConfigStorage.On("ListPipelines", mock.Anything).
 		Return([]string{"test"}, nil)
 
-	mockPipelineRunner.On("Run", mock.Anything, "test", pipelines.DIRECT_ENTRYPOINT, mock.Anything).
+	mockPipelineRunner.On("Process", mock.Anything, "test", pipelines.DIRECT_ENTRYPOINT, mock.Anything).
 		Return(nil)
 
 	handler := middlewares.NewElasticHandler(deps)

--- a/api/operations/ingest_logs_otlp.go
+++ b/api/operations/ingest_logs_otlp.go
@@ -58,7 +58,7 @@ func NewIngestLogsOTLPUsecase(deps IngestLogsOTLPDeps) usecase.Interactor {
 				applog.MarkSensitive(ctx)
 
 				for _, logRecord := range req.LogRecords {
-					err := deps.PipelineRunner.Run(
+					err := deps.PipelineRunner.Process(
 						ctx,
 						req.Pipeline,
 						pipelines.DIRECT_ENTRYPOINT,

--- a/api/operations/ingest_logs_struct.go
+++ b/api/operations/ingest_logs_struct.go
@@ -54,7 +54,7 @@ func NewIngestLogsStructUsecase(deps IngestLogsStructDeps) usecase.Interactor {
 
 				for _, recordData := range req.Records {
 					record := models.NewLogRecord(recordData)
-					err := deps.PipelineRunner.Run(
+					err := deps.PipelineRunner.Process(
 						ctx,
 						req.Pipeline,
 						pipelines.DIRECT_ENTRYPOINT,

--- a/api/operations/ingest_logs_text.go
+++ b/api/operations/ingest_logs_text.go
@@ -73,7 +73,7 @@ func NewIngestLogsTextUsecase(deps IngestLogsTextDeps) usecase.Interactor {
 						},
 					}
 
-					err := deps.PipelineRunner.Run(
+					err := deps.PipelineRunner.Process(
 						ctx,
 						req.Pipeline,
 						pipelines.DIRECT_ENTRYPOINT,

--- a/api/operations/save_forwarder.go
+++ b/api/operations/save_forwarder.go
@@ -60,17 +60,6 @@ func NewSaveForwarderUsecase(deps SaveForwarderDeps) usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
-				if err := deps.PipelineRunner.InvalidateAllCachedBuilds(ctx); err != nil {
-					logger.ErrorContext(
-						ctx,
-						"Failed to refresh pipeline cache after save",
-						slog.String("error", err.Error()),
-					)
-
-					resp.Success = false
-					return status.Wrap(err, status.Internal)
-				}
-
 				resp.Success = true
 
 				return nil

--- a/api/operations/save_forwarder.go
+++ b/api/operations/save_forwarder.go
@@ -16,7 +16,6 @@ import (
 	"link-society.com/flowg/api/routing"
 	"link-society.com/flowg/api/schemas"
 
-	"link-society.com/flowg/internal/engines/pipelines"
 	"link-society.com/flowg/internal/models"
 	storage "link-society.com/flowg/internal/storage/interfaces"
 )
@@ -25,16 +24,15 @@ import (
 type SaveForwarderDeps struct {
 	fx.In
 
-	AuthStorage    storage.AuthStorage
-	ConfigStorage  storage.ConfigStorage
-	PipelineRunner pipelines.Runner
+	AuthStorage   storage.AuthStorage
+	ConfigStorage storage.ConfigStorage
 }
 
 // NewSaveForwarderUsecase creates or overwrites a forwarder.
 //
 // Callers must have the write-forwarders permission. Persisting a forwarder
-// invalidates cached pipeline builds so that subsequent runs use the new
-// definition.
+// notifies the pipeline runner, which rebuilds every pipeline so that
+// subsequent runs use the new definition.
 func NewSaveForwarderUsecase(deps SaveForwarderDeps) usecase.Interactor {
 	logger := logging.Logger()
 

--- a/api/operations/save_pipeline.go
+++ b/api/operations/save_pipeline.go
@@ -58,18 +58,6 @@ func NewSavePipelineUsecase(deps SavePipelineDeps) usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
-				if err := deps.PipelineRunner.InvalidateCachedBuild(ctx, req.Pipeline); err != nil {
-					logger.ErrorContext(
-						ctx,
-						"Failed to refresh pipeline cache after save",
-						slog.String("pipeline", req.Pipeline),
-						slog.String("error", err.Error()),
-					)
-
-					resp.Success = false
-					return status.Wrap(err, status.Internal)
-				}
-
 				resp.Success = true
 
 				return nil

--- a/api/operations/save_pipeline.go
+++ b/api/operations/save_pipeline.go
@@ -16,7 +16,6 @@ import (
 	"link-society.com/flowg/api/routing"
 	"link-society.com/flowg/api/schemas"
 
-	"link-society.com/flowg/internal/engines/pipelines"
 	"link-society.com/flowg/internal/models"
 	storage "link-society.com/flowg/internal/storage/interfaces"
 )
@@ -25,15 +24,14 @@ import (
 type SavePipelineDeps struct {
 	fx.In
 
-	AuthStorage    storage.AuthStorage
-	ConfigStorage  storage.ConfigStorage
-	PipelineRunner pipelines.Runner
+	AuthStorage   storage.AuthStorage
+	ConfigStorage storage.ConfigStorage
 }
 
 // NewSavePipelineUsecase creates or overwrites a pipeline.
 //
 // Callers must have the write-pipelines permission. Persisting a pipeline
-// invalidates its cached build so that subsequent runs use the new flow graph.
+// notifies the pipeline runner, which rebuilds and restarts it.
 func NewSavePipelineUsecase(deps SavePipelineDeps) usecase.Interactor {
 	logger := logging.Logger()
 

--- a/api/operations/save_transformer.go
+++ b/api/operations/save_transformer.go
@@ -59,17 +59,6 @@ func NewSaveTransformerUsecase(deps SaveTransformerDeps) usecase.Interactor {
 					return status.Wrap(err, status.Internal)
 				}
 
-				if err := deps.PipelineRunner.InvalidateAllCachedBuilds(ctx); err != nil {
-					logger.ErrorContext(
-						ctx,
-						"Failed to refresh pipeline cache after save",
-						slog.String("error", err.Error()),
-					)
-
-					resp.Success = false
-					return status.Wrap(err, status.Internal)
-				}
-
 				resp.Success = true
 
 				return nil

--- a/api/operations/save_transformer.go
+++ b/api/operations/save_transformer.go
@@ -16,7 +16,6 @@ import (
 	"link-society.com/flowg/api/routing"
 	"link-society.com/flowg/api/schemas"
 
-	"link-society.com/flowg/internal/engines/pipelines"
 	"link-society.com/flowg/internal/models"
 	storage "link-society.com/flowg/internal/storage/interfaces"
 )
@@ -25,16 +24,15 @@ import (
 type SaveTransformerDeps struct {
 	fx.In
 
-	AuthStorage    storage.AuthStorage
-	ConfigStorage  storage.ConfigStorage
-	PipelineRunner pipelines.Runner
+	AuthStorage   storage.AuthStorage
+	ConfigStorage storage.ConfigStorage
 }
 
 // NewSaveTransformerUsecase creates or overwrites a transformer.
 //
 // Callers must have the write-transformers permission. Persisting a transformer
-// invalidates cached pipeline builds so that subsequent runs pick up the new
-// source.
+// notifies the pipeline runner, which rebuilds every pipeline so that
+// subsequent runs pick up the new source.
 func NewSaveTransformerUsecase(deps SaveTransformerDeps) usecase.Interactor {
 	logger := logging.Logger()
 

--- a/api/operations/test_pipeline.go
+++ b/api/operations/test_pipeline.go
@@ -57,7 +57,7 @@ func NewTestPipelineUsecase(deps TestPipelineDeps) usecase.Interactor {
 
 				for _, recordData := range req.Records {
 					record := models.NewLogRecord(recordData)
-					err := deps.PipelineRunner.Run(
+					err := deps.PipelineRunner.Process(
 						ctx,
 						req.Pipeline,
 						pipelines.DIRECT_ENTRYPOINT,

--- a/docker/flowg.dockerfile
+++ b/docker/flowg.dockerfile
@@ -123,6 +123,7 @@ RUN go generate ./...
 RUN CGO_ENABLED=1 \
     CGO_CFLAGS="-I/workspace/third-party/foundationdb/7.3.77/include" \
     CGO_LDFLAGS="-L/workspace/third-party/foundationdb/7.3.77/lib/linux/$(go env GOARCH)" \
+    LD_LIBRARY_PATH="/workspace/third-party/foundationdb/7.3.77/lib/linux/$(go env GOARCH)" \
     go test -timeout 500ms -v ./...
 RUN CGO_ENABLED=1 \
     CGO_CFLAGS="-I/workspace/third-party/foundationdb/7.3.77/include" \

--- a/internal/app/server/main.go
+++ b/internal/app/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	storage "link-society.com/flowg/internal/storage/interfaces"
 
+	"link-society.com/flowg/internal/engines/confignotify"
 	"link-society.com/flowg/internal/engines/lognotify"
 	"link-society.com/flowg/internal/engines/pipelines"
 
@@ -61,6 +62,8 @@ type StorageOptions interface {
 func NewServer(opts Options) fx.Option {
 	return fx.Module(
 		"app.server",
+		// Engine Layer (confignotify first: storage modules depend on it)
+		confignotify.NewNotifier(),
 		// Storage Layer
 		opts.Storage.AuthModule(),
 		opts.Storage.ConfigModule(),

--- a/internal/engines/confignotify/README.md
+++ b/internal/engines/confignotify/README.md
@@ -1,0 +1,43 @@
+# confignotify
+
+The package at `internal/engines/confignotify` is the notification bus for
+configuration changes. The config storage publishes an event after every
+successful pipeline, transformer or forwarder mutation, and the pipeline runner
+subscribes to (re)build or terminate the affected pipelines.
+
+It exists to decouple the pipeline lifecycle from the API layer: mutations
+trigger lifecycle changes at the storage level, so the runner reacts the same
+way whether a change came from the local API, a bootstrap write, or (on
+clustered backends) another node observed through a storage watcher.
+
+## Responsibilities
+
+- **Subscriptions** — registers per-subscriber mailboxes and tears them down
+  when the subscriber's context is cancelled.
+- **Fan-out** — broadcasts each event to every current subscriber, logging —
+  but never failing on — individual delivery errors.
+- **Wiring** — `NewNotifier` returns an `fx` module providing a `Notifier`
+  whose actor and mailboxes follow the application lifecycle.
+
+## Events
+
+- **PipelineChanged** — a pipeline was created or updated; subscribers should
+  rebuild it.
+- **PipelineDeleted** — a pipeline was removed; subscribers should terminate it.
+- **DependenciesChanged** — a transformer or forwarder changed, or the whole
+  configuration was restored; subscribers should reconcile everything.
+
+## Layout
+
+- **main.go** — the `Notifier` interface, its actor-backed implementation and
+  `fx` wiring.
+- **types.go** — the event model and the messages exchanged with the actor.
+- **worker.go** — the actor body that owns the subscriber registry.
+- **mocks/** — a testify mock of `Notifier` for tests.
+
+## Delivery model
+
+`Subscribe` blocks until the actor confirms the registration, so no event can
+slip through between subscribing and the first delivery. `Notify`, by contrast,
+returns as soon as the event is queued: delivery to subscribers happens
+asynchronously and best-effort.

--- a/internal/engines/confignotify/main.go
+++ b/internal/engines/confignotify/main.go
@@ -1,0 +1,137 @@
+package confignotify
+
+import (
+	"context"
+
+	"github.com/vladopajic/go-actor/actor"
+	"go.uber.org/fx"
+)
+
+// Notifier is the fan-out bus for configuration changes. The config storage
+// publishes an event after every successful mutation, and interested engines
+// (the pipeline runner) subscribe to react to them. On clustered backends the
+// storage watcher publishes the events instead, so subscribers observe local
+// and remote changes through the same bus.
+type Notifier interface {
+	// Subscribe registers the caller as a listener and returns a mailbox that
+	// receives every subsequent event. The subscription is torn down when ctx is
+	// cancelled.
+	Subscribe(ctx context.Context) (actor.MailboxReceiver[Event], error)
+	// Notify broadcasts a configuration change to every current subscriber; it
+	// is a no-op when nobody is listening.
+	Notify(ctx context.Context, event Event) error
+}
+
+type notifierImpl struct {
+	actor.Actor
+
+	subMbox   actor.MailboxSender[SubscribeMessage]
+	eventMbox actor.MailboxSender[Event]
+}
+
+var _ Notifier = (*notifierImpl)(nil)
+
+// NewNotifier returns an fx module providing a Notifier backed by a single
+// actor. The actor and its two mailboxes (subscriptions and event broadcasts)
+// are started and stopped with the application lifecycle.
+func NewNotifier() fx.Option {
+	return fx.Module(
+		"confignotifier",
+		fx.Provide(func(lc fx.Lifecycle) actor.Mailbox[SubscribeMessage] {
+			mbox := actor.NewMailbox[SubscribeMessage]()
+
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					mbox.Start()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					mbox.Stop()
+					return nil
+				},
+			})
+
+			return mbox
+		}),
+		fx.Provide(func(lc fx.Lifecycle) actor.Mailbox[Event] {
+			mbox := actor.NewMailbox[Event]()
+
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					mbox.Start()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					mbox.Stop()
+					return nil
+				},
+			})
+
+			return mbox
+		}),
+		fx.Provide(func(
+			lc fx.Lifecycle,
+			subMbox actor.Mailbox[SubscribeMessage],
+			eventMbox actor.Mailbox[Event],
+		) Notifier {
+			notifier := &notifierImpl{
+				Actor: actor.New(&worker{
+					subscribers: make(map[actor.Mailbox[Event]]<-chan struct{}),
+					subMbox:     subMbox,
+					eventMbox:   eventMbox,
+				}),
+
+				subMbox:   subMbox,
+				eventMbox: eventMbox,
+			}
+
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					notifier.Start()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					notifier.Stop()
+					return nil
+				},
+			})
+
+			return notifier
+		}),
+	)
+}
+
+// Subscribe asks the actor to register a new per-subscriber mailbox and blocks
+// until the actor confirms the registration, guaranteeing no event is missed
+// between the call and the first delivery.
+func (n *notifierImpl) Subscribe(ctx context.Context) (actor.MailboxReceiver[Event], error) {
+	eventM := actor.NewMailbox[Event]()
+	eventM.Start()
+
+	readyC := make(chan ReadyResponse, 1)
+	msg := SubscribeMessage{
+		SenderM: eventM,
+		ReadyC:  readyC,
+		DoneC:   ctx.Done(),
+	}
+
+	err := n.subMbox.Send(ctx, msg)
+	if err != nil {
+		eventM.Stop()
+		return nil, err
+	}
+
+	resp := <-readyC
+	if resp.Err != nil {
+		eventM.Stop()
+		return nil, resp.Err
+	}
+
+	return eventM, nil
+}
+
+// Notify hands an event to the actor for broadcasting; it returns as soon as
+// the event is queued, without waiting for delivery to subscribers.
+func (n *notifierImpl) Notify(ctx context.Context, event Event) error {
+	return n.eventMbox.Send(ctx, event)
+}

--- a/internal/engines/confignotify/mocks/notifier.go
+++ b/internal/engines/confignotify/mocks/notifier.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"context"
+
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+)
+
+// MockNotifier is a testify mock implementation of Notifier for use in tests.
+type MockNotifier struct {
+	mock.Mock
+}
+
+var _ confignotify.Notifier = (*MockNotifier)(nil)
+
+// NewMockNotifier returns a Notifier whose calls can be stubbed and asserted.
+func NewMockNotifier() confignotify.Notifier {
+	return &MockNotifier{}
+}
+
+func (m *MockNotifier) Subscribe(ctx context.Context) (actor.MailboxReceiver[confignotify.Event], error) {
+	args := m.Called(ctx)
+	return args.Get(0).(actor.MailboxReceiver[confignotify.Event]), args.Error(1)
+}
+
+func (m *MockNotifier) Notify(ctx context.Context, event confignotify.Event) error {
+	args := m.Called(ctx, event)
+	return args.Error(0)
+}

--- a/internal/engines/confignotify/notify_test.go
+++ b/internal/engines/confignotify/notify_test.go
@@ -1,0 +1,84 @@
+package confignotify_test
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+)
+
+func TestNotifier(t *testing.T) {
+	var notifier confignotify.Notifier
+
+	app := fxtest.New(
+		t,
+		confignotify.NewNotifier(),
+		fx.Populate(&notifier),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	eventM, err := notifier.Subscribe(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error while subscribing: %v", err)
+	}
+
+	event := confignotify.Event{
+		Kind:     confignotify.PipelineChanged,
+		Pipeline: "test",
+	}
+
+	if err := notifier.Notify(t.Context(), event); err != nil {
+		t.Fatalf("unexpected error while notifying: %v", err)
+	}
+
+	result, ok := <-eventM.ReceiveC()
+	if !ok {
+		t.Fatalf("unexpected closed channel")
+	}
+
+	if result != event {
+		t.Fatalf("unexpected event: %v", result)
+	}
+}
+
+func TestNotifier_MultipleSubscribers(t *testing.T) {
+	var notifier confignotify.Notifier
+
+	app := fxtest.New(
+		t,
+		confignotify.NewNotifier(),
+		fx.Populate(&notifier),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	first, err := notifier.Subscribe(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error while subscribing: %v", err)
+	}
+	second, err := notifier.Subscribe(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error while subscribing: %v", err)
+	}
+
+	event := confignotify.Event{Kind: confignotify.DependenciesChanged}
+
+	if err := notifier.Notify(t.Context(), event); err != nil {
+		t.Fatalf("unexpected error while notifying: %v", err)
+	}
+
+	for _, sub := range []interface{ ReceiveC() <-chan confignotify.Event }{first, second} {
+		result, ok := <-sub.ReceiveC()
+		if !ok {
+			t.Fatalf("unexpected closed channel")
+		}
+		if result != event {
+			t.Fatalf("unexpected event: %v", result)
+		}
+	}
+}

--- a/internal/engines/confignotify/types.go
+++ b/internal/engines/confignotify/types.go
@@ -1,0 +1,42 @@
+package confignotify
+
+import (
+	"github.com/vladopajic/go-actor/actor"
+)
+
+// EventKind discriminates configuration change events.
+type EventKind int
+
+const (
+	// PipelineChanged reports that a pipeline was created or updated.
+	PipelineChanged EventKind = iota
+	// PipelineDeleted reports that a pipeline was removed.
+	PipelineDeleted
+	// DependenciesChanged reports a change that may affect every pipeline build:
+	// a transformer or forwarder mutation, or a configuration restore.
+	DependenciesChanged
+)
+
+// Event is a single configuration change notification. Pipeline carries the
+// affected pipeline name for the pipeline-scoped kinds and is empty for
+// DependenciesChanged.
+type Event struct {
+	Kind     EventKind
+	Pipeline string
+}
+
+// SubscribeMessage requests a new subscription on the actor. SenderM is the
+// mailbox the actor should push events to, ReadyC reports when the
+// registration is complete, and DoneC signals that the subscription should be
+// dropped.
+type SubscribeMessage struct {
+	SenderM actor.Mailbox[Event]
+	ReadyC  chan<- ReadyResponse
+	DoneC   <-chan struct{}
+}
+
+// ReadyResponse acknowledges a SubscribeMessage, reporting any registration
+// error.
+type ReadyResponse struct {
+	Err error
+}

--- a/internal/engines/confignotify/worker.go
+++ b/internal/engines/confignotify/worker.go
@@ -1,0 +1,74 @@
+package confignotify
+
+import (
+	"log/slog"
+
+	"github.com/vladopajic/go-actor/actor"
+)
+
+// worker is the single actor that owns the subscriber registry. All mutations
+// happen on the actor goroutine, so the registry needs no locking.
+type worker struct {
+	subscribers map[actor.Mailbox[Event]]<-chan struct{}
+	subMbox     actor.MailboxReceiver[SubscribeMessage]
+	eventMbox   actor.MailboxReceiver[Event]
+}
+
+var _ actor.Worker = (*worker)(nil)
+
+// DoWork registers one subscriber or broadcasts one event per invocation. Dead
+// subscribers (whose done channel fired) are swept on every invocation, on the
+// actor goroutine, to avoid mutating the registry concurrently.
+func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
+	select {
+	case <-ctx.Done():
+		return actor.WorkerEnd
+
+	case msg, ok := <-w.subMbox.ReceiveC():
+		if !ok {
+			return actor.WorkerEnd
+		}
+
+		w.sweep()
+		w.subscribers[msg.SenderM] = msg.DoneC
+
+		go func() {
+			msg.ReadyC <- ReadyResponse{nil}
+			close(msg.ReadyC)
+		}()
+
+		return actor.WorkerContinue
+
+	case event, ok := <-w.eventMbox.ReceiveC():
+		if !ok {
+			return actor.WorkerEnd
+		}
+
+		w.sweep()
+
+		for sub := range w.subscribers {
+			if err := sub.Send(ctx, event); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"failed to deliver config change event",
+					"channel", "confignotify",
+					"error", err.Error(),
+				)
+			}
+		}
+
+		return actor.WorkerContinue
+	}
+}
+
+// sweep drops subscribers whose done channel fired and stops their mailboxes.
+func (w *worker) sweep() {
+	for sub, doneC := range w.subscribers {
+		select {
+		case <-doneC:
+			delete(w.subscribers, sub)
+			sub.Stop()
+		default:
+		}
+	}
+}

--- a/internal/engines/pipelines/README.md
+++ b/internal/engines/pipelines/README.md
@@ -5,8 +5,10 @@ is authored in the UI as a flow graph; this engine compiles that graph into an
 executable node graph and drives log records through it.
 
 The engine is built on a single [actor](https://github.com/vladopajic/go-actor)
-that owns a cache of compiled pipelines, so a pipeline is built from storage once
-and reused until its definition changes.
+that owns the set of running pipeline builds. Pipelines are eager: every
+persisted pipeline is compiled and started at boot, and the
+[confignotify](../confignotify) events emitted by the config storage rebuild or
+terminate builds as the configuration changes, wherever the change was made.
 
 ## Responsibilities
 
@@ -15,20 +17,37 @@ and reused until its definition changes.
   [forwarders](../forwarders) runtime for each forward node.
 - **Execution** — feeds a record into a chosen entrypoint and propagates it
   through the graph, concurrently fanning out to each node's successors.
-- **Caching** — keeps compiled pipelines hot and exposes invalidation so changes
-  to a pipeline (or its dependencies) take effect on the next run.
+- **Lifecycle** — starts every persisted pipeline at boot (a broken pipeline is
+  logged and skipped so the server stays up), swaps in new builds on
+  `PipelineChanged`, retires builds on `PipelineDeleted`, and reconciles
+  everything on `DependenciesChanged`.
 - **Tracing** — supports dry runs that record what each node received, emitted
   and errored, without performing side effects.
 - **Wiring** — `NewRunner` returns an `fx` module providing a `Runner` bound to
   the application lifecycle.
 
+## Build lifetime
+
+Every use of a running build (a record being processed, a metrics scrape, a
+nested pipeline call) holds an in-flight reservation on it. Retiring a build —
+on update, deletion or shutdown — first marks it closed so new reservations
+fail, then waits for the in-flight ones to drain before closing node resources
+(forwarder connections, metric collectors). On update, in-flight records finish
+on the old build while new records already flow through the new one; if the new
+build fails to compile, the old one keeps running. The drain wait is bounded by
+the caller's context, but the teardown itself always completes in the
+background.
+
 ## Layout
 
-- **main.go** — the `Runner` interface, its actor-backed implementation and `fx`
-  wiring.
-- **worker.go** — the actor body; owns the compiled-pipeline cache.
-- **messages.go** — the actor messages (run, invalidate one, invalidate all) and
-  the entrypoint constants.
+- **main.go** — the `Runner` interface (`Process`, `ScrapMetrics`), its
+  actor-backed implementation, the internal run/terminate lifecycle and the
+  `fx` wiring (eager start at boot, subscription to config events, graceful
+  stop).
+- **worker.go** — the actor body; owns the running builds, the acquire/retire
+  lifetime logic and the event-driven reconcile.
+- **messages.go** — the actor messages (process, scrap metrics, run, terminate)
+  and the entrypoint constants.
 - **types_pipeline.go** — `Pipeline` and the `BuildFlow`/`BuildFromStorage`
   compilers.
 - **types_nodes.go** — the `Node` interface and the node implementations
@@ -36,7 +55,7 @@ and reused until its definition changes.
 - **node_tracer.go** — the dry-run tracer carried through the context.
 - **context.go** — context plumbing used to reach the worker from inside nodes.
 - **errors.go** — the typed errors raised while compiling a flow graph.
-- **mock.go** — a testify mock of `Runner` for tests.
+- **mocks/** — a testify mock of `Runner` for tests.
 
 ## Node types
 

--- a/internal/engines/pipelines/errors.go
+++ b/internal/engines/pipelines/errors.go
@@ -53,3 +53,8 @@ var _ error = (*PipelineNotFoundError)(nil)
 func (e *PipelineNotFoundError) Error() string {
 	return fmt.Sprintf("pipeline not found: %s", e.Pipeline)
 }
+
+func (e *PipelineNotFoundError) Is(target error) bool {
+	_, ok := target.(*PipelineNotFoundError)
+	return ok
+}

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -104,8 +104,15 @@ func NewRunner() fx.Option {
 					return nil
 				},
 				OnStop: func(ctx context.Context) error {
-					var errs []error
+					w.cacheMu.Lock()
+					names := make([]string, 0, len(w.cache))
 					for pipelineName := range w.cache {
+						names = append(names, pipelineName)
+					}
+					w.cacheMu.Unlock()
+
+					var errs []error
+					for _, pipelineName := range names {
 						if err := runner.Terminate(ctx, pipelineName); err != nil {
 							errs = append(errs, err)
 						}
@@ -127,7 +134,7 @@ func NewRunner() fx.Option {
 
 // Run sends a request to the actor to run a pipeline.
 func (r *runnerImpl) Run(ctx context.Context, pipelineName string) error {
-	replyTo := make(chan error)
+	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, runMessage{
 		replyTo:      replyTo,
@@ -137,12 +144,19 @@ func (r *runnerImpl) Run(ctx context.Context, pipelineName string) error {
 		return err
 	}
 
-	return <-replyTo
+	select {
+	case err := <-replyTo:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
-// Terminate sends a request to the actor to terminate a pipeline.
+// Terminate sends a request to the actor to terminate a pipeline. It waits for
+// in-flight records to drain, bounded by ctx; the teardown itself always
+// completes in the background.
 func (r *runnerImpl) Terminate(ctx context.Context, pipelineName string) error {
-	replyTo := make(chan error)
+	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, terminateMessage{
 		replyTo:      replyTo,
@@ -152,7 +166,12 @@ func (r *runnerImpl) Terminate(ctx context.Context, pipelineName string) error {
 		return err
 	}
 
-	return <-replyTo
+	select {
+	case err := <-replyTo:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Process sends a processing request to the actor and waits for the result. The
@@ -164,7 +183,7 @@ func (r *runnerImpl) Process(
 	entrypoint string,
 	record *models.LogRecord,
 ) error {
-	replyTo := make(chan error)
+	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, logMessage{
 		replyTo: replyTo,
@@ -178,7 +197,12 @@ func (r *runnerImpl) Process(
 		return err
 	}
 
-	return <-replyTo
+	select {
+	case err := <-replyTo:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // ScrapMetrics sends a request to the actor to scrap metrics from a pipeline.
@@ -187,7 +211,7 @@ func (r *runnerImpl) ScrapMetrics(
 	pipelineName string,
 	w io.Writer,
 ) error {
-	replyTo := make(chan error)
+	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, scrapMetricsMessage{
 		replyTo:      replyTo,
@@ -198,5 +222,10 @@ func (r *runnerImpl) ScrapMetrics(
 		return err
 	}
 
-	return <-replyTo
+	select {
+	case err := <-replyTo:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -2,6 +2,9 @@ package pipelines
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
 	"io"
 
@@ -19,17 +22,15 @@ import (
 // point of the engine: callers submit a record to a named pipeline and the
 // runner drives it through the pipeline's node graph.
 type Runner interface {
-	// Run pushes a record through pipelineName, starting at entrypoint (e.g.
+	// Run compiles and starts a pipeline
+	Run(ctx context.Context, pipelineName string) error
+	// Terminate stops a running pipeline.
+	Terminate(ctx context.Context, pipelineName string) error
+	// Process pushes a record through pipelineName, starting at entrypoint (e.g.
 	// "direct" or "syslog"), and blocks until processing completes.
-	Run(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error
+	Process(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error
 	// ScrapMetrics forwards a request to scrap metrics from a pipeline.
 	ScrapMetrics(ctx context.Context, pipelineName string, w io.Writer) error
-	// InvalidateCachedBuild drops the compiled build of a single pipeline so the
-	// next Run rebuilds it from storage; call it after the pipeline changes.
-	InvalidateCachedBuild(ctx context.Context, pipelineName string) error
-	// InvalidateAllCachedBuilds drops every compiled pipeline, e.g. on shutdown
-	// or after a bulk configuration import.
-	InvalidateAllCachedBuilds(ctx context.Context) error
 }
 
 type runnerImpl struct {
@@ -69,26 +70,52 @@ func NewRunner() fx.Option {
 			return mbox
 		}),
 		fx.Provide(func(lc fx.Lifecycle, d deps, mbox actor.Mailbox[message]) Runner {
-			a := actor.New(&worker{
+			w := &worker{
 				mbox:          mbox,
 				configStorage: d.ConfigStorage,
 				logStorage:    d.LogStorage,
 				logNotifier:   d.LogNotifier,
-				cache:         make(map[string]*Pipeline),
-			})
+
+				cache:   make(map[string]*Pipeline),
+				cacheMu: sync.Mutex{},
+			}
+			a := actor.New(w)
 			runner := &runnerImpl{mbox: mbox}
 
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
 					a.Start()
+
+					pipelines, err := d.ConfigStorage.ListPipelines(ctx)
+					if err != nil {
+						return fmt.Errorf("failed to start pipelines: %w", err)
+					}
+
+					var errs []error
+					for _, pipelineName := range pipelines {
+						if err := runner.Run(ctx, pipelineName); err != nil {
+							errs = append(errs, err)
+						}
+					}
+					if len(errs) > 0 {
+						return fmt.Errorf("failed to start pipelines: %w", errors.Join(errs...))
+					}
+
 					return nil
 				},
 				OnStop: func(ctx context.Context) error {
-					if err := runner.InvalidateAllCachedBuilds(ctx); err != nil {
-						return err
+					var errs []error
+					for pipelineName := range w.cache {
+						if err := runner.Terminate(ctx, pipelineName); err != nil {
+							errs = append(errs, err)
+						}
+					}
+					if len(errs) > 0 {
+						return fmt.Errorf("failed to close pipelines: %w", errors.Join(errs...))
 					}
 
 					a.Stop()
+
 					return nil
 				},
 			})
@@ -98,10 +125,40 @@ func NewRunner() fx.Option {
 	)
 }
 
-// Run sends a processing request to the actor and waits for the result. The
+// Run sends a request to the actor to run a pipeline.
+func (r *runnerImpl) Run(ctx context.Context, pipelineName string) error {
+	replyTo := make(chan error)
+
+	err := r.mbox.Send(ctx, runMessage{
+		replyTo:      replyTo,
+		pipelineName: pipelineName,
+	})
+	if err != nil {
+		return err
+	}
+
+	return <-replyTo
+}
+
+// Terminate sends a request to the actor to terminate a pipeline.
+func (r *runnerImpl) Terminate(ctx context.Context, pipelineName string) error {
+	replyTo := make(chan error)
+
+	err := r.mbox.Send(ctx, terminateMessage{
+		replyTo:      replyTo,
+		pipelineName: pipelineName,
+	})
+	if err != nil {
+		return err
+	}
+
+	return <-replyTo
+}
+
+// Process sends a processing request to the actor and waits for the result. The
 // active tracer (if any, set via WithTracer) is forwarded so dry runs can record
 // per-node traces.
-func (r *runnerImpl) Run(
+func (r *runnerImpl) Process(
 	ctx context.Context,
 	pipelineName string,
 	entrypoint string,
@@ -136,42 +193,6 @@ func (r *runnerImpl) ScrapMetrics(
 		replyTo:      replyTo,
 		pipelineName: pipelineName,
 		w:            w,
-	})
-	if err != nil {
-		return err
-	}
-
-	return <-replyTo
-}
-
-// InvalidateCachedBuild asks the actor to evict and close the cached build of a
-// single pipeline.
-func (r *runnerImpl) InvalidateCachedBuild(
-	ctx context.Context,
-	pipelineName string,
-) error {
-	replyTo := make(chan error)
-
-	err := r.mbox.Send(ctx, invalidateCacheMessage{
-		replyTo:      replyTo,
-		pipelineName: pipelineName,
-	})
-	if err != nil {
-		return err
-	}
-
-	return <-replyTo
-}
-
-// InvalidateAllCachedBuilds asks the actor to evict and close every cached
-// pipeline build.
-func (r *runnerImpl) InvalidateAllCachedBuilds(
-	ctx context.Context,
-) error {
-	replyTo := make(chan error)
-
-	err := r.mbox.Send(ctx, invalidateAllCacheMessage{
-		replyTo: replyTo,
 	})
 	if err != nil {
 		return err

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"io"
@@ -15,6 +16,7 @@ import (
 
 	storage "link-society.com/flowg/internal/storage/interfaces"
 
+	"link-society.com/flowg/internal/engines/confignotify"
 	"link-society.com/flowg/internal/engines/lognotify"
 )
 
@@ -40,9 +42,10 @@ type runnerImpl struct {
 type deps struct {
 	fx.In
 
-	ConfigStorage storage.ConfigStorage
-	LogStorage    storage.LogStorage
-	LogNotifier   lognotify.LogNotifier
+	ConfigStorage  storage.ConfigStorage
+	LogStorage     storage.LogStorage
+	LogNotifier    lognotify.LogNotifier
+	ConfigNotifier confignotify.Notifier
 }
 
 var _ Runner = (*runnerImpl)(nil)
@@ -84,6 +87,14 @@ func NewRunner() fx.Option {
 
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
+					// the subscription must outlive the start phase; it is torn down
+					// with the notifier's own lifecycle
+					events, err := d.ConfigNotifier.Subscribe(context.Background())
+					if err != nil {
+						return fmt.Errorf("failed to subscribe to config changes: %w", err)
+					}
+					w.eventsC = events.ReceiveC()
+
 					a.Start()
 
 					pipelines, err := d.ConfigStorage.ListPipelines(ctx)
@@ -91,14 +102,18 @@ func NewRunner() fx.Option {
 						return fmt.Errorf("failed to start pipelines: %w", err)
 					}
 
-					var errs []error
+					// a broken pipeline must not prevent the server (and the UI needed
+					// to fix it) from starting
 					for _, pipelineName := range pipelines {
 						if err := runner.Run(ctx, pipelineName); err != nil {
-							errs = append(errs, err)
+							slog.ErrorContext(
+								ctx,
+								"failed to start pipeline",
+								"channel", "pipelines",
+								"pipeline", pipelineName,
+								"error", err.Error(),
+							)
 						}
-					}
-					if len(errs) > 0 {
-						return fmt.Errorf("failed to start pipelines: %w", errors.Join(errs...))
 					}
 
 					return nil

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -23,11 +23,11 @@ import (
 // Runner executes pipelines against incoming log records. It is the public entry
 // point of the engine: callers submit a record to a named pipeline and the
 // runner drives it through the pipeline's node graph.
+//
+// The pipeline lifecycle itself is not part of the interface: builds are
+// started eagerly at boot and follow configuration changes broadcast on the
+// confignotify bus.
 type Runner interface {
-	// Run compiles and starts a pipeline
-	Run(ctx context.Context, pipelineName string) error
-	// Terminate stops a running pipeline.
-	Terminate(ctx context.Context, pipelineName string) error
 	// Process pushes a record through pipelineName, starting at entrypoint (e.g.
 	// "direct" or "syslog"), and blocks until processing completes.
 	Process(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error
@@ -105,7 +105,7 @@ func NewRunner() fx.Option {
 					// a broken pipeline must not prevent the server (and the UI needed
 					// to fix it) from starting
 					for _, pipelineName := range pipelines {
-						if err := runner.Run(ctx, pipelineName); err != nil {
+						if err := runner.run(ctx, pipelineName); err != nil {
 							slog.ErrorContext(
 								ctx,
 								"failed to start pipeline",
@@ -128,7 +128,7 @@ func NewRunner() fx.Option {
 
 					var errs []error
 					for _, pipelineName := range names {
-						if err := runner.Terminate(ctx, pipelineName); err != nil {
+						if err := runner.terminate(ctx, pipelineName); err != nil {
 							errs = append(errs, err)
 						}
 					}
@@ -147,8 +147,9 @@ func NewRunner() fx.Option {
 	)
 }
 
-// Run sends a request to the actor to run a pipeline.
-func (r *runnerImpl) Run(ctx context.Context, pipelineName string) error {
+// run sends a request to the actor to build and start a pipeline. Lifecycle is
+// internal: it is driven by the fx hooks and the confignotify events.
+func (r *runnerImpl) run(ctx context.Context, pipelineName string) error {
 	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, runMessage{
@@ -167,10 +168,10 @@ func (r *runnerImpl) Run(ctx context.Context, pipelineName string) error {
 	}
 }
 
-// Terminate sends a request to the actor to terminate a pipeline. It waits for
+// terminate sends a request to the actor to terminate a pipeline. It waits for
 // in-flight records to drain, bounded by ctx; the teardown itself always
 // completes in the background.
-func (r *runnerImpl) Terminate(ctx context.Context, pipelineName string) error {
+func (r *runnerImpl) terminate(ctx context.Context, pipelineName string) error {
 	replyTo := make(chan error, 1)
 
 	err := r.mbox.Send(ctx, terminateMessage{

--- a/internal/engines/pipelines/main.go
+++ b/internal/engines/pipelines/main.go
@@ -3,11 +3,12 @@ package pipelines
 import (
 	"context"
 	"errors"
+
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"io"
+	"sync"
 
 	"github.com/vladopajic/go-actor/actor"
 	"go.uber.org/fx"

--- a/internal/engines/pipelines/messages.go
+++ b/internal/engines/pipelines/messages.go
@@ -69,14 +69,15 @@ type terminateMessage struct {
 
 func (msg logMessage) handle(ctx context.Context, w *worker) {
 	go func() {
-		var pipeline *Pipeline
-		var err error
 		defer close(msg.replyTo)
 
 		ctx := context.WithValue(ctx, workerKey, w)
+
+		var pipeline *Pipeline
 		if msg.tracer != nil {
 			ctx = WithTracer(ctx, msg.tracer)
 
+			var err error
 			pipeline, err = BuildFlow(ctx, w.configStorage, msg.pipelineName, &msg.tracer.Flow)
 			if err != nil {
 				msg.replyTo <- err
@@ -88,40 +89,32 @@ func (msg logMessage) handle(ctx context.Context, w *worker) {
 				msg.replyTo <- err
 				return
 			}
+			defer func() { _ = pipeline.Close(ctx) }()
 		} else {
-			pipeline, err = w.getPipeline(ctx, msg.pipelineName)
+			var release func()
+			var err error
+			pipeline, release, err = w.acquirePipeline(msg.pipelineName)
 			if err != nil {
 				msg.replyTo <- err
 				return
 			}
+			defer release()
 		}
 
-		if err != nil {
-			msg.replyTo <- err
-			return
-		}
-
-		err = pipeline.Process(ctx, msg.entrypoint, msg.record)
-
-		if msg.tracer != nil {
-			_ = pipeline.Close(ctx)
-		}
-
-		msg.replyTo <- err
+		msg.replyTo <- pipeline.Process(ctx, msg.entrypoint, msg.record)
 	}()
 }
 
 func (msg scrapMetricsMessage) handle(ctx context.Context, w *worker) {
 	go func() {
-		var pipeline *Pipeline
-		var err error
 		defer close(msg.replyTo)
 
-		pipeline, err = w.getPipeline(ctx, msg.pipelineName)
+		pipeline, release, err := w.acquirePipeline(msg.pipelineName)
 		if err != nil {
 			msg.replyTo <- err
 			return
 		}
+		defer release()
 
 		families, err := pipeline.Metrics.Gather()
 		if err != nil {
@@ -148,6 +141,16 @@ func (msg runMessage) handle(ctx context.Context, w *worker) {
 }
 
 func (msg terminateMessage) handle(ctx context.Context, w *worker) {
-	defer close(msg.replyTo)
-	msg.replyTo <- w.closePipeline(ctx, msg.pipelineName)
+	done, err := w.closePipeline(msg.pipelineName)
+	if err != nil {
+		msg.replyTo <- err
+		close(msg.replyTo)
+		return
+	}
+
+	// reply once the drain completed, without blocking the actor loop
+	go func() {
+		msg.replyTo <- <-done
+		close(msg.replyTo)
+	}()
 }

--- a/internal/engines/pipelines/messages.go
+++ b/internal/engines/pipelines/messages.go
@@ -2,7 +2,6 @@ package pipelines
 
 import (
 	"context"
-	"errors"
 
 	"io"
 
@@ -46,15 +45,26 @@ type scrapMetricsMessage struct {
 	w            io.Writer
 }
 
-// invalidateCacheMessage requests eviction of a single pipeline's cached build.
-type invalidateCacheMessage struct {
-	replyTo      chan<- error
+// runMessage requests that a pipeline be loaded from storage, compiled and
+// initialized.
+type runMessage struct {
+	replyTo chan<- error
+
 	pipelineName string
 }
 
-// invalidateAllCacheMessage requests eviction of every cached pipeline build.
-type invalidateAllCacheMessage struct {
+var (
+	_ message = logMessage{}
+	_ message = scrapMetricsMessage{}
+	_ message = runMessage{}
+	_ message = terminateMessage{}
+)
+
+// terminateMessage requests that a pipeline be terminated and removed.
+type terminateMessage struct {
 	replyTo chan<- error
+
+	pipelineName string
 }
 
 func (msg logMessage) handle(ctx context.Context, w *worker) {
@@ -79,9 +89,9 @@ func (msg logMessage) handle(ctx context.Context, w *worker) {
 				return
 			}
 		} else {
-			pipeline, err = w.getOrBuildPipeline(ctx, msg.pipelineName)
-			if pipeline == nil {
-				msg.replyTo <- &PipelineNotFoundError{Pipeline: msg.pipelineName}
+			pipeline, err = w.getPipeline(ctx, msg.pipelineName)
+			if err != nil {
+				msg.replyTo <- err
 				return
 			}
 		}
@@ -107,13 +117,9 @@ func (msg scrapMetricsMessage) handle(ctx context.Context, w *worker) {
 		var err error
 		defer close(msg.replyTo)
 
-		pipeline, err = w.getOrBuildPipeline(ctx, msg.pipelineName)
+		pipeline, err = w.getPipeline(ctx, msg.pipelineName)
 		if err != nil {
 			msg.replyTo <- err
-			return
-		}
-		if pipeline == nil {
-			msg.replyTo <- &PipelineNotFoundError{Pipeline: msg.pipelineName}
 			return
 		}
 
@@ -136,35 +142,12 @@ func (msg scrapMetricsMessage) handle(ctx context.Context, w *worker) {
 	}()
 }
 
-func (msg invalidateCacheMessage) handle(ctx context.Context, w *worker) {
-	w.cacheMu.Lock()
-	defer w.cacheMu.Unlock()
-
-	pipeline, ok := w.cache[msg.pipelineName]
-	if ok {
-		msg.replyTo <- pipeline.Close(ctx)
-		delete(w.cache, msg.pipelineName)
-	} else {
-		msg.replyTo <- nil
-	}
+func (msg runMessage) handle(ctx context.Context, w *worker) {
+	defer close(msg.replyTo)
+	msg.replyTo <- w.buildPipeline(ctx, msg.pipelineName)
 }
 
-func (msg invalidateAllCacheMessage) handle(ctx context.Context, w *worker) {
-	w.cacheMu.Lock()
-	defer w.cacheMu.Unlock()
-
-	var errs []error
-
-	for name, pipeline := range w.cache {
-		if err := pipeline.Close(ctx); err != nil {
-			errs = append(errs, err)
-		}
-		delete(w.cache, name)
-	}
-
-	if len(errs) > 0 {
-		msg.replyTo <- errors.Join(errs...)
-	} else {
-		msg.replyTo <- nil
-	}
+func (msg terminateMessage) handle(ctx context.Context, w *worker) {
+	defer close(msg.replyTo)
+	msg.replyTo <- w.closePipeline(ctx, msg.pipelineName)
 }

--- a/internal/engines/pipelines/mocks/runner.go
+++ b/internal/engines/pipelines/mocks/runner.go
@@ -23,22 +23,22 @@ func NewMockRunner() pipelines.Runner {
 	return &MockRunner{}
 }
 
-func (m *MockRunner) Run(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error {
+func (m *MockRunner) Run(ctx context.Context, pipelineName string) error {
+	args := m.Called(ctx, pipelineName)
+	return args.Error(0)
+}
+
+func (m *MockRunner) Terminate(ctx context.Context, pipelineName string) error {
+	args := m.Called(ctx, pipelineName)
+	return args.Error(0)
+}
+
+func (m *MockRunner) Process(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error {
 	args := m.Called(ctx, pipelineName, entrypoint, record)
 	return args.Error(0)
 }
 
 func (m *MockRunner) ScrapMetrics(ctx context.Context, pipelineName string, w io.Writer) error {
 	args := m.Called(ctx, pipelineName, w)
-	return args.Error(0)
-}
-
-func (m *MockRunner) InvalidateCachedBuild(ctx context.Context, pipelineName string) error {
-	args := m.Called(ctx, pipelineName)
-	return args.Error(0)
-}
-
-func (m *MockRunner) InvalidateAllCachedBuilds(ctx context.Context) error {
-	args := m.Called(ctx)
 	return args.Error(0)
 }

--- a/internal/engines/pipelines/mocks/runner.go
+++ b/internal/engines/pipelines/mocks/runner.go
@@ -23,16 +23,6 @@ func NewMockRunner() pipelines.Runner {
 	return &MockRunner{}
 }
 
-func (m *MockRunner) Run(ctx context.Context, pipelineName string) error {
-	args := m.Called(ctx, pipelineName)
-	return args.Error(0)
-}
-
-func (m *MockRunner) Terminate(ctx context.Context, pipelineName string) error {
-	args := m.Called(ctx, pipelineName)
-	return args.Error(0)
-}
-
 func (m *MockRunner) Process(ctx context.Context, pipelineName string, entrypoint string, record *models.LogRecord) error {
 	args := m.Called(ctx, pipelineName, entrypoint, record)
 	return args.Error(0)

--- a/internal/engines/pipelines/runner_test.go
+++ b/internal/engines/pipelines/runner_test.go
@@ -1,0 +1,147 @@
+package pipelines
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/internal/models"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+	"link-society.com/flowg/internal/engines/lognotify"
+
+	badgerconfig "link-society.com/flowg/internal/storage/backends/badger/concrete/config"
+	badgerlog "link-society.com/flowg/internal/storage/backends/badger/concrete/log"
+)
+
+const rawTestPipeline = `{
+	"version": 2,
+	"nodes": [
+		{
+			"id": "source",
+			"type": "source",
+			"data": {
+				"type": "direct"
+			}
+		}
+	],
+	"edges": []
+}`
+
+func testRunnerModules(configOpts badgerconfig.Options, logOpts badgerlog.Options) []fx.Option {
+	return []fx.Option{
+		confignotify.NewNotifier(),
+		badgerconfig.NewStorage(configOpts),
+		badgerlog.NewStorage(logOpts),
+		lognotify.NewLogNotifier(),
+		NewRunner(),
+		fx.NopLogger,
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("condition not met before timeout")
+}
+
+func TestRunner_StorageDrivenLifecycle(t *testing.T) {
+	configOpts := badgerconfig.DefaultOptions()
+	configOpts.InMemory = true
+	logOpts := badgerlog.DefaultOptions()
+	logOpts.InMemory = true
+
+	var (
+		runner        Runner
+		configStorage storage.ConfigStorage
+	)
+
+	app := fxtest.New(
+		t,
+		fx.Options(testRunnerModules(configOpts, logOpts)...),
+		fx.Populate(&runner, &configStorage),
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	ctx := t.Context()
+	record := models.NewLogRecord(map[string]string{"message": "test"})
+
+	process := func() error {
+		return runner.Process(ctx, "test", DIRECT_ENTRYPOINT, record)
+	}
+
+	var notFound *PipelineNotFoundError
+	if err := process(); !errors.As(err, &notFound) {
+		t.Fatalf("expected PipelineNotFoundError before creation, got: %v", err)
+	}
+
+	// creating the pipeline in storage starts it
+	if err := configStorage.WriteRawPipeline(ctx, "test", rawTestPipeline); err != nil {
+		t.Fatalf("failed to write pipeline: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool { return process() == nil })
+
+	// deleting it from storage terminates it
+	if err := configStorage.DeletePipeline(ctx, "test"); err != nil {
+		t.Fatalf("failed to delete pipeline: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		return errors.As(process(), &notFound)
+	})
+}
+
+func TestRunner_StartsPersistedPipelinesOnBoot(t *testing.T) {
+	dir := t.TempDir()
+
+	configOpts := badgerconfig.DefaultOptions()
+	configOpts.Directory = dir
+	logOpts := badgerlog.DefaultOptions()
+	logOpts.InMemory = true
+
+	// seed the pipeline with a first app instance
+	{
+		var configStorage storage.ConfigStorage
+
+		app := fxtest.New(
+			t,
+			fx.Options(testRunnerModules(configOpts, logOpts)...),
+			fx.Populate(&configStorage),
+		)
+		app.RequireStart()
+
+		if err := configStorage.WriteRawPipeline(t.Context(), "test", rawTestPipeline); err != nil {
+			t.Fatalf("failed to write pipeline: %v", err)
+		}
+
+		app.RequireStop()
+	}
+
+	// a fresh instance on the same storage starts it eagerly
+	var runner Runner
+
+	app := fxtest.New(
+		t,
+		fx.Options(testRunnerModules(configOpts, logOpts)...),
+		fx.Populate(&runner),
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	record := models.NewLogRecord(map[string]string{"message": "test"})
+	if err := runner.Process(t.Context(), "test", DIRECT_ENTRYPOINT, record); err != nil {
+		t.Fatalf("expected pipeline to be running after boot, got: %v", err)
+	}
+}

--- a/internal/engines/pipelines/runner_test.go
+++ b/internal/engines/pipelines/runner_test.go
@@ -1,8 +1,9 @@
 package pipelines
 
 import (
-	"errors"
 	"testing"
+
+	"errors"
 	"time"
 
 	"go.uber.org/fx"

--- a/internal/engines/pipelines/types_nodes.go
+++ b/internal/engines/pipelines/types_nodes.go
@@ -238,11 +238,12 @@ func (n *PipelineNode) Close(ctx context.Context) error {
 func (n *PipelineNode) Process(ctx context.Context, record *models.LogRecord) error {
 	w := getWorker(ctx)
 
-	pipeline, err := w.getPipeline(ctx, n.Pipeline)
+	pipeline, release, err := w.acquirePipeline(n.Pipeline)
 	traceNode(ctx, n.ID, err, record.Fields, nil)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	if isDryRun(ctx) {
 		return nil

--- a/internal/engines/pipelines/types_nodes.go
+++ b/internal/engines/pipelines/types_nodes.go
@@ -238,7 +238,7 @@ func (n *PipelineNode) Close(ctx context.Context) error {
 func (n *PipelineNode) Process(ctx context.Context, record *models.LogRecord) error {
 	w := getWorker(ctx)
 
-	pipeline, err := w.getOrBuildPipeline(ctx, n.Pipeline)
+	pipeline, err := w.getPipeline(ctx, n.Pipeline)
 	traceNode(ctx, n.ID, err, record.Fields, nil)
 	if err != nil {
 		return err

--- a/internal/engines/pipelines/types_pipeline.go
+++ b/internal/engines/pipelines/types_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"link-society.com/flowg/internal/app/metrics"
@@ -23,6 +24,31 @@ type Pipeline struct {
 
 	Metrics   *prometheus.Registry
 	TotalLogs prometheus.Counter
+
+	// stateMu guards closed; inflight counts active uses of this build so that
+	// retiring it can drain them before node resources are closed.
+	stateMu  sync.Mutex
+	closed   bool
+	inflight sync.WaitGroup
+}
+
+// acquire reserves the build for one in-flight use; it fails once the build
+// has been retired. Every successful acquire must be paired with a release.
+func (p *Pipeline) acquire() bool {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+
+	if p.closed {
+		return false
+	}
+
+	p.inflight.Add(1)
+	return true
+}
+
+// release ends an in-flight use started by acquire.
+func (p *Pipeline) release() {
+	p.inflight.Done()
 }
 
 // BuildFromStorage loads the persisted flow graph for name and compiles it into

--- a/internal/engines/pipelines/types_pipeline.go
+++ b/internal/engines/pipelines/types_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"

--- a/internal/engines/pipelines/worker.go
+++ b/internal/engines/pipelines/worker.go
@@ -9,6 +9,7 @@ import (
 
 	storage "link-society.com/flowg/internal/storage/interfaces"
 
+	"link-society.com/flowg/internal/engines/confignotify"
 	"link-society.com/flowg/internal/engines/lognotify"
 )
 
@@ -17,6 +18,10 @@ import (
 // access safe.
 type worker struct {
 	mbox actor.MailboxReceiver[message]
+
+	// eventsC delivers config change notifications; pipeline lifecycle follows
+	// storage mutations, wherever they were initiated.
+	eventsC <-chan confignotify.Event
 
 	configStorage storage.ConfigStorage
 	logStorage    storage.LogStorage
@@ -41,6 +46,98 @@ func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
 		msg.handle(ctx, w)
 
 		return actor.WorkerContinue
+
+	case event, ok := <-w.eventsC:
+		if !ok {
+			// subscription torn down at shutdown; a nil channel blocks forever
+			w.eventsC = nil
+			return actor.WorkerContinue
+		}
+
+		w.handleEvent(ctx, event)
+
+		return actor.WorkerContinue
+	}
+}
+
+// handleEvent maps a config change to the matching lifecycle action.
+func (w *worker) handleEvent(ctx actor.Context, event confignotify.Event) {
+	switch event.Kind {
+	case confignotify.PipelineChanged:
+		if err := w.buildPipeline(ctx, event.Pipeline); err != nil {
+			slog.ErrorContext(
+				ctx,
+				"failed to rebuild pipeline",
+				"channel", "pipelines",
+				"pipeline", event.Pipeline,
+				"error", err.Error(),
+			)
+		}
+
+	case confignotify.PipelineDeleted:
+		if _, err := w.closePipeline(event.Pipeline); err != nil {
+			slog.DebugContext(
+				ctx,
+				"no running build for deleted pipeline",
+				"channel", "pipelines",
+				"pipeline", event.Pipeline,
+				"error", err.Error(),
+			)
+		}
+
+	case confignotify.DependenciesChanged:
+		w.reconcile(ctx)
+	}
+}
+
+// reconcile aligns running builds with storage: every persisted pipeline is
+// rebuilt and builds whose definition disappeared are retired.
+func (w *worker) reconcile(ctx actor.Context) {
+	names, err := w.configStorage.ListPipelines(ctx)
+	if err != nil {
+		slog.ErrorContext(
+			ctx,
+			"failed to list pipelines during reconcile",
+			"channel", "pipelines",
+			"error", err.Error(),
+		)
+		return
+	}
+
+	listed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		listed[name] = struct{}{}
+
+		if err := w.buildPipeline(ctx, name); err != nil {
+			slog.ErrorContext(
+				ctx,
+				"failed to rebuild pipeline",
+				"channel", "pipelines",
+				"pipeline", name,
+				"error", err.Error(),
+			)
+		}
+	}
+
+	w.cacheMu.Lock()
+	var extras []string
+	for name := range w.cache {
+		if _, exists := listed[name]; !exists {
+			extras = append(extras, name)
+		}
+	}
+	w.cacheMu.Unlock()
+
+	for _, name := range extras {
+		if _, err := w.closePipeline(name); err != nil {
+			slog.ErrorContext(
+				ctx,
+				"failed to retire removed pipeline",
+				"channel", "pipelines",
+				"pipeline", name,
+				"error", err.Error(),
+			)
+		}
 	}
 }
 

--- a/internal/engines/pipelines/worker.go
+++ b/internal/engines/pipelines/worker.go
@@ -1,6 +1,8 @@
 package pipelines
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 
 	"github.com/vladopajic/go-actor/actor"
@@ -42,21 +44,40 @@ func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
 	}
 }
 
-// getPipeline retrieves a compiled pipeline from the worker's cache by name.
-func (w *worker) getPipeline(_ctx actor.Context, pipelineName string) (*Pipeline, error) {
+// acquirePipeline returns the cached build with an in-flight reservation so a
+// concurrent retire cannot close it mid-use; callers must call release.
+func (w *worker) acquirePipeline(pipelineName string) (*Pipeline, func(), error) {
 	w.cacheMu.Lock()
-	defer w.cacheMu.Unlock()
-
 	pipeline, exists := w.cache[pipelineName]
-	if !exists {
-		return nil, &PipelineNotFoundError{Pipeline: pipelineName}
+	w.cacheMu.Unlock()
+
+	if !exists || !pipeline.acquire() {
+		return nil, nil, &PipelineNotFoundError{Pipeline: pipelineName}
 	}
 
-	return pipeline, nil
+	return pipeline, pipeline.release, nil
 }
 
-// buildPipeline compiles a new pipeline from storage and adds it to the
-// worker's cache.
+// retirePipeline marks a build closed and closes it in the background once its
+// in-flight uses drained; the returned channel reports the close error.
+func (w *worker) retirePipeline(pipeline *Pipeline) <-chan error {
+	pipeline.stateMu.Lock()
+	pipeline.closed = true
+	pipeline.stateMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		pipeline.inflight.Wait()
+		done <- pipeline.Close(context.Background())
+		close(done)
+	}()
+
+	return done
+}
+
+// buildPipeline compiles a new build from storage, swaps it into the worker's
+// cache and retires the previous build, if any. In-flight records finish on
+// the old build while new ones pick up the new one.
 func (w *worker) buildPipeline(ctx actor.Context, pipelineName string) error {
 	pipeline, err := BuildFromStorage(ctx, w.configStorage, pipelineName)
 	if err != nil {
@@ -72,22 +93,39 @@ func (w *worker) buildPipeline(ctx actor.Context, pipelineName string) error {
 	}
 
 	w.cacheMu.Lock()
+	previous := w.cache[pipelineName]
 	w.cache[pipelineName] = pipeline
 	w.cacheMu.Unlock()
+
+	if previous != nil {
+		done := w.retirePipeline(previous)
+		go func() {
+			if err := <-done; err != nil {
+				slog.ErrorContext(
+					ctx,
+					"failed to close previous pipeline build",
+					"channel", "pipelines",
+					"pipeline", pipelineName,
+					"error", err.Error(),
+				)
+			}
+		}()
+	}
 
 	return nil
 }
 
-// closePipeline removes a pipeline from the worker's cache and closes it.
-func (w *worker) closePipeline(ctx actor.Context, pipelineName string) error {
+// closePipeline removes a build from the worker's cache and retires it; the
+// returned channel reports the close error once in-flight work drained.
+func (w *worker) closePipeline(pipelineName string) (<-chan error, error) {
 	w.cacheMu.Lock()
 	pipeline, exists := w.cache[pipelineName]
-	if !exists {
-		w.cacheMu.Unlock()
-		return &PipelineNotFoundError{Pipeline: pipelineName}
-	}
 	delete(w.cache, pipelineName)
 	w.cacheMu.Unlock()
 
-	return pipeline.Close(ctx)
+	if !exists {
+		return nil, &PipelineNotFoundError{Pipeline: pipelineName}
+	}
+
+	return w.retirePipeline(pipeline), nil
 }

--- a/internal/engines/pipelines/worker.go
+++ b/internal/engines/pipelines/worker.go
@@ -3,6 +3,7 @@ package pipelines
 import (
 	"context"
 	"log/slog"
+
 	"sync"
 
 	"github.com/vladopajic/go-actor/actor"

--- a/internal/engines/pipelines/worker.go
+++ b/internal/engines/pipelines/worker.go
@@ -1,7 +1,6 @@
 package pipelines
 
 import (
-	"context"
 	"sync"
 
 	"github.com/vladopajic/go-actor/actor"
@@ -43,30 +42,49 @@ func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
 	}
 }
 
-// getOrBuildPipeline returns the cached build for a pipeline, compiling and
-// initialising it from storage on first use. The build is closed again if
-// initialisation fails.
-func (w *worker) getOrBuildPipeline(ctx context.Context, pipelineName string) (*Pipeline, error) {
+// getPipeline retrieves a compiled pipeline from the worker's cache by name.
+func (w *worker) getPipeline(_ctx actor.Context, pipelineName string) (*Pipeline, error) {
 	w.cacheMu.Lock()
 	defer w.cacheMu.Unlock()
 
-	if pipeline, exists := w.cache[pipelineName]; exists {
-		return pipeline, nil
+	pipeline, exists := w.cache[pipelineName]
+	if !exists {
+		return nil, &PipelineNotFoundError{Pipeline: pipelineName}
 	}
 
-	pipeline, err := BuildFromStorage(ctx, w.configStorage, pipelineName)
+	return pipeline, nil
+}
+
+// buildPipeline compiles a new pipeline from storage and adds it to the
+// worker's cache.
+func (w *worker) buildPipeline(ctx actor.Context, pipelineName string) error {
+	pipeline, err := BuildFlow(ctx, w.configStorage, pipelineName, nil)
 	if err != nil {
-		return nil, err
-	}
-	if pipeline == nil {
-		return nil, nil
+		return err
 	}
 
 	if err := pipeline.Init(ctx); err != nil {
 		_ = pipeline.Close(ctx)
-		return nil, err
+		return err
 	}
 
+	w.cacheMu.Lock()
 	w.cache[pipelineName] = pipeline
-	return pipeline, nil
+	w.cacheMu.Unlock()
+
+	return nil
+}
+
+// closePipeline removes a pipeline from the worker's cache and closes it.
+func (w *worker) closePipeline(ctx actor.Context, pipelineName string) error {
+	w.cacheMu.Lock()
+	pipeline, exists := w.cache[pipelineName]
+	if !exists {
+		w.cacheMu.Unlock()
+		return &PipelineNotFoundError{Pipeline: pipelineName}
+	}
+	delete(w.cache, pipelineName)
+	w.cacheMu.Unlock()
+
+	return pipeline.Close(ctx)
 }

--- a/internal/engines/pipelines/worker.go
+++ b/internal/engines/pipelines/worker.go
@@ -58,9 +58,12 @@ func (w *worker) getPipeline(_ctx actor.Context, pipelineName string) (*Pipeline
 // buildPipeline compiles a new pipeline from storage and adds it to the
 // worker's cache.
 func (w *worker) buildPipeline(ctx actor.Context, pipelineName string) error {
-	pipeline, err := BuildFlow(ctx, w.configStorage, pipelineName, nil)
+	pipeline, err := BuildFromStorage(ctx, w.configStorage, pipelineName)
 	if err != nil {
 		return err
+	}
+	if pipeline == nil {
+		return &PipelineNotFoundError{Pipeline: pipelineName}
 	}
 
 	if err := pipeline.Init(ctx); err != nil {

--- a/internal/engines/pipelines/worker_test.go
+++ b/internal/engines/pipelines/worker_test.go
@@ -1,12 +1,15 @@
 package pipelines
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/mock"
+
+	"context"
+	"errors"
+
+	"time"
+
 	"github.com/vladopajic/go-actor/actor"
 
 	"link-society.com/flowg/internal/models"

--- a/internal/engines/pipelines/worker_test.go
+++ b/internal/engines/pipelines/worker_test.go
@@ -1,15 +1,27 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/vladopajic/go-actor/actor"
 
 	"link-society.com/flowg/internal/models"
+
+	lognotifyMocks "link-society.com/flowg/internal/engines/lognotify/mocks"
+	"link-society.com/flowg/internal/storage/generic/kv"
 	"link-society.com/flowg/internal/storage/mocks"
+
+	appMetrics "link-society.com/flowg/internal/app/metrics"
 )
+
+func TestMain(m *testing.M) {
+	appMetrics.Setup()
+	m.Run()
+}
 
 // minimalFlowGraph returns a flow graph with a single direct source node,
 // enough to compile without touching transformers or forwarders.
@@ -25,6 +37,30 @@ func minimalFlowGraph() *models.FlowGraphV2 {
 			},
 		},
 		Edges: []*models.FlowEdgeV2{},
+	}
+}
+
+// routedFlowGraph returns a flow graph whose direct source feeds a router node,
+// so that processing exercises the log storage.
+func routedFlowGraph() *models.FlowGraphV2 {
+	return &models.FlowGraphV2{
+		MajorVersion: 2,
+		MinorVersion: 1,
+		Nodes: []*models.FlowNodeV2{
+			{
+				ID:   "source",
+				Type: "source",
+				Data: map[string]string{"type": "direct"},
+			},
+			{
+				ID:   "router",
+				Type: "router",
+				Data: map[string]string{"stream": "default"},
+			},
+		},
+		Edges: []*models.FlowEdgeV2{
+			{ID: "e1", Source: "source", Target: "router"},
+		},
 	}
 }
 
@@ -68,4 +104,118 @@ func TestBuildPipeline_AddsToCache(t *testing.T) {
 	if _, exists := w.cache["test"]; !exists {
 		t.Fatal("expected pipeline in cache")
 	}
+}
+
+func TestClosePipeline_DrainsBeforeClose(t *testing.T) {
+	configStorage := mocks.NewMockConfigStorage().(*mocks.MockConfigStorage)
+	configStorage.On("ReadPipeline", mock.Anything, "test").
+		Return(routedFlowGraph(), nil)
+
+	entered := make(chan struct{})
+	unblock := make(chan struct{})
+
+	logStorage := mocks.NewMockLogStorage().(*mocks.MockLogStorage)
+	logStorage.On("Ingest", mock.Anything, "default", mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(entered)
+			<-unblock
+		}).
+		Return(kv.Key{"k"}, nil)
+
+	logNotifier := lognotifyMocks.NewMockNotifier().(*lognotifyMocks.MockNotifier)
+	logNotifier.On("Notify", mock.Anything, "default", mock.Anything, mock.Anything).
+		Return(nil)
+
+	w := newTestWorker(configStorage)
+	w.logStorage = logStorage
+	w.logNotifier = logNotifier
+
+	if err := w.buildPipeline(actor.ContextStarted(), "test"); err != nil {
+		t.Fatalf("failed to build pipeline: %v", err)
+	}
+
+	// in-flight record, blocked inside the router node
+	processDone := make(chan error, 1)
+	pipeline, release, err := w.acquirePipeline("test")
+	if err != nil {
+		t.Fatalf("failed to acquire pipeline: %v", err)
+	}
+	go func() {
+		defer release()
+		ctx := context.WithValue(context.Background(), workerKey, w)
+		processDone <- pipeline.Process(ctx, DIRECT_ENTRYPOINT, &models.LogRecord{
+			Timestamp: time.Now(),
+			Fields:    map[string]string{"message": "test"},
+		})
+	}()
+
+	<-entered
+
+	closeDone, err := w.closePipeline("test")
+	if err != nil {
+		t.Fatalf("failed to close pipeline: %v", err)
+	}
+
+	// new uses are rejected while the record is still in flight
+	if _, _, err := w.acquirePipeline("test"); err == nil {
+		t.Fatal("expected acquire to fail after close")
+	}
+
+	// the close must not complete while the record is in flight
+	select {
+	case <-closeDone:
+		t.Fatal("pipeline closed while a record was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(unblock)
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("failed to close pipeline: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("close did not complete after drain")
+	}
+
+	if err := <-processDone; err != nil {
+		t.Fatalf("in-flight record failed: %v", err)
+	}
+}
+
+func TestBuildPipeline_SwapRetiresPrevious(t *testing.T) {
+	configStorage := mocks.NewMockConfigStorage().(*mocks.MockConfigStorage)
+	configStorage.On("ReadPipeline", mock.Anything, "test").
+		Return(minimalFlowGraph(), nil)
+
+	w := newTestWorker(configStorage)
+
+	if err := w.buildPipeline(actor.ContextStarted(), "test"); err != nil {
+		t.Fatalf("failed to build pipeline: %v", err)
+	}
+	first, releaseFirst, err := w.acquirePipeline("test")
+	if err != nil {
+		t.Fatalf("failed to acquire first build: %v", err)
+	}
+
+	if err := w.buildPipeline(actor.ContextStarted(), "test"); err != nil {
+		t.Fatalf("failed to rebuild pipeline: %v", err)
+	}
+
+	second, releaseSecond, err := w.acquirePipeline("test")
+	if err != nil {
+		t.Fatalf("failed to acquire second build: %v", err)
+	}
+	defer releaseSecond()
+
+	if first == second {
+		t.Fatal("expected rebuild to produce a new build")
+	}
+
+	// the retired build refuses new uses but stays valid for in-flight ones
+	if first.acquire() {
+		t.Fatal("expected first build to be retired")
+	}
+	releaseFirst()
 }

--- a/internal/engines/pipelines/worker_test.go
+++ b/internal/engines/pipelines/worker_test.go
@@ -1,0 +1,71 @@
+package pipelines
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/models"
+	"link-society.com/flowg/internal/storage/mocks"
+)
+
+// minimalFlowGraph returns a flow graph with a single direct source node,
+// enough to compile without touching transformers or forwarders.
+func minimalFlowGraph() *models.FlowGraphV2 {
+	return &models.FlowGraphV2{
+		MajorVersion: 2,
+		MinorVersion: 1,
+		Nodes: []*models.FlowNodeV2{
+			{
+				ID:   "source",
+				Type: "source",
+				Data: map[string]string{"type": "direct"},
+			},
+		},
+		Edges: []*models.FlowEdgeV2{},
+	}
+}
+
+func newTestWorker(configStorage *mocks.MockConfigStorage) *worker {
+	return &worker{
+		configStorage: configStorage,
+		cache:         make(map[string]*Pipeline),
+	}
+}
+
+func TestBuildPipeline_UnknownPipeline(t *testing.T) {
+	configStorage := mocks.NewMockConfigStorage().(*mocks.MockConfigStorage)
+	configStorage.On("ReadPipeline", mock.Anything, "missing").
+		Return((*models.FlowGraphV2)(nil), nil)
+
+	w := newTestWorker(configStorage)
+
+	err := w.buildPipeline(actor.ContextStarted(), "missing")
+
+	var notFound *PipelineNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected PipelineNotFoundError, got: %v", err)
+	}
+
+	if len(w.cache) != 0 {
+		t.Fatalf("expected empty cache, got %d entries", len(w.cache))
+	}
+}
+
+func TestBuildPipeline_AddsToCache(t *testing.T) {
+	configStorage := mocks.NewMockConfigStorage().(*mocks.MockConfigStorage)
+	configStorage.On("ReadPipeline", mock.Anything, "test").
+		Return(minimalFlowGraph(), nil)
+
+	w := newTestWorker(configStorage)
+
+	if err := w.buildPipeline(actor.ContextStarted(), "test"); err != nil {
+		t.Fatalf("failed to build pipeline: %v", err)
+	}
+
+	if _, exists := w.cache["test"]; !exists {
+		t.Fatal("expected pipeline in cache")
+	}
+}

--- a/internal/services/syslog/worker.go
+++ b/internal/services/syslog/worker.go
@@ -102,7 +102,7 @@ func (w *worker) DoWork(ctx actor.Context) actor.WorkerStatus {
 
 				record := parseLogParts(logParts)
 
-				err := w.pipelineRunner.Run(
+				err := w.pipelineRunner.Process(
 					ctx,
 					pipelineName,
 					pipelines.SYSLOG_ENTRYPOINT,

--- a/internal/storage/backends/badger/concrete/config/README.md
+++ b/internal/storage/backends/badger/concrete/config/README.md
@@ -13,6 +13,9 @@ interface so the engines and API never depend on BadgerDB directly.
 
 - **Resource persistence** — stores and retrieves pipelines, transformers and
   forwarders in a dedicated [kvstore](../../kvstore).
+- **Change notifications** — wires the optional
+  [confignotify](../../../../../engines/confignotify) notifier into the store,
+  so every local mutation is broadcast to the pipeline runner.
 - **System configuration** — persists global settings such as the allowed
   origins used by the ingestion endpoints.
 - **Snapshots** — satisfies `Streamable` so the configuration database can be

--- a/internal/storage/backends/badger/concrete/config/main.go
+++ b/internal/storage/backends/badger/concrete/config/main.go
@@ -6,6 +6,8 @@ import (
 
 	"go.uber.org/fx"
 
+	"link-society.com/flowg/internal/engines/confignotify"
+
 	"link-society.com/flowg/internal/storage/backends/badger"
 	"link-society.com/flowg/internal/storage/databases/config"
 	storage "link-society.com/flowg/internal/storage/interfaces"
@@ -22,6 +24,10 @@ type deps struct {
 	fx.In
 
 	Adapter *badger.BadgerAdapter `name:"storage.config"`
+
+	// Notifier broadcasts config mutations to the pipeline runner; it is
+	// optional so the storage can run standalone (e.g. in tests).
+	Notifier confignotify.Notifier `optional:"true"`
 }
 
 // DefaultOptions returns the default [Options] for the configuration storage.
@@ -47,7 +53,7 @@ func NewStorage(opts Options) fx.Option {
 		"storage.config",
 		badger.NewAdapter(adapterOpts),
 		fx.Provide(func(lc fx.Lifecycle, d deps) storage.ConfigStorage {
-			storage := config.NewStorage(d.Adapter)
+			storage := config.NewStorage(d.Adapter, d.Notifier)
 
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {

--- a/internal/storage/backends/badger/concrete/config/notify_test.go
+++ b/internal/storage/backends/badger/concrete/config/notify_test.go
@@ -1,0 +1,77 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/cmd/flowg-server/logging"
+	"link-society.com/flowg/internal/models"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+	confignotifyMocks "link-society.com/flowg/internal/engines/confignotify/mocks"
+
+	badgerconfig "link-society.com/flowg/internal/storage/backends/badger/concrete/config"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+// TestNotifyOnMutations verifies that every config mutation broadcasts the
+// matching confignotify event.
+func TestNotifyOnMutations(t *testing.T) {
+	logging.Discard()
+
+	ctx := t.Context()
+
+	notifier := confignotifyMocks.NewMockNotifier().(*confignotifyMocks.MockNotifier)
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind:     confignotify.PipelineChanged,
+		Pipeline: "test",
+	}).Return(nil).Once()
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind:     confignotify.PipelineDeleted,
+		Pipeline: "test",
+	}).Return(nil).Once()
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind: confignotify.DependenciesChanged,
+	}).Return(nil).Times(2)
+
+	opts := badgerconfig.DefaultOptions()
+	opts.InMemory = true
+
+	var configStorage storage.ConfigStorage
+
+	app := fxtest.New(
+		t,
+		badgerconfig.NewStorage(opts),
+		fx.Provide(func() confignotify.Notifier { return notifier }),
+		fx.Populate(&configStorage),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	if err := configStorage.WritePipeline(ctx, "test", &models.FlowGraphV2{
+		MajorVersion: 2,
+		MinorVersion: 1,
+		Nodes:        []*models.FlowNodeV2{},
+		Edges:        []*models.FlowEdgeV2{},
+	}); err != nil {
+		t.Fatalf("failed to write pipeline: %v", err)
+	}
+
+	if err := configStorage.DeletePipeline(ctx, "test"); err != nil {
+		t.Fatalf("failed to delete pipeline: %v", err)
+	}
+
+	if err := configStorage.WriteTransformer(ctx, "test", "."); err != nil {
+		t.Fatalf("failed to write transformer: %v", err)
+	}
+
+	if err := configStorage.DeleteTransformer(ctx, "test"); err != nil {
+		t.Fatalf("failed to delete transformer: %v", err)
+	}
+
+	notifier.AssertExpectations(t)
+}

--- a/internal/storage/backends/badger/concrete/config/system_config_cache_test.go
+++ b/internal/storage/backends/badger/concrete/config/system_config_cache_test.go
@@ -1,0 +1,165 @@
+package config_test
+
+import (
+	"testing"
+
+	"bytes"
+	"reflect"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"link-society.com/flowg/cmd/flowg-server/logging"
+	"link-society.com/flowg/internal/models"
+
+	"link-society.com/flowg/internal/storage/backends/badger"
+	badgerconfig "link-society.com/flowg/internal/storage/backends/badger/concrete/config"
+	"link-society.com/flowg/internal/storage/databases/config"
+	storage "link-society.com/flowg/internal/storage/interfaces"
+)
+
+type adapterDeps struct {
+	fx.In
+
+	Adapter *badger.BadgerAdapter `name:"storage.config"`
+}
+
+// TestSystemConfigCacheInvalidation simulates two cluster nodes sharing the
+// same storage: a write on node A stays invisible to node B's cache until node
+// B invalidates it, which is what the FoundationDB watcher does on remote
+// changes.
+func TestSystemConfigCacheInvalidation(t *testing.T) {
+	logging.Discard()
+
+	ctx := t.Context()
+
+	opts := badgerconfig.DefaultOptions()
+	opts.InMemory = true
+
+	var (
+		nodeA storage.ConfigStorage
+		d     adapterDeps
+	)
+
+	app := fxtest.New(
+		t,
+		badgerconfig.NewStorage(opts),
+		fx.Populate(&nodeA),
+		fx.Populate(&d),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	nodeB := config.NewStorage(d.Adapter, nil)
+
+	v1 := &models.SystemConfiguration{SyslogAllowedOrigins: []string{"10.0.0.1"}}
+	v2 := &models.SystemConfiguration{SyslogAllowedOrigins: []string{"10.0.0.2"}}
+
+	if err := nodeA.WriteSystemConfig(ctx, v1); err != nil {
+		t.Fatalf("failed to write system config: %v", err)
+	}
+
+	cached, err := nodeB.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+	if !reflect.DeepEqual(cached.SyslogAllowedOrigins, v1.SyslogAllowedOrigins) {
+		t.Fatalf("unexpected system config: %v", cached)
+	}
+
+	if err := nodeA.WriteSystemConfig(ctx, v2); err != nil {
+		t.Fatalf("failed to write system config: %v", err)
+	}
+
+	// node B still serves its cache
+	stale, err := nodeB.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+	if !reflect.DeepEqual(stale.SyslogAllowedOrigins, v1.SyslogAllowedOrigins) {
+		t.Fatalf("expected stale system config, got: %v", stale)
+	}
+
+	nodeB.InvalidateSystemConfigCache()
+
+	fresh, err := nodeB.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+	if !reflect.DeepEqual(fresh.SyslogAllowedOrigins, v2.SyslogAllowedOrigins) {
+		t.Fatalf("expected fresh system config, got: %v", fresh)
+	}
+}
+
+// TestSystemConfigCacheInvalidatedOnRestore verifies that restoring a backup
+// drops the cached system configuration.
+func TestSystemConfigCacheInvalidatedOnRestore(t *testing.T) {
+	logging.Discard()
+
+	ctx := t.Context()
+
+	v1 := &models.SystemConfiguration{SyslogAllowedOrigins: []string{"10.0.0.1"}}
+
+	var dump bytes.Buffer
+
+	// first instance: seed the config and take a backup
+	{
+		opts := badgerconfig.DefaultOptions()
+		opts.InMemory = true
+
+		var configStorage storage.ConfigStorage
+
+		app := fxtest.New(
+			t,
+			badgerconfig.NewStorage(opts),
+			fx.Populate(&configStorage),
+			fx.NopLogger,
+		)
+		app.RequireStart()
+
+		if err := configStorage.WriteSystemConfig(ctx, v1); err != nil {
+			t.Fatalf("failed to write system config: %v", err)
+		}
+		if _, err := configStorage.Dump(ctx, &dump, 0); err != nil {
+			t.Fatalf("failed to dump config: %v", err)
+		}
+
+		app.RequireStop()
+	}
+
+	// fresh instance: prime the cache with the empty config, then restore
+	opts := badgerconfig.DefaultOptions()
+	opts.InMemory = true
+
+	var configStorage storage.ConfigStorage
+
+	app := fxtest.New(
+		t,
+		badgerconfig.NewStorage(opts),
+		fx.Populate(&configStorage),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	primed, err := configStorage.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+	if len(primed.SyslogAllowedOrigins) != 0 {
+		t.Fatalf("expected empty system config, got: %v", primed)
+	}
+
+	if err := configStorage.Load(ctx, &dump); err != nil {
+		t.Fatalf("failed to restore config: %v", err)
+	}
+
+	restored, err := configStorage.ReadSystemConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to read system config: %v", err)
+	}
+	if !reflect.DeepEqual(restored.SyslogAllowedOrigins, v1.SyslogAllowedOrigins) {
+		t.Fatalf("expected restored system config, got: %v", restored)
+	}
+}

--- a/internal/storage/backends/foundation/README.md
+++ b/internal/storage/backends/foundation/README.md
@@ -45,6 +45,16 @@ them.
 snapshot streaming or bulk load primitive through the client API. Backups are
 taken out-of-band with the `fdbbackup` / `fdbrestore` tooling instead.
 
+### Change log & watches
+
+When `AdapterOptions.EnableChangeLog` is set, every `Update` transaction also
+sets `ChangeLogKey` to a fresh random value, atomically with the mutation.
+`Watch` arms a FoundationDB key watch and returns a channel that fires once
+when the watched key changes — from any node of the cluster. Together they let
+a storage observe every mutation made through the adapter without polling; the
+[concrete/config](concrete/config) module uses this to propagate configuration
+changes to the pipeline runner of every node.
+
 ## Layout
 
 - **adapter.go** — `FoundationAdapter` and `NewAdapter`, plus `AdapterOptions`.

--- a/internal/storage/backends/foundation/README.md
+++ b/internal/storage/backends/foundation/README.md
@@ -47,8 +47,8 @@ taken out-of-band with the `fdbbackup` / `fdbrestore` tooling instead.
 
 ### Change log & watches
 
-When `AdapterOptions.EnableChangeLog` is set, every `Update` transaction also
-sets `ChangeLogKey` to a fresh random value, atomically with the mutation.
+Every `Update` transaction also sets `ChangeLogKey` to a fresh random value,
+atomically with the mutation.
 `Watch` arms a FoundationDB key watch and returns a channel that fires once
 when the watched key changes — from any node of the cluster. Together they let
 a storage observe every mutation made through the adapter without polling; the

--- a/internal/storage/backends/foundation/adapter.go
+++ b/internal/storage/backends/foundation/adapter.go
@@ -3,10 +3,11 @@ package foundation
 import (
 	"context"
 	"fmt"
+
 	"io"
-	"time"
 
 	"crypto/rand"
+	"time"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"

--- a/internal/storage/backends/foundation/adapter.go
+++ b/internal/storage/backends/foundation/adapter.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"time"
 
+	"crypto/rand"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 
@@ -23,6 +25,12 @@ const FoundationApiVersion = 730
 // AdapterOptions.GCInterval is left unset.
 const defaultGCInterval = 5 * time.Minute
 
+// ChangeLogKey is the key bumped on every mutation when
+// [AdapterOptions.EnableChangeLog] is set; watching it (see
+// [FoundationAdapter.Watch]) observes every change made through the adapter,
+// from any node of the cluster.
+var ChangeLogKey = kv.Key{"meta", "changelog"}
+
 // AdapterOptions configures how a FoundationDB-backed [kv.Adapter] connects to
 // its cluster and where within the key space it stores its data.
 type AdapterOptions struct {
@@ -38,6 +46,9 @@ type AdapterOptions struct {
 	Namespace string
 	// GCInterval is how often expired keys are swept; zero uses defaultGCInterval.
 	GCInterval time.Duration
+	// EnableChangeLog makes every Update transaction also bump [ChangeLogKey],
+	// atomically with the mutation, so other nodes can watch for changes.
+	EnableChangeLog bool
 }
 
 // FoundationAdapter is a [kv.Adapter] backed by FoundationDB.
@@ -46,8 +57,9 @@ type AdapterOptions struct {
 // applied on write and stripped on read, so consumers only ever observe logical
 // [kv.Key]s.
 type FoundationAdapter struct {
-	db  fdb.Database
-	sub subspace.Subspace
+	db        fdb.Database
+	sub       subspace.Subspace
+	changeLog bool
 }
 
 var _ kv.Adapter[*FoundationQueryTx, *FoundationMutationTx] = (*FoundationAdapter)(nil)
@@ -80,8 +92,9 @@ func NewAdapter(opts AdapterOptions) fx.Option {
 		}
 
 		adapter := &FoundationAdapter{
-			db:  db,
-			sub: subspace.Sub(opts.KeySpace).Sub(opts.Namespace),
+			db:        db,
+			sub:       subspace.Sub(opts.KeySpace).Sub(opts.Namespace),
+			changeLog: opts.EnableChangeLog,
 		}
 
 		lc.Append(fx.Hook{
@@ -140,16 +153,63 @@ func (a *FoundationAdapter) View(ctx context.Context, txnFn func(txn *Foundation
 
 // Update implements [kv.Adapter.Update]. It runs inside a read-write
 // FoundationDB transaction, which is committed on success; FoundationDB retries
-// automatically on conflict.
+// automatically on conflict. When the changelog is enabled, [ChangeLogKey] is
+// set to a fresh random value in the same transaction.
 func (a *FoundationAdapter) Update(ctx context.Context, txnFn func(txn *FoundationMutationTx) error) error {
 	_, err := a.db.Transact(func(tr fdb.Transaction) (any, error) {
 		if err := applyDeadline(ctx, tr); err != nil {
 			return nil, err
 		}
 
-		return nil, txnFn(&FoundationMutationTx{concrete: tr, sub: a.sub})
+		if err := txnFn(&FoundationMutationTx{concrete: tr, sub: a.sub}); err != nil {
+			return nil, err
+		}
+
+		if a.changeLog {
+			value := make([]byte, 16)
+			rand.Read(value)
+			tr.Set(a.sub.Pack(keyToTuple(ChangeLogKey)), value)
+		}
+
+		return nil, nil
 	})
 	return err
+}
+
+// Watch arms a FoundationDB key watch and returns a channel that fires once
+// when the key's value changes. Cancelling ctx cancels the watch, which then
+// fires with the cancellation error.
+func (a *FoundationAdapter) Watch(ctx context.Context, key kv.Key) (<-chan error, error) {
+	var fut fdb.FutureNil
+	_, err := a.db.Transact(func(tr fdb.Transaction) (any, error) {
+		if err := applyDeadline(ctx, tr); err != nil {
+			return nil, err
+		}
+
+		fut = tr.Watch(a.sub.Pack(keyToTuple(key)))
+		return nil, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to arm watch: %w", err)
+	}
+
+	firedC := make(chan error, 1)
+	resolvedC := make(chan struct{})
+
+	go func() {
+		firedC <- fut.Get()
+		close(resolvedC)
+	}()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			fut.Cancel()
+		case <-resolvedC:
+		}
+	}()
+
+	return firedC, nil
 }
 
 // Backup implements [kv.Adapter.Backup].

--- a/internal/storage/backends/foundation/adapter.go
+++ b/internal/storage/backends/foundation/adapter.go
@@ -25,8 +25,7 @@ const FoundationApiVersion = 730
 // AdapterOptions.GCInterval is left unset.
 const defaultGCInterval = 5 * time.Minute
 
-// ChangeLogKey is the key bumped on every mutation when
-// [AdapterOptions.EnableChangeLog] is set; watching it (see
+// ChangeLogKey is the key bumped by every Update transaction; watching it (see
 // [FoundationAdapter.Watch]) observes every change made through the adapter,
 // from any node of the cluster.
 var ChangeLogKey = kv.Key{"meta", "changelog"}
@@ -46,9 +45,6 @@ type AdapterOptions struct {
 	Namespace string
 	// GCInterval is how often expired keys are swept; zero uses defaultGCInterval.
 	GCInterval time.Duration
-	// EnableChangeLog makes every Update transaction also bump [ChangeLogKey],
-	// atomically with the mutation, so other nodes can watch for changes.
-	EnableChangeLog bool
 }
 
 // FoundationAdapter is a [kv.Adapter] backed by FoundationDB.
@@ -57,9 +53,8 @@ type AdapterOptions struct {
 // applied on write and stripped on read, so consumers only ever observe logical
 // [kv.Key]s.
 type FoundationAdapter struct {
-	db        fdb.Database
-	sub       subspace.Subspace
-	changeLog bool
+	db  fdb.Database
+	sub subspace.Subspace
 }
 
 var _ kv.Adapter[*FoundationQueryTx, *FoundationMutationTx] = (*FoundationAdapter)(nil)
@@ -92,9 +87,8 @@ func NewAdapter(opts AdapterOptions) fx.Option {
 		}
 
 		adapter := &FoundationAdapter{
-			db:        db,
-			sub:       subspace.Sub(opts.KeySpace).Sub(opts.Namespace),
-			changeLog: opts.EnableChangeLog,
+			db:  db,
+			sub: subspace.Sub(opts.KeySpace).Sub(opts.Namespace),
 		}
 
 		lc.Append(fx.Hook{
@@ -153,8 +147,8 @@ func (a *FoundationAdapter) View(ctx context.Context, txnFn func(txn *Foundation
 
 // Update implements [kv.Adapter.Update]. It runs inside a read-write
 // FoundationDB transaction, which is committed on success; FoundationDB retries
-// automatically on conflict. When the changelog is enabled, [ChangeLogKey] is
-// set to a fresh random value in the same transaction.
+// automatically on conflict. [ChangeLogKey] is set to a fresh random value in
+// the same transaction, so watchers observe every mutation.
 func (a *FoundationAdapter) Update(ctx context.Context, txnFn func(txn *FoundationMutationTx) error) error {
 	_, err := a.db.Transact(func(tr fdb.Transaction) (any, error) {
 		if err := applyDeadline(ctx, tr); err != nil {
@@ -165,11 +159,9 @@ func (a *FoundationAdapter) Update(ctx context.Context, txnFn func(txn *Foundati
 			return nil, err
 		}
 
-		if a.changeLog {
-			value := make([]byte, 16)
-			rand.Read(value)
-			tr.Set(a.sub.Pack(keyToTuple(ChangeLogKey)), value)
-		}
+		value := make([]byte, 16)
+		rand.Read(value)
+		tr.Set(a.sub.Pack(keyToTuple(ChangeLogKey)), value)
 
 		return nil, nil
 	})

--- a/internal/storage/backends/foundation/concrete/config/README.md
+++ b/internal/storage/backends/foundation/concrete/config/README.md
@@ -15,6 +15,26 @@ It assembles the FoundationDB adapter (scoped to the `config` subspace) with the
 carries the FoundationDB cluster file and the shared key space, and
 `DefaultOptions` supplies their defaults.
 
+The adapter is created with the change log enabled, and when a
+[confignotify](../../../../../engines/confignotify) notifier is present in the
+container the module also starts a watcher actor. The store itself emits no
+local notification: every node — including the one that made the change —
+observes mutations through the watcher, so local and remote changes follow the
+same path.
+
+## Change watcher
+
+The watcher arms a FoundationDB watch on the adapter's change log key, hashes
+the stored pipelines, transformers and forwarders, and diffs the result against
+its previous snapshot whenever the watch fires: pipeline diffs become
+`PipelineChanged` / `PipelineDeleted` events, transformer or forwarder diffs
+collapse into a single `DependenciesChanged`. Arming the watch before scanning
+guarantees no missed window, and diffing makes FoundationDB's watch coalescing
+harmless. The first scan primes the snapshot silently, since the pipeline
+runner builds everything at boot on its own.
+
 ## Layout
 
 - **main.go** — the `Options`, `DefaultOptions` and `NewStorage` `fx` wiring.
+- **watcher.go** — the change log watcher actor translating storage diffs into
+  confignotify events.

--- a/internal/storage/backends/foundation/concrete/config/README.md
+++ b/internal/storage/backends/foundation/concrete/config/README.md
@@ -25,13 +25,14 @@ same path.
 ## Change watcher
 
 The watcher arms a FoundationDB watch on the adapter's change log key, hashes
-the stored pipelines, transformers and forwarders, and diffs the result against
-its previous snapshot whenever the watch fires: pipeline diffs become
-`PipelineChanged` / `PipelineDeleted` events, transformer or forwarder diffs
-collapse into a single `DependenciesChanged`. Arming the watch before scanning
-guarantees no missed window, and diffing makes FoundationDB's watch coalescing
-harmless. The first scan primes the snapshot silently, since the pipeline
-runner builds everything at boot on its own.
+the stored pipelines, transformers, forwarders and system configuration, and
+diffs the result against its previous snapshot whenever the watch fires:
+pipeline diffs become `PipelineChanged` / `PipelineDeleted` events, transformer
+or forwarder diffs collapse into a single `DependenciesChanged`, and a system
+configuration diff drops the node's cached system configuration. Arming the
+watch before scanning guarantees no missed window, and diffing makes
+FoundationDB's watch coalescing harmless. The first scan primes the snapshot
+silently, since the pipeline runner builds everything at boot on its own.
 
 ## Layout
 

--- a/internal/storage/backends/foundation/concrete/config/main.go
+++ b/internal/storage/backends/foundation/concrete/config/main.go
@@ -60,19 +60,27 @@ func NewStorage(opts Options) fx.Option {
 	return fx.Module(
 		"storage.config",
 		foundation.NewAdapter(adapterOpts),
-		fx.Provide(func(d deps) storage.ConfigStorage {
+		fx.Provide(func(d deps) *config.Storage[*foundation.FoundationQueryTx, *foundation.FoundationMutationTx] {
 			// no local notifier: change events come from the key watcher, so every
 			// node (including the writer) observes mutations through the same path
 			return config.NewStorage(d.Adapter, nil)
 		}),
-		fx.Invoke(func(lc fx.Lifecycle, d deps) {
+		fx.Provide(func(s *config.Storage[*foundation.FoundationQueryTx, *foundation.FoundationMutationTx]) storage.ConfigStorage {
+			return s
+		}),
+		fx.Invoke(func(
+			lc fx.Lifecycle,
+			d deps,
+			s *config.Storage[*foundation.FoundationQueryTx, *foundation.FoundationMutationTx],
+		) {
 			if d.Notifier == nil {
 				return
 			}
 
 			watcher := actor.New(&watchWorker{
-				adapter:  d.Adapter,
-				notifier: d.Notifier,
+				adapter:     d.Adapter,
+				notifier:    d.Notifier,
+				systemCache: s,
 			})
 
 			lc.Append(fx.Hook{

--- a/internal/storage/backends/foundation/concrete/config/main.go
+++ b/internal/storage/backends/foundation/concrete/config/main.go
@@ -48,7 +48,9 @@ func NewStorage(opts Options) fx.Option {
 		"storage.config",
 		foundation.NewAdapter(adapterOpts),
 		fx.Provide(func(d deps) storage.ConfigStorage {
-			return config.NewStorage(d.Adapter)
+			// no local notifier: change events come from the key watcher, so every
+			// node (including the writer) observes mutations through the same path
+			return config.NewStorage(d.Adapter, nil)
 		}),
 	)
 }

--- a/internal/storage/backends/foundation/concrete/config/main.go
+++ b/internal/storage/backends/foundation/concrete/config/main.go
@@ -1,7 +1,12 @@
 package config
 
 import (
+	"context"
+
+	"github.com/vladopajic/go-actor/actor"
 	"go.uber.org/fx"
+
+	"link-society.com/flowg/internal/engines/confignotify"
 
 	"link-society.com/flowg/internal/storage/backends/foundation"
 	"link-society.com/flowg/internal/storage/databases/config"
@@ -22,6 +27,10 @@ type deps struct {
 	fx.In
 
 	Adapter *foundation.FoundationAdapter `name:"storage.config"`
+
+	// Notifier receives the events emitted by the changelog watcher; it is
+	// optional so the storage can run standalone (e.g. in tests).
+	Notifier confignotify.Notifier `optional:"true"`
 }
 
 // DefaultOptions returns the default [Options] for the configuration storage.
@@ -35,6 +44,9 @@ func DefaultOptions() Options {
 
 // NewStorage returns an fx module providing a FoundationDB-backed
 // [storage.ConfigStorage] configured with the given options.
+//
+// The module also starts a changelog watcher that translates config mutations
+// (local or from other nodes) into confignotify events.
 func NewStorage(opts Options) fx.Option {
 	adapterOpts := foundation.AdapterOptions{
 		LogChannel:       "storage.config",
@@ -42,6 +54,7 @@ func NewStorage(opts Options) fx.Option {
 		ConnectionString: opts.ConnectionString,
 		KeySpace:         opts.KeySpace,
 		Namespace:        "config",
+		EnableChangeLog:  true,
 	}
 
 	return fx.Module(
@@ -51,6 +64,27 @@ func NewStorage(opts Options) fx.Option {
 			// no local notifier: change events come from the key watcher, so every
 			// node (including the writer) observes mutations through the same path
 			return config.NewStorage(d.Adapter, nil)
+		}),
+		fx.Invoke(func(lc fx.Lifecycle, d deps) {
+			if d.Notifier == nil {
+				return
+			}
+
+			watcher := actor.New(&watchWorker{
+				adapter:  d.Adapter,
+				notifier: d.Notifier,
+			})
+
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					watcher.Start()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					watcher.Stop()
+					return nil
+				},
+			})
 		}),
 	)
 }

--- a/internal/storage/backends/foundation/concrete/config/main.go
+++ b/internal/storage/backends/foundation/concrete/config/main.go
@@ -54,7 +54,6 @@ func NewStorage(opts Options) fx.Option {
 		ConnectionString: opts.ConnectionString,
 		KeySpace:         opts.KeySpace,
 		Namespace:        "config",
-		EnableChangeLog:  true,
 	}
 
 	return fx.Module(

--- a/internal/storage/backends/foundation/concrete/config/watcher.go
+++ b/internal/storage/backends/foundation/concrete/config/watcher.go
@@ -3,10 +3,11 @@ package config
 import (
 	"context"
 	"log/slog"
+
 	"maps"
-	"time"
 
 	"crypto/sha256"
+	"time"
 
 	"github.com/vladopajic/go-actor/actor"
 

--- a/internal/storage/backends/foundation/concrete/config/watcher.go
+++ b/internal/storage/backends/foundation/concrete/config/watcher.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"time"
+
+	"crypto/sha256"
+
+	"github.com/vladopajic/go-actor/actor"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+
+	"link-society.com/flowg/internal/storage/backends/foundation"
+	"link-society.com/flowg/internal/storage/generic/kv"
+)
+
+// watchedItemTypes are the config item prefixes whose changes drive the
+// pipeline lifecycle.
+var watchedItemTypes = []string{"pipeline", "transformer", "forwarder"}
+
+// watchBackoff is how long the watcher waits before re-arming after an error.
+const watchBackoff = 5 * time.Second
+
+// snapshot maps item type to item name to a hash of its serialized value.
+type snapshot map[string]map[string][sha256.Size]byte
+
+// watchWorker observes the config changelog key and translates mutations into
+// confignotify events, so every node of the cluster (including the one that
+// made the change) reacts to configuration changes through the same path.
+type watchWorker struct {
+	adapter  *foundation.FoundationAdapter
+	notifier confignotify.Notifier
+
+	current snapshot
+}
+
+var _ actor.Worker = (*watchWorker)(nil)
+
+// DoWork arms the changelog watch, diffs the config items against the previous
+// snapshot, emits the matching events and waits for the watch to fire. Arming
+// the watch before scanning guarantees no change is missed in between, and
+// watch coalescing is harmless because the diff always compares against the
+// stored state. The first scan primes the snapshot silently: the pipeline
+// runner builds everything at boot on its own.
+func (w *watchWorker) DoWork(ctx actor.Context) actor.WorkerStatus {
+	if ctx.Err() != nil {
+		return actor.WorkerEnd
+	}
+
+	firedC, err := w.adapter.Watch(ctx, foundation.ChangeLogKey)
+	if err != nil {
+		w.logError(ctx, "failed to arm config changelog watch", err)
+		return w.backoff(ctx)
+	}
+
+	next, err := w.scan(ctx)
+	if err != nil {
+		w.logError(ctx, "failed to scan config items", err)
+		return w.backoff(ctx)
+	}
+
+	if w.current != nil {
+		w.emitDiff(ctx, w.current, next)
+	}
+	w.current = next
+
+	select {
+	case <-ctx.Done():
+		return actor.WorkerEnd
+
+	case err := <-firedC:
+		if err != nil {
+			if ctx.Err() != nil {
+				return actor.WorkerEnd
+			}
+
+			w.logError(ctx, "config changelog watch failed", err)
+			return w.backoff(ctx)
+		}
+
+		return actor.WorkerContinue
+	}
+}
+
+// scan hashes every watched config item in a single read transaction.
+func (w *watchWorker) scan(ctx context.Context) (snapshot, error) {
+	next := make(snapshot, len(watchedItemTypes))
+
+	err := w.adapter.View(ctx, func(txn *foundation.FoundationQueryTx) error {
+		for _, itemType := range watchedItemTypes {
+			items := make(map[string][sha256.Size]byte)
+
+			for pair := range txn.IterPairs(kv.Key{itemType}, kv.KeyRange{}) {
+				key := pair.Key()
+				items[key[len(key)-1]] = sha256.Sum256(pair.Value())
+			}
+
+			next[itemType] = items
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return next, nil
+}
+
+// emitDiff broadcasts the difference between two snapshots. A transformer or
+// forwarder change collapses into a single DependenciesChanged event, since the
+// resulting reconcile rebuilds every pipeline anyway.
+func (w *watchWorker) emitDiff(ctx context.Context, previous snapshot, next snapshot) {
+	for _, itemType := range []string{"transformer", "forwarder"} {
+		if !maps.Equal(previous[itemType], next[itemType]) {
+			w.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+			return
+		}
+	}
+
+	for name, hash := range next["pipeline"] {
+		if prev, exists := previous["pipeline"][name]; !exists || prev != hash {
+			w.notify(ctx, confignotify.Event{
+				Kind:     confignotify.PipelineChanged,
+				Pipeline: name,
+			})
+		}
+	}
+
+	for name := range previous["pipeline"] {
+		if _, exists := next["pipeline"][name]; !exists {
+			w.notify(ctx, confignotify.Event{
+				Kind:     confignotify.PipelineDeleted,
+				Pipeline: name,
+			})
+		}
+	}
+}
+
+func (w *watchWorker) notify(ctx context.Context, event confignotify.Event) {
+	if err := w.notifier.Notify(ctx, event); err != nil {
+		w.logError(ctx, "failed to notify config change", err)
+	}
+}
+
+// backoff waits before retrying after an error, aborting early on shutdown.
+func (w *watchWorker) backoff(ctx actor.Context) actor.WorkerStatus {
+	select {
+	case <-ctx.Done():
+		return actor.WorkerEnd
+	case <-time.After(watchBackoff):
+		return actor.WorkerContinue
+	}
+}
+
+func (w *watchWorker) logError(ctx context.Context, message string, err error) {
+	slog.ErrorContext(
+		ctx,
+		message,
+		"channel", "storage.config",
+		"error", err.Error(),
+	)
+}

--- a/internal/storage/backends/foundation/concrete/config/watcher.go
+++ b/internal/storage/backends/foundation/concrete/config/watcher.go
@@ -16,9 +16,10 @@ import (
 	"link-society.com/flowg/internal/storage/generic/kv"
 )
 
-// watchedItemTypes are the config item prefixes whose changes drive the
-// pipeline lifecycle.
-var watchedItemTypes = []string{"pipeline", "transformer", "forwarder"}
+// watchedItemTypes are the config item prefixes the watcher observes:
+// pipeline, transformer and forwarder changes drive the pipeline lifecycle,
+// system changes invalidate the cached system configuration.
+var watchedItemTypes = []string{"pipeline", "transformer", "forwarder", "system"}
 
 // watchBackoff is how long the watcher waits before re-arming after an error.
 const watchBackoff = 5 * time.Second
@@ -26,12 +27,19 @@ const watchBackoff = 5 * time.Second
 // snapshot maps item type to item name to a hash of its serialized value.
 type snapshot map[string]map[string][sha256.Size]byte
 
+// systemConfigCache is the subset of the config storage the watcher needs to
+// drop the cached system configuration on remote changes.
+type systemConfigCache interface {
+	InvalidateSystemConfigCache()
+}
+
 // watchWorker observes the config changelog key and translates mutations into
 // confignotify events, so every node of the cluster (including the one that
 // made the change) reacts to configuration changes through the same path.
 type watchWorker struct {
-	adapter  *foundation.FoundationAdapter
-	notifier confignotify.Notifier
+	adapter     *foundation.FoundationAdapter
+	notifier    confignotify.Notifier
+	systemCache systemConfigCache
 
 	current snapshot
 }
@@ -109,10 +117,15 @@ func (w *watchWorker) scan(ctx context.Context) (snapshot, error) {
 	return next, nil
 }
 
-// emitDiff broadcasts the difference between two snapshots. A transformer or
-// forwarder change collapses into a single DependenciesChanged event, since the
-// resulting reconcile rebuilds every pipeline anyway.
+// emitDiff broadcasts the difference between two snapshots. A system config
+// change drops the local cache; a transformer or forwarder change collapses
+// into a single DependenciesChanged event, since the resulting reconcile
+// rebuilds every pipeline anyway.
 func (w *watchWorker) emitDiff(ctx context.Context, previous snapshot, next snapshot) {
+	if !maps.Equal(previous["system"], next["system"]) {
+		w.systemCache.InvalidateSystemConfigCache()
+	}
+
 	for _, itemType := range []string{"transformer", "forwarder"} {
 		if !maps.Equal(previous[itemType], next[itemType]) {
 			w.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})

--- a/internal/storage/backends/foundation/concrete/config/watcher_test.go
+++ b/internal/storage/backends/foundation/concrete/config/watcher_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"testing"
+
+	"crypto/sha256"
+
+	"github.com/stretchr/testify/mock"
+
+	"link-society.com/flowg/internal/engines/confignotify"
+	confignotifyMocks "link-society.com/flowg/internal/engines/confignotify/mocks"
+)
+
+type fakeSystemCache struct {
+	invalidated int
+}
+
+func (f *fakeSystemCache) InvalidateSystemConfigCache() {
+	f.invalidated++
+}
+
+// makeSnapshot hashes literal item values into the watcher's snapshot shape.
+func makeSnapshot(items map[string]map[string]string) snapshot {
+	result := make(snapshot, len(items))
+
+	for itemType, byName := range items {
+		hashes := make(map[string][sha256.Size]byte, len(byName))
+		for name, value := range byName {
+			hashes[name] = sha256.Sum256([]byte(value))
+		}
+		result[itemType] = hashes
+	}
+
+	return result
+}
+
+func newTestWatcher() (*watchWorker, *confignotifyMocks.MockNotifier, *fakeSystemCache) {
+	notifier := confignotifyMocks.NewMockNotifier().(*confignotifyMocks.MockNotifier)
+	cache := &fakeSystemCache{}
+
+	return &watchWorker{
+		notifier:    notifier,
+		systemCache: cache,
+	}, notifier, cache
+}
+
+func TestEmitDiff_SystemChangeInvalidatesCache(t *testing.T) {
+	w, notifier, cache := newTestWatcher()
+
+	previous := makeSnapshot(map[string]map[string]string{
+		"system": {"config": "v1"},
+	})
+	next := makeSnapshot(map[string]map[string]string{
+		"system": {"config": "v2"},
+	})
+
+	// no expectation set: any emitted event would fail the test
+	w.emitDiff(t.Context(), previous, next)
+
+	if cache.invalidated != 1 {
+		t.Fatalf("expected 1 cache invalidation, got %d", cache.invalidated)
+	}
+
+	notifier.AssertExpectations(t)
+}
+
+func TestEmitDiff_PipelineChanges(t *testing.T) {
+	w, notifier, cache := newTestWatcher()
+
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind:     confignotify.PipelineChanged,
+		Pipeline: "updated",
+	}).Return(nil).Once()
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind:     confignotify.PipelineChanged,
+		Pipeline: "added",
+	}).Return(nil).Once()
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind:     confignotify.PipelineDeleted,
+		Pipeline: "removed",
+	}).Return(nil).Once()
+
+	previous := makeSnapshot(map[string]map[string]string{
+		"pipeline": {"updated": "v1", "removed": "v1", "untouched": "v1"},
+	})
+	next := makeSnapshot(map[string]map[string]string{
+		"pipeline": {"updated": "v2", "added": "v1", "untouched": "v1"},
+	})
+
+	w.emitDiff(t.Context(), previous, next)
+
+	if cache.invalidated != 0 {
+		t.Fatalf("expected no cache invalidation, got %d", cache.invalidated)
+	}
+
+	notifier.AssertExpectations(t)
+}
+
+func TestEmitDiff_DependencyChangeCollapses(t *testing.T) {
+	w, notifier, _ := newTestWatcher()
+
+	// a single DependenciesChanged, even though a pipeline changed too
+	notifier.On("Notify", mock.Anything, confignotify.Event{
+		Kind: confignotify.DependenciesChanged,
+	}).Return(nil).Once()
+
+	previous := makeSnapshot(map[string]map[string]string{
+		"transformer": {"parse": "v1"},
+		"pipeline":    {"default": "v1"},
+	})
+	next := makeSnapshot(map[string]map[string]string{
+		"transformer": {"parse": "v2"},
+		"pipeline":    {"default": "v2"},
+	})
+
+	w.emitDiff(t.Context(), previous, next)
+
+	notifier.AssertExpectations(t)
+}

--- a/internal/storage/databases/config/README.md
+++ b/internal/storage/databases/config/README.md
@@ -22,6 +22,8 @@ top of any [generic/kv](../../generic/kv) adapter.
   watcher instead.
 - **System configuration** — persists and caches global settings such as the
   allowed origins used by the ingestion endpoints, validating them on write.
+  `InvalidateSystemConfigCache` drops the cache when the stored value changed
+  behind it: on restore, or when another node of a cluster wrote it.
 - **Snapshots** — satisfies `Streamable` so the configuration database can be
   backed up and restored.
 

--- a/internal/storage/databases/config/README.md
+++ b/internal/storage/databases/config/README.md
@@ -14,6 +14,12 @@ top of any [generic/kv](../../generic/kv) adapter.
 - **Resource persistence** — stores and retrieves pipelines, transformers and
   forwarders through a key-value adapter, migrating them to the latest model
   version on read when needed.
+- **Change notifications** — broadcasts a
+  [confignotify](../../../engines/confignotify) event after every successful
+  mutation (when a notifier is wired), so the pipeline runner follows
+  configuration changes without the API layer driving it. Backends with their
+  own change watcher (FoundationDB) pass a nil notifier and emit from the
+  watcher instead.
 - **System configuration** — persists and caches global settings such as the
   allowed origins used by the ingestion endpoints, validating them on write.
 - **Snapshots** — satisfies `Streamable` so the configuration database can be

--- a/internal/storage/databases/config/storage.go
+++ b/internal/storage/databases/config/storage.go
@@ -90,8 +90,17 @@ func (s *Storage[QTx, MTx]) Load(ctx context.Context, r io.Reader) error {
 		return err
 	}
 
+	s.InvalidateSystemConfigCache()
 	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
 	return nil
+}
+
+// InvalidateSystemConfigCache drops the in-memory system configuration so the
+// next read fetches it from storage again. It is called when the stored
+// configuration changed behind the cache: on restore, or when another node of
+// a cluster wrote it.
+func (s *Storage[QTx, MTx]) InvalidateSystemConfigCache() {
+	s.configurationInstance.Store(nil)
 }
 
 // ListTransformers implements [storage.ConfigStorage].

--- a/internal/storage/databases/config/storage.go
+++ b/internal/storage/databases/config/storage.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"log/slog"
+
 	"sync"
 	"sync/atomic"
 
@@ -14,6 +16,8 @@ import (
 	"net"
 
 	"link-society.com/flowg/internal/models"
+
+	"link-society.com/flowg/internal/engines/confignotify"
 
 	"link-society.com/flowg/internal/storage/generic/kv"
 	storage "link-society.com/flowg/internal/storage/interfaces"
@@ -31,8 +35,12 @@ const (
 // Storage is a backend-agnostic implementation of [storage.ConfigStorage]. It
 // runs the config transactions from the transactions subpackage on top of any
 // [kv.Adapter] and caches the decoded system configuration in memory.
+//
+// When a [confignotify.Notifier] is wired, every successful mutation is
+// broadcast on it so the pipeline runner can react to configuration changes.
 type Storage[QTx kv.QueryTx, MTx kv.MutationTx] struct {
-	adapter kv.Adapter[QTx, MTx]
+	adapter  kv.Adapter[QTx, MTx]
+	notifier confignotify.Notifier
 
 	lock                  *sync.Mutex
 	configurationInstance atomic.Pointer[models.SystemConfiguration]
@@ -41,11 +49,33 @@ type Storage[QTx kv.QueryTx, MTx kv.MutationTx] struct {
 var _ storage.ConfigStorage = (*Storage[kv.QueryTx, kv.MutationTx])(nil)
 
 // NewStorage returns a [Storage] that persists configuration data through the
-// given key-value adapter.
-func NewStorage[QTx kv.QueryTx, MTx kv.MutationTx](adapter kv.Adapter[QTx, MTx]) *Storage[QTx, MTx] {
+// given key-value adapter. notifier may be nil, in which case no change
+// notification is emitted (e.g. on backends with their own change watcher).
+func NewStorage[QTx kv.QueryTx, MTx kv.MutationTx](
+	adapter kv.Adapter[QTx, MTx],
+	notifier confignotify.Notifier,
+) *Storage[QTx, MTx] {
 	return &Storage[QTx, MTx]{
-		adapter: adapter,
-		lock:    &sync.Mutex{},
+		adapter:  adapter,
+		notifier: notifier,
+		lock:     &sync.Mutex{},
+	}
+}
+
+// notify broadcasts a config change when a notifier is wired; the mutation
+// already succeeded, so delivery errors are logged instead of returned.
+func (s *Storage[QTx, MTx]) notify(ctx context.Context, event confignotify.Event) {
+	if s.notifier == nil {
+		return
+	}
+
+	if err := s.notifier.Notify(ctx, event); err != nil {
+		slog.ErrorContext(
+			ctx,
+			"failed to notify config change",
+			"channel", "storage.config",
+			"error", err.Error(),
+		)
 	}
 }
 
@@ -56,7 +86,12 @@ func (s *Storage[QTx, MTx]) Dump(ctx context.Context, w io.Writer, version uint6
 
 // Load implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) Load(ctx context.Context, r io.Reader) error {
-	return s.adapter.Restore(ctx, r)
+	if err := s.adapter.Restore(ctx, r); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+	return nil
 }
 
 // ListTransformers implements [storage.ConfigStorage].
@@ -81,12 +116,22 @@ func (s *Storage[QTx, MTx]) ReadTransformer(ctx context.Context, name string) (*
 
 // WriteTransformer implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) WriteTransformer(ctx context.Context, name string, content string) error {
-	return s.writeItem(ctx, transformerItemType, name, []byte(content))
+	if err := s.writeItem(ctx, transformerItemType, name, []byte(content)); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+	return nil
 }
 
 // DeleteTransformer implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) DeleteTransformer(ctx context.Context, name string) error {
-	return s.deleteItem(ctx, transformerItemType, name)
+	if err := s.deleteItem(ctx, transformerItemType, name); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+	return nil
 }
 
 // ListPipelines implements [storage.ConfigStorage].
@@ -126,17 +171,32 @@ func (s *Storage[QTx, MTx]) WritePipeline(ctx context.Context, name string, flow
 		return fmt.Errorf("failed to marshal flow graph: %w", err)
 	}
 
-	return s.writeItem(ctx, pipelineItemType, name, content)
+	if err := s.writeItem(ctx, pipelineItemType, name, content); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.PipelineChanged, Pipeline: name})
+	return nil
 }
 
 // WriteRawPipeline implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) WriteRawPipeline(ctx context.Context, name string, content string) error {
-	return s.writeItem(ctx, pipelineItemType, name, []byte(content))
+	if err := s.writeItem(ctx, pipelineItemType, name, []byte(content)); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.PipelineChanged, Pipeline: name})
+	return nil
 }
 
 // DeletePipeline implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) DeletePipeline(ctx context.Context, name string) error {
-	return s.deleteItem(ctx, pipelineItemType, name)
+	if err := s.deleteItem(ctx, pipelineItemType, name); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.PipelineDeleted, Pipeline: name})
+	return nil
 }
 
 // ListForwarders implements [storage.ConfigStorage].
@@ -177,12 +237,22 @@ func (s *Storage[QTx, MTx]) WriteForwarder(ctx context.Context, name string, for
 		return fmt.Errorf("failed to marshal forwarder: %w", err)
 	}
 
-	return s.writeItem(ctx, forwarderItemType, name, content)
+	if err := s.writeItem(ctx, forwarderItemType, name, content); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+	return nil
 }
 
 // DeleteForwarder implements [storage.ConfigStorage].
 func (s *Storage[QTx, MTx]) DeleteForwarder(ctx context.Context, name string) error {
-	return s.deleteItem(ctx, forwarderItemType, name)
+	if err := s.deleteItem(ctx, forwarderItemType, name); err != nil {
+		return err
+	}
+
+	s.notify(ctx, confignotify.Event{Kind: confignotify.DependenciesChanged})
+	return nil
 }
 
 // HasSystemConfig implements [storage.ConfigStorage].

--- a/internal/storage/databases/config/storage.go
+++ b/internal/storage/databases/config/storage.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-
 	"log/slog"
 
 	"sync"

--- a/scripts/test.taskfile.yml
+++ b/scripts/test.taskfile.yml
@@ -68,6 +68,8 @@ tasks:
       CGO_ENABLED: "1"
       CGO_CFLAGS: "-I{{ .FDB }}/include"
       CGO_LDFLAGS: "-L{{ .FDB }}/lib/{{ .GOOS }}/{{ .GOARCH }} -Wl,-rpath,{{ .RPATH }}"
+      # test binaries run from a temp dir, so the rpath cannot resolve libfdb_c
+      LD_LIBRARY_PATH: "{{ .FDB }}/lib/{{ .GOOS }}/{{ .GOARCH }}"
 
   "test:unit:rust:vrl":
     internal: true

--- a/tests/specs/cluster/pipeline_watch.hurl
+++ b/tests/specs/cluster/pipeline_watch.hurl
@@ -1,0 +1,147 @@
+###############################################################################
+# DESCRIPTION: Test that pipeline lifecycle changes propagate across a 3-node
+#              FlowG cluster through the FoundationDB changelog watcher: a
+#              pipeline created (or deleted) on one node must eventually be
+#              running (or terminated) on every node, including the writer,
+#              which observes its own change through the watch.
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Create a pipeline "watched" on node0, routing to the stream "watched"
+#  - Verify every node eventually runs it (ingestion succeeds)
+#  - Verify the ingested records all landed in the stream
+
+PUT {{node0_url}}/api/v1/pipelines/watched
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "flow": {
+    "nodes": [
+      {
+        "id": "__builtin__source_direct",
+        "type": "source",
+        "position": {"x": 210, "y": 195},
+        "data": {"type": "direct"}
+      },
+      {
+        "id": "node-router",
+        "type": "router",
+        "position": {"x": 405, "y": 195},
+        "data": {"stream": "watched"}
+      }
+    ],
+    "edges": [
+      {
+        "id": "xy-edge____builtin__source_direct-node-router",
+        "source": "__builtin__source_direct",
+        "sourceHandle": "",
+        "target": "node-router"
+      }
+    ]
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# the changelog watch fires asynchronously: retry until each node runs the
+# pipeline (ingestion returns 404 until then)
+POST {{node0_url}}/api/v1/pipelines/watched/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+[Options]
+retry: 30
+retry-interval: 1000ms
+{
+  "records": [
+    { "message": "watched-from-node0" }
+  ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.processed_count" == 1
+
+POST {{node1_url}}/api/v1/pipelines/watched/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+[Options]
+retry: 30
+retry-interval: 1000ms
+{
+  "records": [
+    { "message": "watched-from-node1" }
+  ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.processed_count" == 1
+
+POST {{node2_url}}/api/v1/pipelines/watched/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+[Options]
+retry: 30
+retry-interval: 1000ms
+{
+  "records": [
+    { "message": "watched-from-node2" }
+  ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.processed_count" == 1
+
+# the records went through the new pipeline into its stream
+GET {{node1_url}}/api/v1/streams/watched/logs
+Authorization: Bearer {{admin_token}}
+[Query]
+from: {{timewindow_begin}}
+to: {{timewindow_end}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.records" count == 3
+jsonpath "$.records[*].fields.message" contains "watched-from-node0"
+jsonpath "$.records[*].fields.message" contains "watched-from-node1"
+jsonpath "$.records[*].fields.message" contains "watched-from-node2"
+
+# -----------------------------------------------------------------------------
+# TEST:
+#  - Delete the pipeline from node1
+#  - Verify every node eventually terminates it (ingestion returns 404)
+
+DELETE {{node1_url}}/api/v1/pipelines/watched
+Authorization: Bearer {{admin_token}}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+POST {{node0_url}}/api/v1/pipelines/watched/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+[Options]
+retry: 30
+retry-interval: 1000ms
+{
+  "records": [
+    { "message": "after-delete" }
+  ]
+}
+HTTP 404
+
+POST {{node2_url}}/api/v1/pipelines/watched/logs/struct
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+[Options]
+retry: 30
+retry-interval: 1000ms
+{
+  "records": [
+    { "message": "after-delete" }
+  ]
+}
+HTTP 404


### PR DESCRIPTION
## Decision Record

FlowG uses a cache to keep compiled pipelines alive for performance:

- compiling VRL scripts can be slow
- maintaining live connections instead of closing/opening them for every log is faster/cheaper

When a change is made the cache is invalidated **on a single node**. The side effect is not broadcasted.

Similarly, the system configuration (allowed syslog origins, default role for new users, ...) is cached, and updates do not broadcast the cache invalidation.

In order to facilitate future changes, we also eagerly compile pipelines, instead of lazily (waiting for the first log that needs it). When a pipeline is added, it is compiled and initialized and added to the cache. When it is updated, we drain and close the old pipeline, and compile/initialize the new one. When it is deleted, we drain and close it. Existing pipelines are started on boot, and drained on shutdown.

## Changes

 - [x] :recycle: Eagerly compile pipelines
 - [x] :bug: Propagate side effects (pipelines and system configuration) in cluster mode
 - [x] :white_check_mark: Validate pipeline lifecycle in "cluster" test suite

## License Agreement

 - [x] I guarantee that I have the rights on the code submitted in this PR
 - [x] I accept that this contribution will be released under the terms of the MIT License
